### PR TITLE
add default cases to configs that use CDEMatchError

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -11,7 +11,7 @@ import zscale._
 import groundtest._
 import scala.math.max
 import DefaultTestSuites._
-import cde.{Parameters, Config, Dump, Knob}
+import cde.{Parameters, Config, Dump, Knob, CDEMatchError}
 
 object ConfigUtils {
   def max_int(values: Int*): Int = {
@@ -265,6 +265,7 @@ class DefaultConfig extends Config (
         }
         devset
       }
+      case _ => throw new CDEMatchError
   }},
   knobValues = {
     case "NTILES" => 1
@@ -275,32 +276,36 @@ class DefaultConfig extends Config (
     case "L1I_SETS" => 64
     case "L1I_WAYS" => 4
     case "L1I_BUFFER_WAYS" => false
+    case _ => throw new CDEMatchError
   }
 )
 class DefaultVLSIConfig extends DefaultConfig
 class DefaultCPPConfig extends DefaultConfig
 
-class With2Cores extends Config(knobValues = { case "NTILES" => 2 })
-class With4Cores extends Config(knobValues = { case "NTILES" => 4 })
-class With8Cores extends Config(knobValues = { case "NTILES" => 8 })
+class With2Cores extends Config(knobValues = { case "NTILES" => 2; case _ => throw new CDEMatchError })
+class With4Cores extends Config(knobValues = { case "NTILES" => 4; case _ => throw new CDEMatchError })
+class With8Cores extends Config(knobValues = { case "NTILES" => 8; case _ => throw new CDEMatchError })
 
-class With2BanksPerMemChannel extends Config(knobValues = { case "NBANKS_PER_MEM_CHANNEL" => 2 })
-class With4BanksPerMemChannel extends Config(knobValues = { case "NBANKS_PER_MEM_CHANNEL" => 4 })
-class With8BanksPerMemChannel extends Config(knobValues = { case "NBANKS_PER_MEM_CHANNEL" => 8 })
+class With2BanksPerMemChannel extends Config(knobValues = { case "NBANKS_PER_MEM_CHANNEL" => 2; case _ => throw new CDEMatchError })
+class With4BanksPerMemChannel extends Config(knobValues = { case "NBANKS_PER_MEM_CHANNEL" => 4; case _ => throw new CDEMatchError })
+class With8BanksPerMemChannel extends Config(knobValues = { case "NBANKS_PER_MEM_CHANNEL" => 8; case _ => throw new CDEMatchError })
 
 class With2MemoryChannels extends Config(
   (pname,site,here) => pname match {
     case NMemoryChannels => Dump("N_MEM_CHANNELS", 2)
+    case _ => throw new CDEMatchError
   }
 )
 class With4MemoryChannels extends Config(
   (pname,site,here) => pname match {
     case NMemoryChannels => Dump("N_MEM_CHANNELS", 4)
+    case _ => throw new CDEMatchError
   }
 )
 class With8MemoryChannels extends Config(
   (pname,site,here) => pname match {
     case NMemoryChannels => Dump("N_MEM_CHANNELS", 8)
+    case _ => throw new CDEMatchError
   }
 )
 
@@ -327,25 +332,27 @@ class WithL2Cache extends Config(
         case InnerTLId => "L1toL2"
         case OuterTLId => "L2toMC"})))
     case L2Replacer => () => new SeqRandom(site(NWays))
+    case _ => throw new CDEMatchError
   },
-  knobValues = { case "L2_WAYS" => 8; case "L2_CAPACITY_IN_KB" => 2048; case "L2_SPLIT_METADATA" => false }
+  knobValues = { case "L2_WAYS" => 8; case "L2_CAPACITY_IN_KB" => 2048; case "L2_SPLIT_METADATA" => false; case _ => throw new CDEMatchError }
 )
 
 class WithPLRU extends Config(
   (pname, site, here) => pname match {
     case L2Replacer => () => new SeqPLRU(site(NSets), site(NWays))
+    case _ => throw new CDEMatchError
   })
 
-class WithL2Capacity2048 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 2048 })
-class WithL2Capacity1024 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 1024 })
-class WithL2Capacity512 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 512 })
-class WithL2Capacity256 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 256 })
-class WithL2Capacity128 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 128 })
-class WithL2Capacity64 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 64 })
+class WithL2Capacity2048 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 2048; case _ => throw new CDEMatchError })
+class WithL2Capacity1024 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 1024; case _ => throw new CDEMatchError })
+class WithL2Capacity512 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 512; case _ => throw new CDEMatchError })
+class WithL2Capacity256 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 256; case _ => throw new CDEMatchError })
+class WithL2Capacity128 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 128; case _ => throw new CDEMatchError })
+class WithL2Capacity64 extends Config(knobValues = { case "L2_CAPACITY_IN_KB" => 64; case _ => throw new CDEMatchError })
 
