### PR TITLE
Move N_CORES and MMIO_BASE out of the SCRFile class and into the uncore instance

### DIFF
--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -171,6 +171,8 @@ class Uncore(implicit val p: Parameters) extends Module
   scrArb.io.in(0) <> htif.io.scr
   scrArb.io.in(1) <> outmemsys.io.scr
   scrFile.io.smi <> scrArb.io.out
+  scrFile.io.scr.attach(UInt(nTiles), "N_CORES", false, true)
+  scrFile.io.scr.attach(UInt(p(MMIOBase) >> 20), "MMIO_BASE", false, true)
   // scrFile.io.scr <> (... your SCR connections ...)
 
   // Configures the enabled memory channels.  This can't be changed while the


### PR DESCRIPTION
See https://github.com/ucb-bar/uncore/pull/15