### PR TITLE
ahb: AHB parameters should match TileLink parameters by default

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -233,6 +233,11 @@ class DefaultConfig extends Config (
       case LNHeaderBits => log2Ceil(site(TLKey(site(TLId))).nManagers) +
                              log2Up(site(TLKey(site(TLId))).nClients)
       case ExtraL1Clients => 1 // HTIF // TODO not really a parameter
+      case HastiId => "TL"
+      case HastiKey("TL") =>
+        HastiParameters(
+          addrBits = site(PAddrBits),
+          dataBits = site(TLKey(site(TLId))).dataBits / site(TLKey(site(TLId))).dataBeats)
       case TLKey("L1toL2") => 
         TileLinkParameters(
           coherencePolicy = new MESICoherence(site(L2DirectoryRepresentation)),


### PR DESCRIPTION
Do not merge this until submodules uncore and junctions have been moved forward