### PR TITLE
Fix the backup memory port

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -87,13 +87,15 @@ class DefaultConfig extends Config (
       case PPNBits => site(PAddrBits) - site(PgIdxBits)
       case VAddrBits => site(VPNBits) + site(PgIdxBits)
       case ASIdBits => 7
-      case MIFTagBits => // Bits needed at the L2 agent
+      case MIFTagBits => Dump("MIF_TAG_BITS",
+                         // Bits needed at the L2 agent
                          log2Up(site(NAcquireTransactors)+2) +
                          // Bits added by NASTI interconnect
                          max(log2Up(site(MaxBanksPerMemoryChannel)),
-                            (if (site(UseDma)) 3 else 2))
-      case MIFDataBits => 64
-      case MIFAddrBits => site(PAddrBits) - site(CacheBlockOffsetBits)
+                            (if (site(UseDma)) 3 else 2)))
+      case MIFDataBits => Dump("MIF_DATA_BITS", 128)
+      case MIFAddrBits => Dump("MIF_ADDR_BITS",
+                               site(PAddrBits) - site(CacheBlockOffsetBits))
       case MIFDataBeats => site(CacheBlockBytes) * 8 / site(MIFDataBits)
       case NastiKey => {
         Dump("MEM_STRB_BITS", site(MIFDataBits) / 8)
@@ -447,5 +449,7 @@ class WithOneOrMaxChannels extends Config(
     case MemoryChannelMuxConfigs => Dump("MEMORY_CHANNEL_MUX_CONFIGS", List(1, site(NMemoryChannels)))
   }
 )
-
 class OneOrEightChannelBenchmarkConfig extends Config(new WithOneOrMaxChannels ++ new With8MemoryChannels ++ new SingleChannelBenchmarkConfig)
+
+class SimulateBackupMemConfig extends Config(){ Dump("MEM_BACKUP_EN", true) }
+class BackupMemVLSIConfig extends Config(new SimulateBackupMemConfig ++ new DefaultVLSIConfig)

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -444,12 +444,16 @@ class DualChannelBenchmarkConfig extends Config(new With2MemoryChannels ++ new S
 class QuadChannelBenchmarkConfig extends Config(new With4MemoryChannels ++ new SingleChannelBenchmarkConfig)
 class OctoChannelBenchmarkConfig extends Config(new With8MemoryChannels ++ new SingleChannelBenchmarkConfig)
 
+class EightChannelVLSIConfig extends Config(new With8MemoryChannels ++ new DefaultVLSIConfig)
+
 class WithOneOrMaxChannels extends Config(
   (pname, site, here) => pname match {
     case MemoryChannelMuxConfigs => Dump("MEMORY_CHANNEL_MUX_CONFIGS", List(1, site(NMemoryChannels)))
   }
 )
 class OneOrEightChannelBenchmarkConfig extends Config(new WithOneOrMaxChannels ++ new With8MemoryChannels ++ new SingleChannelBenchmarkConfig)
+class OneOrEightChannelVLSIConfig extends Config(new WithOneOrMaxChannels ++ new EightChannelVLSIConfig)
 
 class SimulateBackupMemConfig extends Config(){ Dump("MEM_BACKUP_EN", true) }
 class BackupMemVLSIConfig extends Config(new SimulateBackupMemConfig ++ new DefaultVLSIConfig)
+class OneOrEightChannelBackupMemVLSIConfig extends Config(new WithOneOrMaxChannels ++ new With8MemoryChannels ++ new BackupMemVLSIConfig)

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -93,7 +93,7 @@ class DefaultConfig extends Config (
                          // Bits added by NASTI interconnect
                          max(log2Up(site(MaxBanksPerMemoryChannel)),
                             (if (site(UseDma)) 3 else 2)))
-      case MIFDataBits => Dump("MIF_DATA_BITS", 128)
+      case MIFDataBits => Dump("MIF_DATA_BITS", 64)
       case MIFAddrBits => Dump("MIF_ADDR_BITS",
                                site(PAddrBits) - site(CacheBlockOffsetBits))
       case MIFDataBeats => site(CacheBlockBytes) * 8 / site(MIFDataBits)

--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -334,6 +334,13 @@ class OuterMemorySystem(implicit val p: Parameters) extends Module with HasTopLe
   if(p(UseBackupMemoryPort)) {
     VLSIUtils.doOuterMemorySystemSerdes(
       mem_channels, io.mem, io.mem_backup, io.mem_backup_en,
-      nMemChannels, htifW, p(CacheBlockOffsetBits))
+      1, htifW, p(CacheBlockOffsetBits))
+    for (i <- 1 until nMemChannels) { io.mem(i) <> mem_channels(i) }
+    assert(!Vec(mem_channels.map{ io => io.r.valid }).toBits.orR ||
+           !io.mem_backup_en ||
+           Vec(channelConfigs.map{i => UInt(i)})(io.memory_channel_mux_select) === UInt(1),
+           "Backup memory port only works when 1 memory channel is enabled")
+    Predef.assert(channelConfigs.sortWith(_ < _)(0) == 1,
+                  "Backup memory port requires a single memory port mux config")
   } else { io.mem <> mem_channels }
 }

