### PR TITLE
Allow aggregate CONFIG on Command Line

### DIFF
--- a/src/main/scala/Testing.scala
+++ b/src/main/scala/Testing.scala
@@ -177,14 +177,26 @@ object TestGenerator extends App {
   val projectName = args(0)
   val topModuleName = args(1)
   val configClassName = args(2)
-  val config = try {
-      Class.forName(s"$projectName.$configClassName").newInstance.asInstanceOf[Config]
+
+  val aggregateConfigs = configClassName.split('_').reverse
+
+  var finalConfig = new Config()
+  var ii = 0;
+  for (ii <- 0 to (aggregateConfigs.length - 1)) {
+    val currentConfigName = aggregateConfigs(ii);
+    val currentConfig = try {
+      Class.forName(s"$projectName.$currentConfigName").newInstance.asInstanceOf[Config]
     } catch {
       case e: java.lang.ClassNotFoundException =>
-        throwException("Unable to find configClassName \"" + configClassName +
-                       "\", did you misspell it?", e)
+        throwException("Unable to find part \"" + currentConfigName +
+          "\" of configClassName \"" + configClassName +
+          "\", did you misspell it?", e)
     }
-  val world = config.toInstance
+    finalConfig = currentConfig ++ finalConfig
+  }
+
+  val world = (new Config(finalConfig)).toInstance
+
   val paramsFromConfig: Parameters = Parameters.root(world)
 
   val gen = () => 

--- a/src/main/scala/Testing.scala
+++ b/src/main/scala/Testing.scala
@@ -178,12 +178,9 @@ object TestGenerator extends App {
   val topModuleName = args(1)
   val configClassName = args(2)
 
-  val aggregateConfigs = configClassName.split('_').reverse
+  val aggregateConfigs = configClassName.split('_')
 
-  var finalConfig = new Config()
-  var ii = 0;
-  for (ii <- 0 to (aggregateConfigs.length - 1)) {
-    val currentConfigName = aggregateConfigs(ii);
+  val finalConfig = aggregateConfigs.foldRight(new Config()) { case (currentConfigName, finalConfig) =>
     val currentConfig = try {
       Class.forName(s"$projectName.$currentConfigName").newInstance.asInstanceOf[Config]
     } catch {
@@ -192,7 +189,7 @@ object TestGenerator extends App {
           "\" of configClassName \"" + configClassName +
           "\", did you misspell it?", e)
     }
-    finalConfig = currentConfig ++ finalConfig
+    currentConfig ++ finalConfig
   }
 
   val world = (new Config(finalConfig)).toInstance


### PR DESCRIPTION
This allows composing Config classes on the command line. Underscores are translated into the ++ operator.

As a fairly extreme example,

make CONFIG=TinyConfig

is equivalent to 

make CONFIG=WithRV32_WithSmallCores_WithStatelessBridge_BaseConfig

This does not support parameterized Config constructors (e.g. WithNCores). 