### PR TITLE
Double Java MaxPermSize.

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -8,7 +8,7 @@ PROJECT := rocketchip
 CXX ?= g++
 CXXFLAGS := -O1
 
-SBT := java -Xmx2048M -Xss8M -XX:MaxPermSize=128M -jar sbt-launch.jar
+SBT := java -Xmx2048M -Xss8M -XX:MaxPermSize=256M -jar sbt-launch.jar
 SHELL := /bin/bash
 
 CHISEL_ARGS := $(PROJECT) $(MODEL) $(CONFIG) --W0W --minimumCompatibility 3.0.0 --backend $(BACKEND) --configName $(CONFIG) --compileInitializationUnoptimized --targetDir $(generated_dir)


### PR DESCRIPTION
Builds fail with:

    java.util.concurrent.ExecutionException: java.lang.OutOfMemoryError: PermGen space
    	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
    	at java.util.concurrent.FutureTask.get(FutureTask.java:188)
    	at sbt.ConcurrentRestrictions$$anon$4.take(ConcurrentRestrictions.scala:188)
    	at sbt.Execute.next$1(Execute.scala:83)
    	at sbt.Execute.processAll(Execute.scala:86)

deep in sbt/scala.