### PR TITLE
replace emulator with verilator for chisel3

### DIFF
--- a/csrc/emulator_type.h
+++ b/csrc/emulator_type.h
@@ -1,0 +1,105 @@
+// See LICENSE for license details.
+
+#ifndef VERILATOR
+#define bool_t dat_t<1>
+#else
+#define bool_t CData
+#endif
+
+#ifndef VERILATOR
+#define mem_addr_t dat_t<MEM_ADDR_BITS>
+#elif MEM_ADDR_BITS <= 8
+#define mem_addr_t CData
+#elif MEM_ADDR_BITS <= 16
+#define mem_addr_t SData
+#elif MEM_ADDR_BITS <= 32
+#define mem_addr_t IData
+#elif MEM_ADDR_BITS <= 64
+#define mem_addr_t QData
+#else // MEM_ADDR_BITS > 64
+#define mem_addr_t WData*
+#endif
+
+#ifndef VERILATOR
+#define mem_id_t dat_t<MEM_ID_BITS>
+#elif MEM_ID_BITS <= 8
+#define mem_id_t CData
+#elif MEM_ID_BITS <= 16
+#define mem_id_t SData
+#elif MEM_ID_BITS <= 32
+#define mem_id_t IData
+#elif MEM_ID_BITS <= 64
+#define mem_id_t QData
+#else // MEM_ID_BITS > 64
+#define mem_id_t WData*
+#endif
+
+#ifndef VERILATOR
+#define mem_size_t dat_t<MEM_SIZE_BITS>
+#elif MEM_SIZE_BITS <= 8
+#define mem_size_t CData
+#elif MEM_SIZE_BITS <= 16
+#define mem_size_t SData
+#elif MEM_SIZE_BITS <= 32
+#define mem_size_t IData
+#elif MEM_SIZE_BITS <= 64
+#define mem_size_t QData
+#else // MEM_SIZE_BITS > 64
+#define mem_size_t WData*
+#endif
+
+#ifndef VERILATOR
+#define mem_len_t dat_t<MEM_LEN_BITS>
+#elif MEM_LEN_BITS <= 8
+#define mem_len_t CData
+#elif MEM_LEN_BITS <= 16
+#define mem_len_t SData
+#elif MEM_LEN_BITS <= 32
+#define mem_len_t IData
+#elif MEM_LEN_BITS <= 64
+#define mem_len_t QData
+#else // MEM_LEN_BITS > 64
+#define mem_len_t WData*
+#endif
+
+#ifndef VERILATOR
+#define mem_strb_t dat_t<MEM_STRB_BITS>
+#elif MEM_STRB_BITS <= 8
+#define mem_strb_t CData
+#elif MEM_STRB_BITS <= 16
+#define mem_strb_t SData
+#elif MEM_STRB_BITS <= 32
+#define mem_strb_t IData
+#elif MEM_STRB_BITS <= 64
+#define mem_strb_t QData
+#else // MEM_STRB_BITS > 64
+#define mem_strb_t WData*
+#endif
+
+#ifndef VERILATOR
+#define mem_data_t dat_t<MEM_DATA_BITS>
+#elif MEM_DATA_BITS <= 8
+#define mem_data_t CData
+#elif MEM_DATA_BITS <= 16
+#define mem_data_t SData
+#elif MEM_DATA_BITS <= 32
+#define mem_data_t IData
+#elif MEM_DATA_BITS <= 64
+#define mem_data_t QData
+#else // MEM_DATA_BITS > 64
+#define mem_data_t WData*
+#endif
+
+#ifndef VERILATOR
+#define mem_resp_t dat_t<MEM_RESP_BITS>
+#elif MEM_RESP_BITS <= 8
+#define mem_resp_t CData
+#elif MEM_RESP_BITS <= 16
+#define mem_resp_t SData
+#elif MEM_RESP_BITS <= 32
+#define mem_resp_t IData
+#elif MEM_RESP_BITS <= 64
+#define mem_resp_t QData
+#else // MEM_RESP_BITS > 64
+#define mem_resp_t WData*
+#endif

