### PR TITLE
Fix FPGA/VLSI Mem Gen for Python 2 and 3 Environments

### DIFF
--- a/fsim/fpga_mem_gen
+++ b/fsim/fpga_mem_gen
@@ -53,7 +53,7 @@ def parse_line(line):
   mask_gran = 1
   tokens = line.split()
   i = 0
-  for i in xrange(0,len(tokens),2):
+  for i in range(0,len(tokens),2):
     s = tokens[i]
     if s == 'name':
       name = tokens[i+1]
@@ -188,7 +188,7 @@ def main():
   if len(sys.argv) < 2:
     sys.exit('Please give a .conf file as input')
   for line in open(sys.argv[1]):
-    print gen_mem(*parse_line(line))
+    print(gen_mem(*parse_line(line)))
 
 
 if __name__ == '__main__':

--- a/vsim/vlsi_mem_gen
+++ b/vsim/vlsi_mem_gen
@@ -15,7 +15,7 @@ def parse_line(line):
   mask_gran = 1
   tokens = line.split()
   i = 0
-  for i in xrange(0,len(tokens),2):
+  for i in range(0,len(tokens),2):
     s = tokens[i]
     if s == 'name':
       name = tokens[i+1]
@@ -130,7 +130,7 @@ def gen_mem(name, width, depth, ports):
     %s\n\
   end\n\
   %s\n" % ('\n  '.join(decl), '\n    '.join(sequential), '\n  '.join(combinational))
-  
+
   s = "module %s(\n\
   %s\n\
 );\n\
@@ -144,7 +144,7 @@ def main():
   if len(sys.argv) < 2:
     sys.exit('Please give a .conf file as input')
   for line in open(sys.argv[1]):
-    print gen_mem(*parse_line(line))
+    print(gen_mem(*parse_line(line)))
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
Running fpga_mem_gen in a Python 3 environment dies due to one use of `range` and a `print` statement that doesn't use parentheses. This trivially fixes both of these without breaking Python 2 compatibility.

Commit message:

Two quick fixes that enable fpga_mem_gen to work with either Python 2 or
Python 3:
* Change an `xrange` instance to `range`
* Wrap the arguments of a bare `print` in parentheses