### PR TITLE
Add asynchronous FIFOs as an option for clock domain crossings.

### DIFF
--- a/junctions/src/main/scala/nasti.scala
+++ b/junctions/src/main/scala/nasti.scala
@@ -708,7 +708,7 @@ class NastiMemoryDemux(nRoutes: Int)(implicit p: Parameters) extends NastiModule
 
 object AsyncNastiTo {
   // source(master) is in our clock domain, output is in the 'to' clock domain
-  def apply[T <: Data](to_clock: Clock, to_reset: Bool, source: NastiIO, depth: Int = 3, sync: Int = 2)(implicit p: Parameters): NastiIO = {
+  def apply[T <: Data](to_clock: Clock, to_reset: Bool, source: NastiIO, depth: Int = 4, sync: Int = 2)(implicit p: Parameters): NastiIO = {
     val sink = Wire(new NastiIO)
 
     sink.aw <> AsyncDecoupledTo(to_clock, to_reset, source.aw, depth, sync)
@@ -723,7 +723,7 @@ object AsyncNastiTo {
 
 object AsyncNastiFrom {
   // source(master) is in the 'from' clock domain, output is in our clock domain
-  def apply[T <: Data](from_clock: Clock, from_reset: Bool, source: NastiIO, depth: Int = 3, sync: Int = 2)(implicit p: Parameters): NastiIO = {
+  def apply[T <: Data](from_clock: Clock, from_reset: Bool, source: NastiIO, depth: Int = 4, sync: Int = 2)(implicit p: Parameters): NastiIO = {
     val sink = Wire(new NastiIO)
 
     sink.aw <> AsyncDecoupledFrom(from_clock, from_reset, source.aw, depth, sync)


### PR DESCRIPTION
This extends AsyncDecoupledTo and AsyncDecoupledFrom to instantiate
async fifos if requested by setting depth > 0.  The modules use
the standard technique of gray-coding the read and write pointers
for synchronization, and are ported from verilog implementations
previously used for this purpose.

Note that only FIFO depths which are powers of 2 are supported.