### PR TITLE
build.scala uses space-delimited ROCKETCHIP_ADDONS

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -33,7 +33,7 @@ object BuildSettings extends Build {
     addons := {
       val a = sys.env.getOrElse("ROCKETCHIP_ADDONS", "")
       println(s"Using addons: $a")
-      a.split(",")
+      a.split(" ")
     },
     unmanagedSourceDirectories in Compile ++= addons.value.map(baseDirectory.value / _ / "src/main/scala"),
     mainClass in (Compile, run) := Some("rocketchip.TestGenerator"),


### PR DESCRIPTION
This prevents the build from barfing if you use more than one rocketchip addon.