### PR TITLE
Support make-3.82 and newer

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -42,7 +42,7 @@ $(sim_dir)/libdramsim.a: $(DRAMSIM_OBJS)
 %.hex:
 	$(MAKE) -C $(dir $@) $(notdir $@)
 
-%.riscv.hex: %
+%.riscv.hex: %.riscv
 	$(MAKE) -C $(dir $@) $(notdir $@)
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
make changed its priorties for resolving implicit rules, which causes different
behavior when running "make run-bmark-tests".  This patch changes the hex file
rules to ensure they match between the two versions of make.

I've tried this with both make-3.81 and make-4.1, and they both work for me.