### PR TITLE
Remove empty Verilog from FIRRTL

### DIFF
--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -21,7 +21,7 @@ $(generated_dir_debug)/%.$(CONFIG).fir $(generated_dir_debug)/%.$(CONFIG).prm $(
 
 %.v: %.fir $(FIRRTL_JAR)
 	mkdir -p $(dir $@)
-	$(FIRRTL) $(patsubst %,-i %,$(filter %.fir,$^)) -o $@ -X verilog
+	$(FIRRTL) $(patsubst %,-i %,$(filter %.fir,$^)) -o $@ -X verilog || (rm -f $@ && exit 1)
 
 # Build and install our own Verilator, to work around versionining issues.
 VERILATOR_VERSION=3.884

--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -23,7 +23,7 @@ $(generated_dir)/%.$(CONFIG).fir $(generated_dir)/%.$(CONFIG).d $(generated_dir)
 
 $(generated_dir)/%.v: $(generated_dir)/%.fir $(FIRRTL_JAR)
 	mkdir -p $(dir $@)
-	$(FIRRTL) -i $< -o $@ -X verilog
+	$(FIRRTL) -i $< -o $@ -X verilog || (rm -f $@ && exit 1)
 
 endif
 


### PR DESCRIPTION
FIRRTL generates empty Verilog files when it fails.  This is a huge
pain, since it proceeds to screw up the build process (make doesn't know
those empty Verilog files are invalid).  This patch removes FIRRTL's
output when FIRRTL fails.