--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -67,8 +67,6 @@ $(simv_debug) : $(sim_vsrcs) $(sim_csrcs) $(sim_dir)/libdramsim.a $(consts_heade
 	$(VCS) $(VCS_OPTS) -o $(simv_debug) \
 	+define+DEBUG -debug_pp \
 
-#	+define+MEM_BACKUP_EN \
-
 #--------------------------------------------------------------------
 # Run
 #--------------------------------------------------------------------

--- a/vsrc/backup_mem.v
+++ b/vsrc/backup_mem.v
@@ -42,27 +42,27 @@ module BackupMemory
   input                       mem_req_valid,
   output                      mem_req_ready,
   input                       mem_req_rw,
-  input [`MEM_ADDR_BITS-1:0]  mem_req_addr,
-  input [`MEM_TAG_BITS-1:0]   mem_req_tag,
+  input [`MIF_ADDR_BITS-1:0]  mem_req_addr,
+  input [`MIF_TAG_BITS-1:0]   mem_req_tag,
 
   input                       mem_req_data_valid,
   output                      mem_req_data_ready,
-  input [`MEM_DATA_BITS-1:0]  mem_req_data_bits,
+  input [`MIF_DATA_BITS-1:0]  mem_req_data_bits,
 
   output reg                  mem_resp_valid,
-  output reg [`MEM_DATA_BITS-1:0] mem_resp_data,
-  output reg [`MEM_TAG_BITS-1:0] mem_resp_tag
+  output reg [`MIF_DATA_BITS-1:0] mem_resp_data,
+  output reg [`MIF_TAG_BITS-1:0] mem_resp_tag
 );
 
   localparam DATA_CYCLES = 4;
   localparam DEPTH = 2*1024*1024;
 
   reg [`ceilLog2(DATA_CYCLES)-1:0] cnt;
-  reg [`MEM_TAG_BITS-1:0] tag;
+  reg [`MIF_TAG_BITS-1:0] tag;
   reg state_busy, state_rw;
-  reg [`MEM_ADDR_BITS-1:0] addr;
+  reg [`MIF_ADDR_BITS-1:0] addr;
 
-  reg [`MEM_DATA_BITS-1:0] ram [DEPTH-1:0];
+  reg [`MIF_DATA_BITS-1:0] ram [DEPTH-1:0];
   wire [`ceilLog2(DEPTH)-1:0] ram_addr = state_busy  ?         {addr[`ceilLog2(DEPTH/DATA_CYCLES)-1:0], cnt}
                                                      : {mem_req_addr[`ceilLog2(DEPTH/DATA_CYCLES)-1:0], cnt};
   wire do_read = mem_req_valid && mem_req_ready && !mem_req_rw || state_busy && !state_rw;

--- a/vsrc/rocketTestHarness.v
+++ b/vsrc/rocketTestHarness.v
@@ -88,12 +88,12 @@ module rocketTestHarness;
   end
 
   wire mem_bk_req_valid, mem_bk_req_rw, mem_bk_req_data_valid;
-  wire [`MEM_ID_BITS-1:0] mem_bk_req_tag;
-  wire [`MEM_ADDR_BITS-1:0] mem_bk_req_addr;
-  wire [`MEM_DATA_BITS-1:0] mem_bk_req_data_bits;
+  wire [`MIF_TAG_BITS-1:0] mem_bk_req_tag;
+  wire [`MIF_ADDR_BITS-1:0] mem_bk_req_addr;
+  wire [`MIF_DATA_BITS-1:0] mem_bk_req_data_bits;
   wire mem_bk_req_ready, mem_bk_req_data_ready, mem_bk_resp_valid;
-  wire [`MEM_ID_BITS-1:0]  mem_bk_resp_tag;
-  wire [`MEM_DATA_BITS-1:0] mem_bk_resp_data;
+  wire [`MIF_TAG_BITS-1:0]  mem_bk_resp_tag;
+  wire [`MIF_DATA_BITS-1:0] mem_bk_resp_data;
 
 `ifdef MEM_BACKUP_EN
   memdessertMemDessert dessert
@@ -150,9 +150,9 @@ module rocketTestHarness;
   assign mem_in_bits = {`HTIF_WIDTH {1'b0}};   
   assign mem_bk_req_valid = 1'b0;
   assign mem_bk_req_ready = 1'b0;
-  assign mem_bk_req_addr = {`MEM_ADDR_BITS {1'b0}}; 
+  assign mem_bk_req_addr = {`MIF_ADDR_BITS {1'b0}};
   assign mem_bk_req_rw = 1'b0;
-  assign mem_bk_req_tag = {`MEM_ID_BITS {1'b0}}; 
+  assign mem_bk_req_tag = {`MIF_TAG_BITS {1'b0}};
   assign mem_bk_req_data_valid = 1'b0;
   assign mem_bk_req_data_bits = 16'd0; 
 `endif


### PR DESCRIPTION
We still use the backup memory port when building chips, but it's gotten no testing upstream so it's completely broken.  This resurrects the backup memory port Verilog test harness, adds a configuration option that will enable that test harness, and fixes the backup memory port on multi-channel configurations.