-class With1L2Ways extends Config(knobValues = { case "L2_WAYS" => 1 })
-class With2L2Ways extends Config(knobValues = { case "L2_WAYS" => 2 })
-class With4L2Ways extends Config(knobValues = { case "L2_WAYS" => 4 })
+class With1L2Ways extends Config(knobValues = { case "L2_WAYS" => 1; case _ => throw new CDEMatchError })
+class With2L2Ways extends Config(knobValues = { case "L2_WAYS" => 2; case _ => throw new CDEMatchError })
+class With4L2Ways extends Config(knobValues = { case "L2_WAYS" => 4; case _ => throw new CDEMatchError })
 
 class DefaultL2Config extends Config(new WithL2Cache ++ new DefaultConfig)
 class DefaultL2VLSIConfig extends Config(new WithL2Cache ++ new DefaultVLSIConfig)
@@ -365,6 +372,7 @@ class WithZscale extends Config(
     }
     case BootROMCapacity => Dump("BOOT_CAPACITY", 16*1024)
     case DRAMCapacity => Dump("DRAM_CAPACITY", 64*1024*1024)
+    case _ => throw new CDEMatchError
   }
 )
 
@@ -373,6 +381,7 @@ class WithRV32 extends Config(
     case XLen => 32
     case UseVM => false
     case UseFPU => false
+    case _ => throw new CDEMatchError
   }
 )
 
@@ -382,6 +391,7 @@ class FPGAConfig extends Config (
   (pname,site,here) => pname match {
     case NAcquireTransactors => 4
     case UseHtifClockDiv => false
+    case _ => throw new CDEMatchError
   }
 )
 
@@ -396,6 +406,7 @@ class SmallConfig extends Config (
       case StoreDataQueueDepth => 2
       case ReplayQueueDepth => 2
       case NAcquireTransactors => 2
+      case _ => throw new CDEMatchError
     }},
   knobValues = {
     case "L1D_SETS" => 64
@@ -403,6 +414,7 @@ class SmallConfig extends Config (
     case "L1I_SETS" => 64
     case "L1I_WAYS" => 1
     case "L1D_MSHRS" => 1
+    case _ => throw new CDEMatchError
   }
 )
 
@@ -441,6 +453,7 @@ class WithRoccExample extends Config(
         generator = (p: Parameters) => Module(new CharacterCountExample()(p))))
 
     case RoccMaxTaggedMemXacts => 1
+    case _ => throw new CDEMatchError
   })
 
 class RoccExampleConfig extends Config(new WithRoccExample ++ new DefaultConfig)
@@ -456,6 +469,7 @@ class WithDmaController extends Config(
             DmaCtrlRegNumbers.CSR_BASE,
             DmaCtrlRegNumbers.CSR_END)))
     case RoccMaxTaggedMemXacts => 1
+    case _ => throw new CDEMatchError
   })
 
 class WithStreamLoopback extends Config(
@@ -463,6 +477,7 @@ class WithStreamLoopback extends Config(
     case UseStreamLoopback => true
     case StreamLoopbackSize => 128
     case StreamLoopbackWidth => 64
+    case _ => throw new CDEMatchError
   })
 
 class DmaControllerConfig extends Config(new WithDmaController ++ new WithStreamLoopback ++ new DefaultL2Config)
