### PR TITLE
Add support for per-way cache metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ env:
     - CONFIG=BroadcastRegressionTestConfig
     - CONFIG=CacheRegressionTestConfig
     - CONFIG=UnitTestConfig
+    - CONFIG=SplitL2MetadataTestConfig
 
 # blacklist private branches
 branches:

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -110,6 +110,7 @@ class DefaultConfig extends Config (
       case RowBits => findBy(CacheName)
       case NTLBEntries => findBy(CacheName)
       case CacheIdBits => findBy(CacheName)
+      case SplitMetadata => findBy(CacheName)
       case ICacheBufferWays => Knob("L1I_BUFFER_WAYS")
       case "L1I" => {
         case NSets => Knob("L1I_SETS") //64
@@ -117,6 +118,7 @@ class DefaultConfig extends Config (
         case RowBits => 4*site(CoreInstBits)
         case NTLBEntries => 8
         case CacheIdBits => 0
+	case SplitMetadata => false
       }:PF
       case "L1D" => {
         case NSets => Knob("L1D_SETS") //64
@@ -124,6 +126,7 @@ class DefaultConfig extends Config (
         case RowBits => 2*site(CoreDataBits)
         case NTLBEntries => 8
         case CacheIdBits => 0
+	case SplitMetadata => false
       }:PF
       case ECCCode => None
       case Replacer => () => new RandomReplacement(site(NWays))
@@ -295,6 +298,7 @@ class WithL2Cache extends Config(
       case NWays => Knob("L2_WAYS")
       case RowBits => site(TLKey(site(TLId))).dataBitsPerBeat
       case CacheIdBits => log2Ceil(site(NMemoryChannels) * site(NBanksPerMemoryChannel))
+      case SplitMetadata => Knob("L2_SPLIT_METADATA")
     }: PartialFunction[Any,Any] 
     case NAcquireTransactors => 2
     case NSecondaryMisses => 4
@@ -307,7 +311,7 @@ class WithL2Cache extends Config(
         case OuterTLId => "L2toMC"})))
     case L2Replacer => () => new SeqRandom(site(NWays))
   },
-  knobValues = { case "L2_WAYS" => 8; case "L2_CAPACITY_IN_KB" => 2048 }
+  knobValues = { case "L2_WAYS" => 8; case "L2_CAPACITY_IN_KB" => 2048; case "L2_SPLIT_METADATA" => false }
 )
 
 class WithPLRU extends Config(
@@ -457,3 +461,6 @@ class OneOrEightChannelVLSIConfig extends Config(new WithOneOrMaxChannels ++ new
 class SimulateBackupMemConfig extends Config(){ Dump("MEM_BACKUP_EN", true) }
 class BackupMemVLSIConfig extends Config(new SimulateBackupMemConfig ++ new DefaultVLSIConfig)
 class OneOrEightChannelBackupMemVLSIConfig extends Config(new WithOneOrMaxChannels ++ new With8MemoryChannels ++ new BackupMemVLSIConfig)
+
+class WithSplitL2Metadata extends Config(knobValues = { case "L2_SPLIT_METADATA" => true })
+class SplitL2MetadataTestConfig extends Config(new WithSplitL2Metadata ++ new DefaultL2Config)


### PR DESCRIPTION
Based off Henry's comments in ucb-bar/uncore#9, I divided my patches and now have a separate commit for split metadata support (in any cache level).

(This corresponds with ucb-bar/uncore#14)