### PR TITLE
Refactor unit tests, distributing across packages

### DIFF
--- a/groundtest/src/main/scala/CacheFillTest.scala
+++ b/groundtest/src/main/scala/CacheFillTest.scala
@@ -4,7 +4,6 @@ import Chisel._
 import uncore.tilelink._
 import uncore.constants._
 import uncore.agents._
-import groundtest.common._
 import cde.{Parameters, Field}
 
 class CacheFillTest(implicit p: Parameters) extends GroundTest()(p)

--- a/groundtest/src/main/scala/Comparator.scala
+++ b/groundtest/src/main/scala/Comparator.scala
@@ -5,7 +5,6 @@ import uncore.tilelink._
 import uncore.constants._
 import junctions._
 import rocket._
-import groundtest.common._
 import scala.util.Random
 import cde.{Parameters, Field}
 

--- a/groundtest/src/main/scala/Generator.scala
+++ b/groundtest/src/main/scala/Generator.scala
@@ -6,7 +6,6 @@ import uncore.devices.NTiles
 import uncore.constants._
 import junctions._
 import rocket._
-import groundtest.common._
 import scala.util.Random
 import cde.{Parameters, Field}
 

--- a/groundtest/src/main/scala/NastiTest.scala
+++ b/groundtest/src/main/scala/NastiTest.scala
@@ -4,7 +4,6 @@ import Chisel._
 import uncore.tilelink._
 import uncore.converters._
 import junctions._
-import groundtest.common._
 import cde.Parameters
 
 class NastiGenerator(id: Int)(implicit val p: Parameters) extends Module

--- a/groundtest/src/main/scala/Regression.scala
+++ b/groundtest/src/main/scala/Regression.scala
@@ -4,9 +4,8 @@ import Chisel._
 import uncore.tilelink._
 import uncore.constants._
 import uncore.agents._
-import junctions.{ParameterizedBundle, HasAddrMapParameters}
+import junctions.{ParameterizedBundle, HasAddrMapParameters, Timer}
 import rocket.HellaCacheIO
-import groundtest.common._
 import cde.{Parameters, Field}
 
 class RegressionIO(implicit val p: Parameters) extends ParameterizedBundle()(p) {

--- a/groundtest/src/main/scala/Tile.scala
+++ b/groundtest/src/main/scala/Tile.scala
@@ -1,4 +1,4 @@
-package groundtest.common
+package groundtest
 
 import Chisel._
 import rocket._

--- a/groundtest/src/main/scala/TraceGen.scala
+++ b/groundtest/src/main/scala/TraceGen.scala
@@ -22,7 +22,6 @@ import uncore.constants._
 import uncore.devices.NTiles
 import junctions._
 import rocket._
-import groundtest.common._
 import scala.util.Random
 import cde.{Parameters, Field}
 

--- a/groundtest/src/main/scala/Util.scala
+++ b/groundtest/src/main/scala/Util.scala
@@ -1,55 +1,6 @@
-package groundtest.common
+package groundtest
 
 import Chisel._
-
-// ============
-// Static timer
-// ============
-
-// Timer with a statically-specified period.
-// Can take multiple inflight start-stop events with ID
-// Will continue to count down as long as at least one event is inflight
-
-class Timer(initCount: Int, maxInflight: Int) extends Module {
-  val io = new Bundle {
-    val start = Valid(UInt(width = log2Up(maxInflight))).flip
-    val stop = Valid(UInt(width = log2Up(maxInflight))).flip
-    val timeout = Valid(UInt(width = log2Up(maxInflight)))
-  }
-
-  val inflight = Reg(init = Vec.fill(maxInflight) { Bool(false) })
-  val countdown = Reg(UInt(width = log2Up(initCount)))
-  val active = inflight.reduce(_ || _)
-
-  when (active) {
-    countdown := countdown - UInt(1)
-  }
-
-  when (io.start.valid) {
-    inflight(io.start.bits) := Bool(true)
-    countdown := UInt(initCount - 1)
-  }
-  when (io.stop.valid) {
-    inflight(io.stop.bits) := Bool(false)
-  }
-
-  io.timeout.valid := countdown === UInt(0) && active
-  io.timeout.bits := PriorityEncoder(inflight)
-
-  assert(!io.stop.valid || inflight(io.stop.bits),
-         "Timer stop for transaction that's not inflight")
-}
-
-object Timer {
-  def apply(initCount: Int, start: Bool, stop: Bool): Bool = {
-    val timer = Module(new Timer(initCount, 1))
-    timer.io.start.valid := start
-    timer.io.start.bits  := UInt(0)
-    timer.io.stop.valid  := stop
-    timer.io.stop.bits   := UInt(0)
-    timer.io.timeout.valid
-  }
-}
 
 // =============
 // Dynamic timer

--- a/junctions/src/main/scala/unittests/MiscNastiTests.scala
+++ b/junctions/src/main/scala/unittests/MiscNastiTests.scala
@@ -1,9 +1,8 @@
-package groundtest.unittests
+package junctions.unittests
 
 import Chisel._
 import junctions._
 import junctions.NastiConstants._
-import groundtest.common._
 import cde.Parameters
 
 class NastiDriver(dataWidth: Int, burstLen: Int, nBursts: Int)
@@ -76,12 +75,6 @@ class NastiDriver(dataWidth: Int, burstLen: Int, nBursts: Int)
 
   assert(!io.nasti.r.valid || read_data === expected_data,
     s"NastiDriver got wrong data")
-
-  val ar_timeout = Timer(1024, io.nasti.ar.fire(), io.nasti.r.fire())
-  val aw_timeout = Timer(1024, io.nasti.aw.fire(), io.nasti.b.fire())
-
-  assert(!ar_timeout && !aw_timeout,
-    s"NastiDriver for $name timed out")
 }
 
 

