### PR TITLE
Add new option to adjust memory size and warning if lack of memory.

### DIFF
--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
   FILE *vcdfile = NULL;
   bool dramsim2 = false;
   bool log = false;
-	uint64_t memsz = MEM_SIZE;
+  uint64_t memsz = MEM_SIZE;
 
 
   for (int i = 1; i < argc; i++)
@@ -68,16 +68,16 @@ int main(int argc, char** argv)
   tile.init(random_seed != 0);
 
   mm_t* mm = dramsim2 ? (mm_t*)(new mm_dramsim2_t) : (mm_t*)(new mm_magic_t);
-	try {
-		mm->init(memsz, tile.Top__io_mem_resp_bits_data.width()/8, LINE_SIZE);
-	}
-	catch (const std::bad_alloc& e) {
-		fprintf(stderr,
-				"I've failed to grasp %d byte of your memory\n"
-				"Set smaller amount of memory by -m <N>" , memsz 
-				);
-		exit(-1);
-	}
+  try {
+  	mm->init(memsz, tile.Top__io_mem_resp_bits_data.width()/8, LINE_SIZE);
+  }
+  catch (const std::bad_alloc& e) {
+  	fprintf(stderr,
+  			"I've failed to grasp %d byte of your memory\n"
+  			"Set smaller amount of memory by -m <N>" , memsz 
+  			);
+  	exit(-1);
+  }
   if (loadmem)
     load_mem(mm->get_data(), loadmem);
 

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
     if (arg.substr(0, 2) == "-v")
       vcd = argv[i]+2;
     else if (arg.substr(0, 2) == "-m")
-      memsz = atoll(argv[i]+2);
+      memsz = atoll(argv[i+1]);
     else if (arg.substr(0, 2) == "-s")
       random_seed = atoi(argv[i]+2);
     else if (arg == "+dramsim")
@@ -49,6 +49,7 @@ int main(int argc, char** argv)
       loadmem = argv[i]+9;
   }
 
+	printf("memsize = %ld, loadmem = %s\n", memsz, loadmem);
   const int disasm_len = 24;
   if (vcd)
   {
@@ -73,8 +74,8 @@ int main(int argc, char** argv)
   }
   catch (const std::bad_alloc& e) {
   	fprintf(stderr,
-  			"I've failed to grasp %d byte of your memory\n"
-  			"Set smaller amount of memory by -m <N>" , memsz 
+  			"I've failed to grasp %ld byte of your memory\n"
+  			"Set smaller amount of memory by -m <N>\n" , memsz 
   			);
   	exit(-1);
   }
@@ -144,6 +145,7 @@ int main(int argc, char** argv)
 
   if (vcd)
     fclose(vcdfile);
+
 
   if (htif->exit_code())
   {

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -29,14 +29,13 @@ int main(int argc, char** argv)
   bool log = false;
   uint64_t memsz = MEM_SIZE;
 
-
   for (int i = 1; i < argc; i++)
   {
     std::string arg = argv[i];
     if (arg.substr(0, 2) == "-v")
       vcd = argv[i]+2;
-    else if (arg.substr(0, 2) == "-m")
-      memsz = atoll(argv[i+1]);
+    else if (arg.substr(0, 9) == "+memsize=")
+      memsz = atoll(argv[i]+9);
     else if (arg.substr(0, 2) == "-s")
       random_seed = atoi(argv[i]+2);
     else if (arg == "+dramsim")
@@ -49,7 +48,6 @@ int main(int argc, char** argv)
       loadmem = argv[i]+9;
   }
 
-	printf("memsize = %ld, loadmem = %s\n", memsz, loadmem);
   const int disasm_len = 24;
   if (vcd)
   {
@@ -74,8 +72,8 @@ int main(int argc, char** argv)
   }
   catch (const std::bad_alloc& e) {
   	fprintf(stderr,
-  			"I've failed to grasp %ld byte of your memory\n"
-  			"Set smaller amount of memory by -m <N>\n" , memsz 
+  			"I've failed to grasp %ld byte (%ldMB) of your memory\n"
+  			"Set smaller amount of memory by +memsize=<N>\n" , memsz, memsz / (1024 * 1024)
   			);
   	exit(-1);
   }

--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -66,6 +66,7 @@ int main(int argc, char** argv)
   srand(random_seed);
   tile.init(random_seed != 0);
 
+  // Instantiate and initialize main memory
   mm_t* mm = dramsim2 ? (mm_t*)(new mm_dramsim2_t) : (mm_t*)(new mm_magic_t);
   try {
   	mm->init(memsz, tile.Top__io_mem_resp_bits_data.width()/8, LINE_SIZE);
@@ -80,12 +81,14 @@ int main(int argc, char** argv)
   if (loadmem)
     load_mem(mm->get_data(), loadmem);
 
+  // Instantiate HTIF
   htif = new htif_emulator_t(std::vector<std::string>(argv + 1, argv + argc));
   int htif_bits = tile.Top__io_host_in_bits.width();
   assert(htif_bits % 8 == 0 && htif_bits <= val_n_bits());
 
   signal(SIGTERM, handle_sigterm);
 
+  // reset for a few cycles to support pipelined reset
   tile.Top__io_host_in_valid = LIT<1>(0);
   tile.Top__io_host_out_ready = LIT<1>(0);
   tile.Top__io_mem_backup_en = LIT<1>(0);
@@ -143,7 +146,6 @@ int main(int argc, char** argv)
 
   if (vcd)
     fclose(vcdfile);
-
 
   if (htif->exit_code())
   {


### PR DESCRIPTION
# abstract
The document and ```C++ cycle accurate simulation emulator``` outputs are not kind enough to tell about memory shortage of the program.
By informing about memory shortage and allowing user to manage amount of memory usage in simulation, ```rocket-chip``` project can be developed even on small virtual machine or laptop.

## warning if enough memory is not available.
If there is only less than 4GB memory on the computer, the program that exist before does sudden death. I added new try{..}catch{..} sentence to handle it.

```
% ./emulator-DefaultCPPConfig +dramsim +max-cycles=100000000 +verbose +loadmem=output/rv64ui-p-add.hex
I've failed to grasp 4294967296 byte (4096MB) of your memory
Set smaller amount of memory by +memsize=<N>
```

## add new option

New option +memsize=<N> is added.

This is the behavior that required memory isn't available:

```
% ./emulator-DefaultCPPConfig +dramsim +max-cycles=100000000 +memsize=8589934592 +verbose +loadmem=output/rv64ui-p-add.hex
I've failed to grasp 8589934592 byte (8192MB) of your memory
Set smaller amount of memory by +memsize=<N>
```

This is the behavior that required memory is available:

```
% ./emulator-DefaultCPPConfig +dramsim +max-cycles=100000000 +memsize=4194304 +verbose +loadmem=output/rv64ui-p-add.hex
C0:          0 [0] pc=[00000002000] W[r 0=0000000000000048][0] R[r13=00000000003741c8] R[r28=36f000000000006c] inst=[a3c6f23b] DASM(a3c6f23b)
C0:          1 [0] pc=[00000002000] W[r 0=0000000000000048][0] R[r13=00000000003741c8] R[r28=36f000000000006c] inst=[a3c6f23b] DASM(a3c6f23b)
C0:          2 [0] pc=[00000002000] W[r 0=0000000000000048][0] R[r13=00000000003741c8] R[r28=36f000000000006c] inst=[a3c6f23b] DASM(a3c6f23b)
:
:
```