--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -13,46 +13,16 @@ include $(base_dir)/Makefrag
 
 CXXSRCS := emulator mm mm_dramsim2
 CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include -I$(base_dir)/csrc -I$(base_dir)/dramsim2
-LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L. -ldramsim -lfesvr -lpthread
-OBJS := $(addsuffix .o,$(CXXSRCS) $(MODEL).$(CONFIG))
-DEBUG_OBJS := $(addsuffix .debug.o,$(CXXSRCS) $(MODEL).$(CONFIG))
-
-model_header = $(generated_dir)/$(MODEL).$(CONFIG).h
-model_header_debug = $(generated_dir_debug)/$(MODEL).$(CONFIG).h
-
-$(MODEL).$(CONFIG).o: %.o: $(generated_dir)/%.h
-	$(MAKE) -j $(patsubst %.cpp,%.o,$(shell ls $(generated_dir)/$(MODEL).$(CONFIG)-*.cpp))
-	$(LD) -r $(patsubst %.cpp,%.o,$(shell ls $(generated_dir)/$(MODEL).$(CONFIG)-*.cpp)) -o $@
-
-$(MODEL).$(CONFIG).debug.o: %.debug.o: $(generated_dir_debug)/%.h
-	$(MAKE) -j $(patsubst %.cpp,%.o,$(shell ls $(generated_dir_debug)/$(MODEL).$(CONFIG)-*.cpp))
-	$(LD) -r $(patsubst %.cpp,%.o,$(shell ls $(generated_dir_debug)/$(MODEL).$(CONFIG)-*.cpp)) -o $@
-
-$(generated_dir)/%.o: $(generated_dir)/%.cpp $(generated_dir)/%.h
-	$(CXX) $(CXXFLAGS) -I$(generated_dir) -c -o $@ $<
-
-$(generated_dir_debug)/%.o: $(generated_dir_debug)/%.cpp $(generated_dir_debug)/%.h
-	$(CXX) $(CXXFLAGS) -I$(generated_dir_debug) -c -o $@ $<
-
-$(addsuffix .o,$(CXXSRCS)): %.o: $(base_dir)/csrc/%.cc $(base_dir)/csrc/*.h $(model_header) $(consts_header)
-	$(CXX) $(CXXFLAGS) -include $(scr_header) -include $(model_header) -include $(consts_header) -I$(generated_dir) -c -o $@ $<
-
-$(addsuffix .debug.o,$(CXXSRCS)): %.debug.o: $(base_dir)/csrc/%.cc $(base_dir)/csrc/*.h $(model_header_debug) $(consts_header_debug)
-	$(CXX) $(CXXFLAGS) -include $(scr_header_debug) -include $(model_header_debug) -include $(consts_header_debug) -I$(generated_dir_debug) -c -o $@ $<
-
-$(generated_dir)/$(MODEL).$(CONFIG).d $(model_header) $(params_file): $(chisel_srcs)
-	cd $(base_dir) && $(SBT) "project $(PROJECT)" "run $(CHISEL_ARGS) --noIoDebug"
-
-$(model_header_debug) $(params_file_debug): $(chisel_srcs)
-	cd $(base_dir) && $(SBT) "project $(PROJECT)" "run $(CHISEL_ARGS)-debug  --debug --vcd --ioDebug"
+LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -ldramsim -lfesvr -lpthread
 
 emu = emulator-$(MODEL)-$(CONFIG)
-$(emu): $(model_header) $(OBJS) libdramsim.a
-	$(CXX) $(CXXFLAGS) -o $@ $(OBJS) $(LDFLAGS)
-
 emu_debug = emulator-$(MODEL)-$(CONFIG)-debug
-$(emu_debug): $(generated_dir)/$(MODEL).$(CONFIG).d $(model_header_debug) $(DEBUG_OBJS) libdramsim.a
-	$(CXX) $(CXXFLAGS) -o $@ $(DEBUG_OBJS) $(LDFLAGS)
+
+ifeq ($(CHISEL_VERSION),2)
+include $(sim_dir)/Makefrag-emulator
+else
+include $(sim_dir)/Makefrag-verilator
+endif
 
 all: $(emu)
 debug: $(emu_debug)
@@ -73,16 +43,16 @@ ifneq ($(MAKECMDGOALS),clean)
 -include $(generated_dir)/$(MODEL).$(CONFIG).d
 endif
 
-$(output_dir)/%.run: $(output_dir)/% emulator-$(MODEL)-$(CONFIG)
+$(output_dir)/%.run: $(output_dir)/% $(emu)
 	./$(emu) +dramsim +max-cycles=$(timeout_cycles) $< 2> /dev/null 2> $@ && [ $$PIPESTATUS -eq 0 ]
 
-$(output_dir)/%.out: $(output_dir)/% emulator-$(MODEL)-$(CONFIG)
+$(output_dir)/%.out: $(output_dir)/% $(emu)
 	./$(emu) +dramsim +max-cycles=$(timeout_cycles) +verbose $< $(disasm) $@ && [ $$PIPESTATUS -eq 0 ]
 
-$(output_dir)/%.vcd: $(output_dir)/% emulator-$(MODEL)-$(CONFIG)-debug
+$(output_dir)/%.vcd: $(output_dir)/% $(emu_debug)
 	./$(emu_debug) +dramsim +max-cycles=$(timeout_cycles) +verbose -v$@ $< $(disasm) $(patsubst %.vcd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 
-$(output_dir)/%.vpd: $(output_dir)/% emulator-$(MODEL)-$(CONFIG)-debug
+$(output_dir)/%.vpd: $(output_dir)/% $(emu_debug)
 	rm -rf $@.vcd && mkfifo $@.vcd
 	vcd2vpd $@.vcd $@ > /dev/null &
 	./$(emu_debug) +dramsim +max-cycles=$(timeout_cycles) +verbose -v$@.vcd $< $(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]

--- a/emulator/Makefrag-emulator
+++ b/emulator/Makefrag-emulator
@@ -1,0 +1,40 @@
+#--------------------------------------------------------------------
+# Chisel Emulator Generation
+#--------------------------------------------------------------------
+OBJS := $(addsuffix .o,$(CXXSRCS) $(MODEL).$(CONFIG))
+DEBUG_OBJS := $(addsuffix .debug.o,$(CXXSRCS) $(MODEL).$(CONFIG))
+
+model_header = $(generated_dir)/$(MODEL).$(CONFIG).h
+model_header_debug = $(generated_dir_debug)/$(MODEL).$(CONFIG).h
+
+$(MODEL).$(CONFIG).o: %.o: $(generated_dir)/%.h
+	$(MAKE) -j $(patsubst %.cpp,%.o,$(shell ls $(generated_dir)/$(MODEL).$(CONFIG)-*.cpp))
+	$(LD) -r $(patsubst %.cpp,%.o,$(shell ls $(generated_dir)/$(MODEL).$(CONFIG)-*.cpp)) -o $@
+
+$(MODEL).$(CONFIG).debug.o: %.debug.o: $(generated_dir_debug)/%.h
+	$(MAKE) -j $(patsubst %.cpp,%.o,$(shell ls $(generated_dir_debug)/$(MODEL).$(CONFIG)-*.cpp))
+	$(LD) -r $(patsubst %.cpp,%.o,$(shell ls $(generated_dir_debug)/$(MODEL).$(CONFIG)-*.cpp)) -o $@
+
+$(generated_dir)/%.o: $(generated_dir)/%.cpp $(generated_dir)/%.h
+	$(CXX) $(CXXFLAGS) -I$(generated_dir) -c -o $@ $<
+
+$(generated_dir_debug)/%.o: $(generated_dir_debug)/%.cpp $(generated_dir_debug)/%.h
+	$(CXX) $(CXXFLAGS) -I$(generated_dir_debug) -c -o $@ $<
+
+$(addsuffix .o,$(CXXSRCS)): %.o: $(base_dir)/csrc/%.cc $(base_dir)/csrc/*.h $(model_header) $(consts_header)
+	$(CXX) $(CXXFLAGS) -include $(scr_header) -include $(model_header) -include $(consts_header) -I$(generated_dir) -c -o $@ $<
+
+$(addsuffix .debug.o,$(CXXSRCS)): %.debug.o: $(base_dir)/csrc/%.cc $(base_dir)/csrc/*.h $(model_header_debug) $(consts_header_debug)
+	$(CXX) $(CXXFLAGS) -include $(scr_header_debug) -include $(model_header_debug) -include $(consts_header_debug) -I$(generated_dir_debug) -c -o $@ $<
+
+$(generated_dir)/$(MODEL).$(CONFIG).d $(model_header) $(params_file): $(chisel_srcs)
+	cd $(base_dir) && $(SBT) "project $(PROJECT)" "run $(CHISEL_ARGS) --noIoDebug"
+
+$(model_header_debug) $(params_file_debug): $(chisel_srcs)
+	cd $(base_dir) && $(SBT) "project $(PROJECT)" "run $(CHISEL_ARGS)-debug  --debug --vcd --ioDebug"
+
+$(emu): $(model_header) $(OBJS) libdramsim.a
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS) $(LDFLAGS)
+
+$(emu_debug): $(generated_dir)/$(MODEL).$(CONFIG).d $(model_header_debug) $(DEBUG_OBJS) libdramsim.a
+	$(CXX) $(CXXFLAGS) -o $@ $(DEBUG_OBJS) $(LDFLAGS)

--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -1,0 +1,57 @@
+#--------------------------------------------------------------------
+# Verilator Generation 
+#--------------------------------------------------------------------
+
+firrtl = $(generated_dir)/$(MODEL).$(CONFIG).fir
+firrtl_debug = $(generated_dir_debug)/$(MODEL).$(CONFIG).fir
+verilog = $(generated_dir)/$(MODEL).$(CONFIG).v
+verilog_debug = $(generated_dir_debug)/$(MODEL).$(CONFIG).v
+
+FIRRTL ?= $(base_dir)/firrtl/utils/bin/firrtl
+
+$(FIRRTL):
+	$(MAKE) -C $(base_dir)/firrtl SBT="$(SBT)" root_dir=$(base_dir)/firrtl build-scala
+
+.SECONDARY: $(firrtl) $(firrtl_debug) $(verilog) $(verilog_debug)
+
+$(firrtl) $(params_file) $(generated_dir)/%.$(CONFIG).d: $(chisel_srcs)
+	mkdir -p $(dir $@)
+	cd $(base_dir) && $(SBT) "run $(PROJECT) $(MODEL) $(CONFIG) --targetDir $(generated_dir)"
+	mv $(generated_dir)/$(MODEL).fir $(generated_dir)/$(MODEL).$(CONFIG).fir
+
+$(firrtl_debug) $(params_file_debug): $(chisel_srcs)
+	mkdir -p $(dir $@)
+	cd $(base_dir) && $(SBT) "run $(PROJECT) $(MODEL) $(CONFIG) --targetDir $(generated_dir_debug)"
+	mv $(generated_dir_debug)/$(MODEL).fir $(generated_dir_debug)/$(MODEL).$(CONFIG).fir
+
+%.v: %.fir $(FIRRTL)
+	mkdir -p $(dir $@)
+	$(FIRRTL) $(patsubst %,-i %,$(filter %.fir,$^)) -o $@ -X verilog
+
+VERILATOR := verilator --cc --exe
+VERILATOR_FLAGS := --top-module $(MODEL) +define+PRINTF_COND=$(MODEL).reset --assert \
+	-Wno-UNSIGNED -Wno-COMBDLY -Wno-MULTIDRIVEN -Wno-WIDTH -Wno-STMTDLY -Wno-SELRANGE -Wno-IMPLICIT
+cppfiles = $(addprefix $(base_dir)/csrc/, $(addsuffix .cc, $(CXXSRCS)))
+
+model_header = $(generated_dir)/$(MODEL).$(CONFIG)/V$(MODEL).h
+model_header_debug = $(generated_dir_debug)/$(MODEL).$(CONFIG)/V$(MODEL).h
+
+$(addsuffix .o,$(CXXSRCS)): %.o: $(base_dir)/csrc/%.cc $(base_dir)/csrc/*.h $(consts_header)
+	$(CXX) $(CXXFLAGS) -DVERILATOR -I$(generated_dir) -c -o $@ $<
+
+$(addsuffix .debug.o,$(CXXSRCS)): %.debug.o: $(base_dir)/csrc/%.cc $(base_dir)/csrc/*.h $(consts_header_debug)
+	$(CXX) $(CXXFLAGS) -DVERILATOR -I$(generated_dir_debug) -c -o $@ $<
+
+$(emu): $(verilog) $(cppfiles) libdramsim.a $(consts_header)
+	mkdir -p $(generated_dir)/$(MODEL).$(CONFIG)
+	$(VERILATOR) $(VERILATOR_FLAGS) -Mdir $(generated_dir)/$(MODEL).$(CONFIG) \
+	-o $(abspath $(sim_dir))/$@ $< $(cppfiles) -LDFLAGS "$(LDFLAGS)" \
+	-CFLAGS "$(CXXFLAGS) -DVERILATOR -I$(generated_dir) -include $(model_header) -include $(consts_header) -include $(scr_header)"
+	$(MAKE) -C $(generated_dir)/$(MODEL).$(CONFIG) -f V$(MODEL).mk
+
+$(emu_debug): $(verilog_debug) $(cppfiles) libdramsim.a $(consts_header_debug) $(generated_dir)/$(MODEL).$(CONFIG).d
+	mkdir -p $(generated_dir_debug)/$(MODEL).$(CONFIG)
+	$(VERILATOR) $(VERILATOR_FLAGS) -Mdir $(generated_dir_debug)/$(MODEL).$(CONFIG)  --trace \
+	-o $(abspath $(sim_dir))/$@ $< $(cppfiles) -LDFLAGS "$(LDFLAGS)" \
+	-CFLAGS "$(CXXFLAGS) -DVERILATOR -I$(generated_dir_debug) -include $(model_header_debug) -include $(consts_header_debug) -include $(scr_header_debug)"
+	$(MAKE) -C $(generated_dir_debug)/$(MODEL).$(CONFIG) -f V$(MODEL).mk

--- a/src/main/scala/TestBench.scala
+++ b/src/main/scala/TestBench.scala
@@ -323,6 +323,7 @@ object TestBenchGeneration extends FileSystemUtilities {
     val nMemChannel = p(NMemoryChannels)
 
     val assigns = (0 until nMemChannel).map { i => s"""
+#ifndef VERILATOR
       mem_ar_valid[$i] = &tile.Top__io_mem_axi_${i}_ar_valid;
       mem_ar_ready[$i] = &tile.Top__io_mem_axi_${i}_ar_ready;
       mem_ar_bits_addr[$i] = &tile.Top__io_mem_axi_${i}_ar_bits_addr;
@@ -354,11 +355,55 @@ object TestBenchGeneration extends FileSystemUtilities {
       mem_r_bits_id[$i] = &tile.Top__io_mem_axi_${i}_r_bits_id;
       mem_r_bits_data[$i] = &tile.Top__io_mem_axi_${i}_r_bits_data;
       mem_r_bits_last[$i] = &tile.Top__io_mem_axi_${i}_r_bits_last;
+#else
+      mem_ar_valid[$i] = &tile.io_mem_axi_${i}_ar_valid;
+      mem_ar_ready[$i] = &tile.io_mem_axi_${i}_ar_ready;
+      mem_ar_bits_addr[$i] = &tile.io_mem_axi_${i}_ar_bits_addr;
+      mem_ar_bits_id[$i] = &tile.io_mem_axi_${i}_ar_bits_id;
+      mem_ar_bits_size[$i] = &tile.io_mem_axi_${i}_ar_bits_size;
+      mem_ar_bits_len[$i] = &tile.io_mem_axi_${i}_ar_bits_len;
 
+      mem_aw_valid[$i] = &tile.io_mem_axi_${i}_aw_valid;
+      mem_aw_ready[$i] = &tile.io_mem_axi_${i}_aw_ready;
+      mem_aw_bits_addr[$i] = &tile.io_mem_axi_${i}_aw_bits_addr;
+      mem_aw_bits_id[$i] = &tile.io_mem_axi_${i}_aw_bits_id;
+      mem_aw_bits_size[$i] = &tile.io_mem_axi_${i}_aw_bits_size;
+      mem_aw_bits_len[$i] = &tile.io_mem_axi_${i}_aw_bits_len;
+
+      mem_w_valid[$i] = &tile.io_mem_axi_${i}_w_valid;
+      mem_w_ready[$i] = &tile.io_mem_axi_${i}_w_ready;
+#if MEM_DATA_BITS > 64
+      mem_w_bits_data[$i] = tile.io_mem_axi_${i}_w_bits_data;
+#else
+      mem_w_bits_data[$i] = &tile.io_mem_axi_${i}_w_bits_data;
+#endif
+      mem_w_bits_strb[$i] = &tile.io_mem_axi_${i}_w_bits_strb;
+      mem_w_bits_last[$i] = &tile.io_mem_axi_${i}_w_bits_last;
+
+      mem_b_valid[$i] = &tile.io_mem_axi_${i}_b_valid;
+      mem_b_ready[$i] = &tile.io_mem_axi_${i}_b_ready;
+      mem_b_bits_resp[$i] = &tile.io_mem_axi_${i}_b_bits_resp;
+      mem_b_bits_id[$i] = &tile.io_mem_axi_${i}_b_bits_id;
+
+      mem_r_valid[$i] = &tile.io_mem_axi_${i}_r_valid;
+      mem_r_ready[$i] = &tile.io_mem_axi_${i}_r_ready;
+      mem_r_bits_resp[$i] = &tile.io_mem_axi_${i}_r_bits_resp;
+      mem_r_bits_id[$i] = &tile.io_mem_axi_${i}_r_bits_id;
+#if MEM_DATA_BITS > 64
+      mem_r_bits_data[$i] = tile.io_mem_axi_${i}_r_bits_data;
+#else
+      mem_r_bits_data[$i] = &tile.io_mem_axi_${i}_r_bits_data;
+#endif
+      mem_r_bits_last[$i] = &tile.io_mem_axi_${i}_r_bits_last;
+#endif
     """ }.mkString
 
     val interrupts = (0 until p(NExtInterrupts)) map { i => s"""
+#ifndef VERILATOR
       tile.Top__io_interrupts_$i = LIT<1>(0);
+#else
+      tile.io_interrupts_$i = 0;
+#endif
 """ } mkString
 
     val f = createOutputFile(s"$topModuleName.$configClassName.tb.cpp")


### PR DESCRIPTION
This works good in general, but mkpipe for vpd doesn't work, so make run-test-*-debug dumps nothing even though verilator correctly dumps waveform to the file. It's not clear what's happening to the dump file in VerilatedVcdC.