--- a/junctions/src/main/scala/unittests/MultiWidthFifoTest.scala
+++ b/junctions/src/main/scala/unittests/MultiWidthFifoTest.scala
@@ -1,4 +1,4 @@
-package groundtest.unittests
+package junctions.unittests
 
 import Chisel._
 import junctions._

--- a/junctions/src/main/scala/unittests/NastiDemuxTest.scala
+++ b/junctions/src/main/scala/unittests/NastiDemuxTest.scala
@@ -1,4 +1,4 @@
-package groundtest.unittests
+package junctions.unittests
 
 import Chisel._
 import junctions._

--- a/junctions/src/main/scala/util.scala
+++ b/junctions/src/main/scala/util.scala
@@ -312,3 +312,54 @@ class MultiWidthFifo(inW: Int, outW: Int, n: Int) extends Module {
     io.in.ready := size < UInt(n * nBeats)
   }
 }
+
+// ============
+// Static timer
+// ============
+
+// Timer with a statically-specified period.
+// Can take multiple inflight start-stop events with ID
+// Will continue to count down as long as at least one event is inflight
+
+class Timer(initCount: Int, maxInflight: Int) extends Module {
+  val io = new Bundle {
+    val start = Valid(UInt(width = log2Up(maxInflight))).flip
+    val stop = Valid(UInt(width = log2Up(maxInflight))).flip
+    val timeout = Valid(UInt(width = log2Up(maxInflight)))
+  }
+
+  val inflight = Reg(init = Vec.fill(maxInflight) { Bool(false) })
+  val countdown = Reg(UInt(width = log2Up(initCount)))
+  val active = inflight.reduce(_ || _)
+
+  when (active) {
+    countdown := countdown - UInt(1)
+  }
+
+  when (io.start.valid) {
+    inflight(io.start.bits) := Bool(true)
+    countdown := UInt(initCount - 1)
+  }
+  when (io.stop.valid) {
+    inflight(io.stop.bits) := Bool(false)
+  }
+
+  io.timeout.valid := countdown === UInt(0) && active
+  io.timeout.bits := PriorityEncoder(inflight)
+
+  assert(!io.stop.valid || inflight(io.stop.bits),
+         "Timer stop for transaction that's not inflight")
+}
+
+object Timer {
+  def apply(initCount: Int, start: Bool, stop: Bool): Bool = {
+    val timer = Module(new Timer(initCount, 1))
+    timer.io.start.valid := start
+    timer.io.start.bits  := UInt(0)
+    timer.io.stop.valid  := stop
+    timer.io.stop.bits   := UInt(0)
+    timer.io.timeout.valid
+  }
+}
+
+

--- a/src/main/scala/DirectGroundTest.scala
+++ b/src/main/scala/DirectGroundTest.scala
@@ -3,7 +3,6 @@ package rocketchip
 import Chisel._
 import cde.{Parameters, Field}
 import groundtest._
-import groundtest.common._
 import uncore.tilelink._
 import uncore.agents._
 

