### PR TITLE
The FPGA doesn't have an HTIF clock divider

### DIFF
--- a/csrc/htif_emulator.h
+++ b/csrc/htif_emulator.h
@@ -24,7 +24,11 @@ class htif_emulator_t : public htif_pthread_t
 
   void set_clock_divisor(int divisor, int hold_cycles)
   {
+#ifdef UNCORE_SCR__HTIF_IO_CLOCK_DIVISOR
+    /* We only want to write the HTIF clock divisor SCR on targets where it
+     * actually exists (there isn't one on the FPGA, for example). */
     write_cr(-1, UNCORE_SCR__HTIF_IO_CLOCK_DIVISOR, divisor | hold_cycles << 16);
+#endif
   }
 
   void start()


### PR DESCRIPTION
We used to just be writing the SCR anyway, but now that the SCR maps are
automatically defined VCS will detect the missing SCR and bail out when
compiling test harness code.  This patch just doesn't write the HTIF SCR when
there isn't one.