### PR TITLE
Fix "make run-asm-tests" for Chisel 3

### DIFF
--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -21,10 +21,10 @@ $(FIRRTL):
 # files.
 .SECONDARY: $(generated_dir)/$(MODEL).$(CONFIG).fir
 
-$(generated_dir)/%.$(CONFIG).fir: $(chisel_srcs)
+$(generated_dir)/%.$(CONFIG).fir $(generated_dir)/%.$(CONFIG).d: $(chisel_srcs)
 	mkdir -p $(dir $@)
-	cd $(base_dir) && $(SBT) "run $(PROJECT) $(patsubst %.$(CONFIG).fir,%,$(notdir $@)) $(CONFIG) $(CHISEL_ARGS) --configDump --noInlineMem"
-	mv $(patsubst %.$(CONFIG).fir,%.fir,$@) $@
+	cd $(base_dir) && $(SBT) "run $(PROJECT) $(patsubst %.$(CONFIG).fir,%,$(patsubst %.d,%.fir,$(notdir $@))) $(CONFIG) $(CHISEL_ARGS) --configDump --noInlineMem"
+	mv $(generated_dir)/$(MODEL).fir $(generated_dir)/$(MODEL).$(CONFIG).fir
 
 $(generated_dir)/%.v $(generated_dir)/%.prm: $(generated_dir)/%.fir $(FIRRTL)
 	mkdir -p $(dir $@)


### PR DESCRIPTION
This was just a missing Makefrag-verilog dependency (the .d file).