--- a/src/main/scala/Testing.scala
+++ b/src/main/scala/Testing.scala
@@ -177,14 +177,26 @@ object TestGenerator extends App {
   val projectName = args(0)
   val topModuleName = args(1)
   val configClassName = args(2)
-  val config = try {
-      Class.forName(s"$projectName.$configClassName").newInstance.asInstanceOf[Config]
+
+  val aggregateConfigs = configClassName.split('_').reverse
+
+  var finalConfig = new Config()
+  var ii = 0;
+  for (ii <- 0 to (aggregateConfigs.length - 1)) {
+    val currentConfigName = aggregateConfigs(ii);
+    val currentConfig = try {
+      Class.forName(s"$projectName.$currentConfigName").newInstance.asInstanceOf[Config]
     } catch {
       case e: java.lang.ClassNotFoundException =>
-        throwException("Unable to find configClassName \"" + configClassName +
-                       "\", did you misspell it?", e)
+        throwException("Unable to find part \"" + currentConfigName +
+          "\" of configClassName \"" + configClassName +
+          "\", did you misspell it?", e)
     }
-  val world = config.toInstance
+    finalConfig = currentConfig ++ finalConfig
+  }
+
+  val world = (new Config(finalConfig)).toInstance
+
   val paramsFromConfig: Parameters = Parameters.root(world)
 
   val gen = () => 

--- a/src/main/scala/Testing.scala
+++ b/src/main/scala/Testing.scala
@@ -178,12 +178,9 @@ object TestGenerator extends App {
   val topModuleName = args(1)
   val configClassName = args(2)
 
-  val aggregateConfigs = configClassName.split('_').reverse
+  val aggregateConfigs = configClassName.split('_')
 
-  var finalConfig = new Config()
-  var ii = 0;
-  for (ii <- 0 to (aggregateConfigs.length - 1)) {
-    val currentConfigName = aggregateConfigs(ii);
+  val finalConfig = aggregateConfigs.foldRight(new Config()) { case (currentConfigName, finalConfig) =>
     val currentConfig = try {
       Class.forName(s"$projectName.$currentConfigName").newInstance.asInstanceOf[Config]
     } catch {
@@ -192,7 +189,7 @@ object TestGenerator extends App {
           "\" of configClassName \"" + configClassName +
           "\", did you misspell it?", e)
     }
-    finalConfig = currentConfig ++ finalConfig
+    currentConfig ++ finalConfig
   }
 
   val world = (new Config(finalConfig)).toInstance

--- a/src/main/scala/UnitTest.scala
+++ b/src/main/scala/UnitTest.scala
@@ -1,0 +1,16 @@
+package rocketchip
+
+import Chisel._
+import junctions.unittests.UnitTestSuite
+import rocket.Tile
+import cde.Parameters
+
+class UnitTestTile(clockSignal: Clock = null, resetSignal: Bool = null)
+    (implicit p: Parameters) extends Tile(clockSignal, resetSignal)(p) {
+
+  require(io.cached.size == 0)
+  require(io.uncached.size == 0)
+
+  val tests = Module(new UnitTestSuite)
+  when (tests.io.finished) { stop() }
+}

--- a/uncore/src/main/scala/unittests/Drivers.scala
+++ b/uncore/src/main/scala/unittests/Drivers.scala
@@ -1,4 +1,4 @@
-package groundtest.unittests
+package uncore.unittests
 
 import Chisel._
 import junctions._

--- a/uncore/src/main/scala/unittests/Tests.scala
+++ b/uncore/src/main/scala/unittests/Tests.scala
@@ -1,12 +1,11 @@
-package groundtest.unittests
-
+package uncore.unittests
 
 import Chisel._
 import junctions._
+import junctions.unittests._
 import uncore.devices._
 import uncore.tilelink._
 import uncore.converters._
-import groundtest.common._
 import cde.Parameters
 
 class SmiConverterTest(implicit val p: Parameters) extends UnitTest
@@ -75,4 +74,12 @@ class TileLinkRAMTest(implicit val p: Parameters)
   ram.io <> driver.io.mem
   driver.io.start := io.start
   io.finished := driver.io.finished
+}
+
+object UncoreUnitTests {
+  def apply(implicit p: Parameters): Seq[UnitTest] =
+    Seq(
+      Module(new SmiConverterTest),
+      Module(new ROMSlaveTest),
+      Module(new TileLinkRAMTest))
 }


### PR DESCRIPTION
Move the unit tests out of groundtest.unittests to junctions.unittests and uncore.unittests. This puts them in the same packages in which the hardware being tested is defined.

There is now a separate kind of tile for building and running the unit tests.