### PR TITLE
Don't make MIFTagBits a computed parameter

### DIFF
--- a/csrc/vcs_main.rocketTestHarness.cc
+++ b/csrc/vcs_main.rocketTestHarness.cc
@@ -101,17 +101,27 @@ void memory_tick(
   for (size_t i = 0; i < mmc->get_word_size()/sizeof(uint32_t); i++)
     write_data[i] = vc_4stVectorRef(w_data)[i].d;
 
+  uint32_t aw_id_val, ar_id_val;
+
+  if (MEM_ID_BITS == 1) {
+    aw_id_val = vc_getScalar(aw_id);
+    ar_id_val = vc_getScalar(ar_id);
+  } else {
+    aw_id_val = vc_4stVectorRef(aw_id)->d;
+    ar_id_val = vc_4stVectorRef(ar_id)->d;
+  }
+
   mmc->tick
   (
     vc_getScalar(ar_valid),
     vc_4stVectorRef(ar_addr)->d - MEM_BASE,
-    vc_4stVectorRef(ar_id)->d,
+    ar_id_val,
     vc_4stVectorRef(ar_size)->d,
     vc_4stVectorRef(ar_len)->d,
 
     vc_getScalar(aw_valid),
     vc_4stVectorRef(aw_addr)->d - MEM_BASE,
-    vc_4stVectorRef(aw_id)->d,
+    aw_id_val,
     vc_4stVectorRef(aw_size)->d,
     vc_4stVectorRef(aw_len)->d,
 
@@ -138,16 +148,21 @@ void memory_tick(
   vc_put4stVector(b_resp, d);
 
   d[0].c = 0;
-  d[0].d = mmc->b_id();
-  vc_put4stVector(b_id, d);
-
-  d[0].c = 0;
   d[0].d = mmc->r_resp();
   vc_put4stVector(r_resp, d);
 
-  d[0].c = 0;
-  d[0].d = mmc->r_id();
-  vc_put4stVector(r_id, d);
+  if (MEM_ID_BITS > 1) {
+    d[0].c = 0;
+    d[0].d = mmc->b_id();
+    vc_put4stVector(b_id, d);
+
+    d[0].c = 0;
+    d[0].d = mmc->r_id();
+    vc_put4stVector(r_id, d);
+  } else {
+    vc_putScalar(b_id, mmc->b_id());
+    vc_putScalar(r_id, mmc->r_id());
+  }
 
   for (size_t i = 0; i < mmc->get_word_size()/sizeof(uint32_t); i++)
   {

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -102,11 +102,7 @@ class DefaultConfig extends Config (
       case PPNBits => site(PAddrBits) - site(PgIdxBits)
       case VAddrBits => site(VPNBits) + site(PgIdxBits)
       case ASIdBits => 7
-      case MIFTagBits => Dump("MIF_TAG_BITS",
-                         // Bits needed at the L2 agent
-                         log2Up(site(NAcquireTransactors)+2) +
-                         // Bits added by NASTI interconnect
-                         log2Up(site(NBanksPerMemoryChannel)))
+      case MIFTagBits => Dump("MIF_TAG_BITS", 5)
       case MIFDataBits => Dump("MIF_DATA_BITS", 64)
       case MIFAddrBits => Dump("MIF_ADDR_BITS",
                                site(PAddrBits) - site(CacheBlockOffsetBits))


### PR DESCRIPTION
For the hurricane2 tape out and other future work, the width of the AXI id fields will be fixed. Thus, the TL -> AXI converter will have to account from this and map TileLink ids to AXI ids.