### PR TITLE
Default to Chisel 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,17 +32,17 @@ addons:
 
 env:
   matrix:
-    - CONFIG=DefaultConfig
-    - CONFIG=DefaultL2Config
-    - CONFIG=RoccExampleConfig
-    - CONFIG=DualCoreConfig
-    - CONFIG=MemtestConfig
-    - CONFIG=FancyMemtestConfig
-    - CONFIG=BroadcastRegressionTestConfig
-    - CONFIG=CacheRegressionTestConfig
-    - CONFIG=NastiConverterTestConfig
-    - CONFIG=UnitTestConfig
-    - CONFIG=SplitL2MetadataTestConfig
+    - CONFIG=DefaultConfig                  CHISEL_VERSION=3
+    - CONFIG=DefaultL2Config                CHISEL_VERSION=3
+    - CONFIG=RoccExampleConfig              CHISEL_VERSION=3
+    - CONFIG=DualCoreConfig                 CHISEL_VERSION=3
+    - CONFIG=MemtestConfig                  CHISEL_VERSION=3
+    - CONFIG=FancyMemtestConfig             CHISEL_VERSION=3
+    - CONFIG=BroadcastRegressionTestConfig  CHISEL_VERSION=3
+    - CONFIG=CacheRegressionTestConfig      CHISEL_VERSION=3
+    - CONFIG=NastiConverterTestConfig       CHISEL_VERSION=3
+    - CONFIG=UnitTestConfig                 CHISEL_VERSION=3
+    - CONFIG=SplitL2MetadataTestConfig      CHISEL_VERSION=3
 
 # blacklist private branches
 branches:
@@ -55,11 +55,11 @@ before_install:
   - export CXX=g++-4.8 CC=gcc-4.8
 
 script:
-  - make vsim-verilog -C regression CONFIG=$CONFIG TORTURE_CONFIG=default CHISEL_VERSION=3
-  - make fsim-verilog -C regression CONFIG=$CONFIG TORTURE_CONFIG=default
-  - make emulator-ndebug -C regression CONFIG=$CONFIG TORTURE_CONFIG=default
-  - make emulator-asm-tests   -C regression CONFIG=$CONFIG TORTURE_CONFIG=default
-  - make emulator-bmark-tests -C regression CONFIG=$CONFIG TORTURE_CONFIG=default -j1
+  - make vsim-verilog -C regression CONFIG=$CONFIG TORTURE_CONFIG=default CHISEL_VERSION=$CHISEL_VERSION
+  - make fsim-verilog -C regression CONFIG=$CONFIG TORTURE_CONFIG=default CHISEL_VERSION=$CHISEL_VERSION
+  - make emulator-ndebug -C regression CONFIG=$CONFIG TORTURE_CONFIG=default CHISEL_VERSION=$CHISEL_VERSION
+  - make emulator-asm-tests   -C regression CONFIG=$CONFIG TORTURE_CONFIG=default CHISEL_VERSION=$CHISEL_VERSION
+  - make emulator-bmark-tests -C regression CONFIG=$CONFIG TORTURE_CONFIG=default CHISEL_VERSION=$CHISEL_VERSION -j1
 
 before_cache:
   - ls -tr regression/install | tail -n+2 | sed s@^@regression/install/@ | xargs rm -rf

--- a/Makefrag
+++ b/Makefrag
@@ -8,7 +8,7 @@ PROJECT := rocketchip
 CXX ?= g++
 CXXFLAGS := -O1
 
-CHISEL_VERSION ?= 2
+CHISEL_VERSION ?= 3
 export CHISEL_VERSION
 
 SBT ?= java -Xmx2G -Xss8M -XX:MaxPermSize=256M -jar $(base_dir)/sbt-launch.jar

--- a/emulator/.gitignore
+++ b/emulator/.gitignore
@@ -8,3 +8,4 @@ generated-src
 generated-src-debug
 kernel
 kernel.hex
+verilator/

