### PR TITLE
Fix ROCKETCHIP_ADDONS chisel_srcs Makefrag parsing

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -13,9 +13,12 @@ SHELL := /bin/bash
 
 CHISEL_ARGS := $(PROJECT) $(MODEL) $(CONFIG) --W0W --minimumCompatibility 3.0.0 --backend $(BACKEND) --configName $(CONFIG) --compileInitializationUnoptimized --targetDir $(generated_dir)
 
+comma := ,
+empty :=
+space := $(empty) $(empty)
 src_path = src/main/scala
 default_submodules = . junctions uncore hardfloat rocket zscale groundtest
-chisel_srcs = $(addprefix $(base_dir)/,$(addsuffix /$(src_path)/*.scala,$(default_submodules) $(ROCKETCHIP_ADDONS)))
+chisel_srcs = $(addprefix $(base_dir)/,$(addsuffix /$(src_path)/*.scala,$(default_submodules) $(subst $(comma),$(space),$(ROCKETCHIP_ADDONS))))
 
 disasm := 2>
 which_disasm := $(shell which spike-dasm 2> /dev/null)


### PR DESCRIPTION
The ROCKETCHIP_ADDONS environment variable is intended to be comma-separated (see project/build.scala). However, the variable chisel_srcs will treat a comma-separated ROCKETCHIP_ADDONS as one variable when evaluating chisle_srcs unless all commas are changed to spaces. This replaces commas with spaces in the normal kludgy Makefil fashion.