### PR TITLE
Switch memory to Tilelink interconnect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ env:
     - CONFIG=RoccExampleConfig
     - CONFIG=DualCoreConfig
     - CONFIG=MemtestConfig
-    - CONFIG=MemtestL2Config
+    - CONFIG=FancyMemtestConfig
+    - CONFIG=MemoryMuxMemtestConfig
     - CONFIG=BroadcastRegressionTestConfig
     - CONFIG=CacheRegressionTestConfig
     - CONFIG=UnitTestConfig

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -217,7 +217,10 @@ class DefaultConfig extends Config (
           maxClientsPerPort = site(NAcquireTransactors) + 2,
           maxManagerXacts = 1,
           dataBits = site(CacheBlockBytes)*8)
-      case TLKey("Outermost") => site(TLKey("L2toMC")).copy(dataBeats = site(MIFDataBeats))
+      case TLKey("Outermost") => site(TLKey("L2toMC")).copy(
+        maxClientXacts = site(NAcquireTransactors) + 2,
+        maxClientsPerPort = site(NBanksPerMemoryChannel),
+        dataBeats = site(MIFDataBeats))
       case TLKey("L2toMMIO") => {
         val addrMap = new AddrHashMap(site(GlobalAddrMap), site(MMIOBase))
         TileLinkParameters(

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -219,7 +219,7 @@ class DefaultConfig extends Config (
           dataBits = site(CacheBlockBytes)*8)
       case TLKey("Outermost") => site(TLKey("L2toMC")).copy(
         maxClientXacts = site(NAcquireTransactors) + 2,
-        maxClientsPerPort = site(NBanksPerMemoryChannel),
+        maxClientsPerPort = site(MaxBanksPerMemoryChannel),
         dataBeats = site(MIFDataBeats))
       case TLKey("L2toMMIO") => {
         val addrMap = new AddrHashMap(site(GlobalAddrMap), site(MMIOBase))

--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -278,11 +278,13 @@ class OuterMemorySystem(implicit val p: Parameters) extends Module with HasTopLe
                 "More memory channels elaborated than can be enabled")
   val mem_ic =
     if (channelConfigs.size == 1) {
-      val ic = Module(new NastiMemoryInterconnect(nBanksPerMemChannel, nMemChannels))
+      val ic = Module(new TileLinkMemoryInterconnect(
+        nBanksPerMemChannel, nMemChannels)(outermostTLParams))
       ic
     } else {
       val nBanks = nBanksPerMemChannel * nMemChannels
-      val ic = Module(new NastiMemorySelector(nBanks, nMemChannels, channelConfigs))
+      val ic = Module(new TileLinkMemorySelector(
+        nBanks, nMemChannels, channelConfigs)(outermostTLParams))
       ic.io.select := io.memory_channel_mux_select
       ic
     }
@@ -290,11 +292,9 @@ class OuterMemorySystem(implicit val p: Parameters) extends Module with HasTopLe
   for ((bank, i) <- managerEndpoints.zipWithIndex) {
     val unwrap = Module(new ClientTileLinkIOUnwrapper()(outerTLParams))
     val narrow = Module(new TileLinkIONarrower("L2toMC", "Outermost"))
-    val conv = Module(new NastiIOTileLinkIOConverter()(outermostTLParams))
     unwrap.io.in <> ClientTileLinkEnqueuer(bank.outerTL, backendBuffering)(outerTLParams)
     narrow.io.in <> unwrap.io.out
-    conv.io.tl <> narrow.io.out
-    TopUtils.connectNasti(mem_ic.io.masters(i), conv.io.nasti)
+    mem_ic.io.in(i) <> narrow.io.out
   }
 
   val mmioOutermostTLParams = p.alterPartial({case TLId => "MMIO_Outermost"})
@@ -307,8 +307,8 @@ class OuterMemorySystem(implicit val p: Parameters) extends Module with HasTopLe
   mmio_narrow.io.in <> mmioManager.io.outer
   mmio_net.io.in.head <> mmio_narrow.io.out
 
-  def connectTilelinkNasti(nasti: NastiIO, tl: ClientUncachedTileLinkIO) = {
-    val conv = Module(new NastiIOTileLinkIOConverter()(mmioOutermostTLParams))
+  def connectTilelinkNasti(nasti: NastiIO, tl: ClientUncachedTileLinkIO)(implicit p: Parameters) = {
+    val conv = Module(new NastiIOTileLinkIOConverter())
     conv.io.tl <> tl
     TopUtils.connectNasti(nasti, conv.io.nasti)
   }
@@ -317,13 +317,13 @@ class OuterMemorySystem(implicit val p: Parameters) extends Module with HasTopLe
     val csrName = s"conf:csr$i"
     val csrPort = addrHashMap(csrName).port
     val conv = Module(new SmiIONastiIOConverter(xLen, csrAddrBits))
-    connectTilelinkNasti(conv.io.nasti, mmio_net.io.out(csrPort))
+    connectTilelinkNasti(conv.io.nasti, mmio_net.io.out(csrPort))(mmioOutermostTLParams)
     io.csr(i) <> conv.io.smi
   }
 
   val scrPort = addrHashMap("conf:scr").port
   val scr_conv = Module(new SmiIONastiIOConverter(scrDataBits, scrAddrBits))
-  connectTilelinkNasti(scr_conv.io.nasti, mmio_net.io.out(scrPort))
+  connectTilelinkNasti(scr_conv.io.nasti, mmio_net.io.out(scrPort))(mmioOutermostTLParams)
   io.scr <> scr_conv.io.smi
 
   if (p(UseStreamLoopback)) {
@@ -331,14 +331,19 @@ class OuterMemorySystem(implicit val p: Parameters) extends Module with HasTopLe
     val lo_size = p(StreamLoopbackSize)
     val lo_conv = Module(new NastiIOStreamIOConverter(lo_width))
     val lo_port = addrHashMap("devices:loopback").port
-    connectTilelinkNasti(lo_conv.io.nasti, mmio_net.io.out(lo_port))
+    connectTilelinkNasti(lo_conv.io.nasti, mmio_net.io.out(lo_port))(mmioOutermostTLParams)
     lo_conv.io.stream.in <> Queue(lo_conv.io.stream.out, lo_size)
   }
 
   val dtPort = addrHashMap("conf:devicetree").port
-  connectTilelinkNasti(io.deviceTree, mmio_net.io.out(dtPort))
+  connectTilelinkNasti(io.deviceTree, mmio_net.io.out(dtPort))(mmioOutermostTLParams)
 
-  val mem_channels = mem_ic.io.slaves
+  val mem_channels = Wire(Vec(nMemChannels, new NastiIO))
+
+  mem_channels.zip(mem_ic.io.out).foreach { case (ch, out) =>
+    connectTilelinkNasti(ch, out)(outermostTLParams)
+  }
+
   // Create a SerDes for backup memory port
   if(p(UseBackupMemoryPort)) {
     VLSIUtils.doOuterMemorySystemSerdes(

--- a/src/main/scala/TestConfigs.scala
+++ b/src/main/scala/TestConfigs.scala
@@ -144,3 +144,7 @@ class TraceGenConfig extends Config(new With2Cores ++ new WithL2Cache ++ new Wit
 class FancyMemtestConfig extends Config(
   new With2Cores ++ new With2MemoryChannels ++ new With2BanksPerMemChannel ++
   new WithMemtest ++ new WithL2Cache ++ new GroundTestConfig)
+
+class MemoryMuxMemtestConfig extends Config(
+  new With2MemoryChannels ++ new WithOneOrMaxChannels ++
+  new WithMemtest ++ new GroundTestConfig)


### PR DESCRIPTION
Similar to the last PR. This changes the routing for the memory channels from AXI to TileLink. Related PR for uncore.