### PR TITLE
Removed jackhammer submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,10 +28,6 @@
 [submodule "junctions"]
 	path = junctions
 	url = git@github.com:ucb-bar/junctions
-[submodule "jackhammer"]
-	path = jackhammer
-	url = git@github.com:ucb-bar/jackhammer.git
-	branch = new-rocketchip
 [submodule "vlsi"]
 	path = vlsi
 	url = git@github.com:ucb-bar/vlsi.git


### PR DESCRIPTION
This was previously removed from the master branch of ucb-bar/rocket-chip, but not from the hwacha branch.  Removing it now should prevent `git submodule update` from failing due to the unavailability of jackhammer.