--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -28,7 +28,34 @@ $(generated_dir_debug)/%.$(CONFIG).fir $(generated_dir_debug)/%.$(CONFIG).prm $(
 	mkdir -p $(dir $@)
 	$(FIRRTL) $(patsubst %,-i %,$(filter %.fir,$^)) -o $@ -X verilog
 
-VERILATOR := verilator --cc --exe
+# Build and install our own Verilator, to work around versionining issues.
+VERILATOR_VERSION=3.884
+VERILATOR_SRCDIR=verilator/src/verilator-$(VERILATOR_VERSION)
+INSTALLED_VERILATOR=$(abspath verilator/install/bin/verilator)
+$(INSTALLED_VERILATOR): $(VERILATOR_SRCDIR)/bin/verilator
+	$(MAKE) -C $(VERILATOR_SRCDIR) install
+	touch $@
+
+$(VERILATOR_SRCDIR)/bin/verilator: $(VERILATOR_SRCDIR)/Makefile
+	$(MAKE) -C $(VERILATOR_SRCDIR)
+	touch $@
+
+$(VERILATOR_SRCDIR)/Makefile: $(VERILATOR_SRCDIR)/configure
+	mkdir -p $(dir $@)
+	cd $(dir $@) && ./configure --prefix=$(abspath verilator/install)
+
+$(VERILATOR_SRCDIR)/configure: verilator/verilator-$(VERILATOR_VERSION).tar.gz
+	rm -rf $(dir $@)
+	mkdir -p $(dir $@)
+	cat $^ | tar -xz --strip-components=1 -C $(dir $@)
+	touch $@
+
+verilator/verilator-$(VERILATOR_VERSION).tar.gz:
+	mkdir -p $(dir $@)
+	wget http://www.veripool.org/ftp/verilator-$(VERILATOR_VERSION).tgz -O $@
+
+# Run Verilator to produce a fast binary to emulate this circuit.
+VERILATOR := $(INSTALLED_VERILATOR) --cc --exe
 VERILATOR_FLAGS := --top-module $(MODEL) +define+PRINTF_COND=$(MODEL).reset --assert \
 	-Wno-UNSIGNED -Wno-COMBDLY -Wno-MULTIDRIVEN -Wno-WIDTH -Wno-STMTDLY -Wno-SELRANGE -Wno-IMPLICIT
 cppfiles = $(addprefix $(base_dir)/csrc/, $(addsuffix .cc, $(CXXSRCS)))
@@ -42,14 +69,14 @@ $(addsuffix .o,$(CXXSRCS)): %.o: $(base_dir)/csrc/%.cc $(base_dir)/csrc/*.h $(co
 $(addsuffix .debug.o,$(CXXSRCS)): %.debug.o: $(base_dir)/csrc/%.cc $(base_dir)/csrc/*.h $(consts_header_debug)
 	$(CXX) $(CXXFLAGS) -DVERILATOR -I$(generated_dir_debug) -c -o $@ $<
 
-$(emu): $(verilog) $(cppfiles) libdramsim.a $(consts_header)
+$(emu): $(verilog) $(cppfiles) libdramsim.a $(consts_header) $(INSTALLED_VERILATOR)
 	mkdir -p $(generated_dir)/$(MODEL).$(CONFIG)
 	$(VERILATOR) $(VERILATOR_FLAGS) -Mdir $(generated_dir)/$(MODEL).$(CONFIG) \
 	-o $(abspath $(sim_dir))/$@ $< $(cppfiles) -LDFLAGS "$(LDFLAGS)" \
 	-CFLAGS "$(CXXFLAGS) -DVERILATOR -I$(generated_dir) -include $(model_header) -include $(consts_header) -include $(scr_header)"
 	$(MAKE) -C $(generated_dir)/$(MODEL).$(CONFIG) -f V$(MODEL).mk
 
-$(emu_debug): $(verilog_debug) $(cppfiles) libdramsim.a $(consts_header_debug) $(generated_dir)/$(MODEL).$(CONFIG).d
+$(emu_debug): $(verilog_debug) $(cppfiles) libdramsim.a $(consts_header_debug) $(generated_dir)/$(MODEL).$(CONFIG).d $(INSTALLED_VERILATOR)
 	mkdir -p $(generated_dir_debug)/$(MODEL).$(CONFIG)
 	$(VERILATOR) $(VERILATOR_FLAGS) -Mdir $(generated_dir_debug)/$(MODEL).$(CONFIG)  --trace \
 	-o $(abspath $(sim_dir))/$@ $< $(cppfiles) -LDFLAGS "$(LDFLAGS)" \

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -81,7 +81,7 @@ stamps/other-submodules.stamp:
 $(RISCV)/install.stamp:
 	mkdir -p $(dir $@)
 	git -C $(abspath $(TOP)) submodule update --init riscv-tools
-	rm $(abspath $(TOP))/riscv-tools/.travis.yml
+	rm -f $(abspath $(TOP))/riscv-tools/.travis.yml
 	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-gnu-toolchain
 	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-isa-sim
 	git -C $(abspath $(TOP))/riscv-tools submodule update --init --recursive riscv-fesvr


### PR DESCRIPTION
Thanks to Donggyu (for making Verilator work) and Colin (for making Rocket Chip run under Chisel 3 in all configurations), we can now switch over to Chisel 3.  This PR cleans up a few rough edges:

* The newest Verilator is installed and used, since nobody has it and we need it.
* Travis runs Chisel 2 and Chisel 3 on all configurations
* CHISEL_VERSION=3 is now the default

I don't think we're quite ready to deprecate Chisel 2 yet, so I'm leaving all the Chisel 2 stuff in place.  This means Travis will take twice as long to test everything.