### PR TITLE
Use new setName method for SeqMem to fix readmemh reference in Zscale

### DIFF
--- a/src/main/scala/ZscaleChip.scala
+++ b/src/main/scala/ZscaleChip.scala
@@ -67,6 +67,7 @@ class ZscaleTop extends Module {
 
   val sys = Module(new ZscaleSystem)
   val bootmem = Module(new HASTISRAM(params(BootROMCapacity)/4))
+  bootmem.ram.setName("ram")
   val dram = Module(new HASTISRAM(params(DRAMCapacity)/4))
 
   sys.io.host <> io.host


### PR DESCRIPTION
The Zscale test harness broke because it used cross-module references in Verilog for readmemh. Although this could be fixed by using a testbench that sets up memory contents via AHB, the addition of `setName` to `SeqMem` that Jim merged in allows this patch to fix Zscale.