@@ -482,6 +497,7 @@ class EightChannelVLSIConfig extends Config(new With8MemoryChannels ++ new Defau
 class WithOneOrMaxChannels extends Config(
   (pname, site, here) => pname match {
     case MemoryChannelMuxConfigs => Dump("MEMORY_CHANNEL_MUX_CONFIGS", List(1, site(NMemoryChannels)))
+    case _ => throw new CDEMatchError
   }
 )
 class OneOrEightChannelBenchmarkConfig extends Config(new WithOneOrMaxChannels ++ new With8MemoryChannels ++ new SingleChannelBenchmarkConfig)
@@ -491,7 +507,7 @@ class SimulateBackupMemConfig extends Config(){ Dump("MEM_BACKUP_EN", true) }
 class BackupMemVLSIConfig extends Config(new SimulateBackupMemConfig ++ new DefaultVLSIConfig)
 class OneOrEightChannelBackupMemVLSIConfig extends Config(new WithOneOrMaxChannels ++ new With8MemoryChannels ++ new BackupMemVLSIConfig)
 
-class WithSplitL2Metadata extends Config(knobValues = { case "L2_SPLIT_METADATA" => true })
+class WithSplitL2Metadata extends Config(knobValues = { case "L2_SPLIT_METADATA" => true; case _ => throw new CDEMatchError })
 class SplitL2MetadataTestConfig extends Config(new WithSplitL2Metadata ++ new DefaultL2Config)
 
 class DualCoreConfig extends Config(new With2Cores ++ new DefaultConfig)

--- a/src/main/scala/TestConfigs.scala
+++ b/src/main/scala/TestConfigs.scala
@@ -6,7 +6,7 @@ import rocket._
 import uncore._
 import junctions._
 import scala.collection.mutable.LinkedHashSet
-import cde.{Parameters, Config, Dump, Knob}
+import cde.{Parameters, Config, Dump, Knob, CDEMatchError}
 import scala.math.max
 import ConfigUtils._
 
@@ -37,6 +37,7 @@ class WithGroundTest extends Config(
     case GroundTestCSRs => Nil
     case RoccNCSRs => site(GroundTestCSRs).size
     case UseFPU => false
+    case _ => throw new CDEMatchError
   })
 
 class WithMemtest extends Config(
@@ -48,16 +49,19 @@ class WithMemtest extends Config(
     case GeneratorStartAddress => 0
     case BuildGroundTest =>
       (id: Int, p: Parameters) => Module(new GeneratorTest(id)(p))
+    case _ => throw new CDEMatchError
   })
 
 class WithCacheFillTest extends Config(
   (pname, site, here) => pname match {
     case BuildGroundTest =>
       (id: Int, p: Parameters) => Module(new CacheFillTest()(p))
+    case _ => throw new CDEMatchError
   },
   knobValues = {
     case "L2_WAYS" => 4
     case "L2_CAPACITY_IN_KB" => 4
+    case _ => throw new CDEMatchError
   })
 
 class WithBroadcastRegressionTest extends Config(
@@ -67,6 +71,7 @@ class WithBroadcastRegressionTest extends Config(
     case GroundTestRegressions =>
       (p: Parameters) => RegressionTests.broadcastRegressions(p)
     case GroundTestMaxXacts => 3
+    case _ => throw new CDEMatchError
   })
 
 class WithCacheRegressionTest extends Config(
@@ -76,6 +81,7 @@ class WithCacheRegressionTest extends Config(
     case GroundTestRegressions =>
       (p: Parameters) => RegressionTests.cacheRegressions(p)
     case GroundTestMaxXacts => 3
+    case _ => throw new CDEMatchError
   })
 
 class WithDmaTest extends Config(
@@ -91,6 +97,7 @@ class WithDmaTest extends Config(
       (0x00800008, 0x00800008, 64))
     case DmaTestDataStart => 0x3012CC00
     case DmaTestDataStride => 8
+    case _ => throw new CDEMatchError
   })
 
 class WithDmaStreamTest extends Config(
@@ -102,18 +109,21 @@ class WithDmaStreamTest extends Config(
       size = site(StreamLoopbackWidth) / 8)
     case GroundTestCSRs =>
       Seq(DmaCtrlRegNumbers.CSR_BASE + DmaCtrlRegNumbers.OUTSTANDING)
+    case _ => throw new CDEMatchError
   })
 
 class WithNastiConverterTest extends Config(
   (pname, site, here) => pname match {
     case BuildGroundTest =>
       (id: Int, p: Parameters) => Module(new NastiConverterTest()(p))
+    case _ => throw new CDEMatchError
   })
 
 class WithUnitTest extends Config(
   (pname, site, here) => pname match {
     case BuildGroundTest =>
       (id: Int, p: Parameters) => Module(new UnitTestSuite()(p))
+    case _ => throw new CDEMatchError
   })
 
 class WithTraceGen extends Config(
@@ -123,6 +133,7 @@ class WithTraceGen extends Config(
     case NGenerators => site(NTiles)
     case MaxGenerateRequests => 128
     case AddressBag => List(0x8, 0x10, 0x108, 0x100008)
+    case _ => throw new CDEMatchError
   })
 
 class GroundTestConfig extends Config(new WithGroundTest ++ new DefaultConfig)


### PR DESCRIPTION
this avoids filling in the stack trace every time
a config doesn't contain the parameter

This speeds up a Hwacha config's compile time by 1 minute (from 2 to 1) in Chisel 2 and 4 minutes (6->2) in chisel3.

See https://github.com/ucb-bar/context-dependent-environments/pull/2

and some discussion https://github.com/ucb-bar/chisel3/issues/143