### PR TITLE
Add JTAG DTM and test support in simulation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "firrtl"]
 	path = firrtl
 	url = https://github.com/ucb-bar/firrtl.git
+[submodule "openocd"]
+	path = openocd
+	url = http://github.com/sifive/openocd.git

--- a/csrc/jtag_vpi.c
+++ b/csrc/jtag_vpi.c
@@ -1,0 +1,419 @@
+/*
+ * TCP/IP controlled VPI JTAG Interface.
+ * Based on Julius Baxter's work on jp_vpi.c
+ *
+ * Copyright (C) 2012 Franck Jullien, <franck.jullien@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation  and/or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of any
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+#include <vpi_user.h>
+
+#define RSP_SERVER_PORT	5555
+#define	XFERT_MAX_SIZE	512
+
+const char * cmd_to_string[] = {"CMD_RESET",
+				"CMD_TMS_SEQ",
+				"CMD_SCAN_CHAIN"};
+
+struct vpi_cmd {
+	int cmd;
+	unsigned char buffer_out[XFERT_MAX_SIZE];
+	unsigned char buffer_in[XFERT_MAX_SIZE];
+	int length;
+	int nb_bits;
+};
+
+int listenfd = 0;
+int connfd = 0;
+
+int init_jtag_server(int port)
+{
+	struct sockaddr_in serv_addr;
+	int flags;
+
+	printf("Listening on port %d\n", port);
+
+	listenfd = socket(AF_INET, SOCK_STREAM, 0);
+	memset(&serv_addr, '0', sizeof(serv_addr));
+
+	serv_addr.sin_family = AF_INET;
+	serv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+	serv_addr.sin_port = htons(port);
+
+	bind(listenfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+
+	listen(listenfd, 10);
+
+	printf("Waiting for client connection...");
+	connfd = accept(listenfd, (struct sockaddr*)NULL, NULL);
+	printf("ok\n");
+
+	flags = fcntl(listenfd, F_GETFL, 0);
+	fcntl(listenfd, F_SETFL, flags | O_NONBLOCK);
+
+	return 0;
+}
+
+// See if there's anything on the FIFO for us
+
+void check_for_command(char *userdata)
+{
+	vpiHandle systfref, args_iter, argh;
+	struct t_vpi_value argval;
+	struct vpi_cmd vpi;
+	int nb;
+	int loaded_words = 0;
+
+	(void)userdata;
+
+	// Get the command from TCP server
+	if(!connfd)
+	  init_jtag_server(RSP_SERVER_PORT);
+	nb = read(connfd, &vpi, sizeof(struct vpi_cmd));
+
+	if (((nb < 0) && (errno == EAGAIN)) || (nb == 0)) {
+		// Nothing in the fifo this time, let's return
+		return;
+	} else {
+		if (nb < 0) {
+			// some sort of error
+			perror("check_for_command");
+			exit(1);
+		}
+	}
+
+/************* vpi.cmd to VPI ******************************/
+
+	// Obtain a handle to the argument list
+	systfref = vpi_handle(vpiSysTfCall, NULL);
+	// Now call iterate with the vpiArgument parameter
+	args_iter = vpi_iterate(vpiArgument, systfref);
+	// get a handle on the variable passed to the function
+	argh = vpi_scan(args_iter);
+	// now store the command value back in the sim
+	argval.format = vpiIntVal;
+	// Now set the command value
+	vpi_get_value(argh, &argval);
+
+	argval.value.integer = (uint32_t)vpi.cmd;
+
+	// And vpi_put_value() it back into the sim
+	vpi_put_value(argh, &argval, NULL, vpiNoDelay);
+
+/************* vpi.length to VPI ******************************/
+
+	// now get a handle on the next object (memory array)
+	argh = vpi_scan(args_iter);
+	// now store the command value back in the sim
+	argval.format = vpiIntVal;
+	// Now set the command value
+	vpi_get_value(argh, &argval);
+
+	argval.value.integer = (uint32_t)vpi.length;
+
+	// And vpi_put_value() it back into the sim
+	vpi_put_value(argh, &argval, NULL, vpiNoDelay);
+
+/************* vpi.nb_bits to VPI ******************************/
+
+	// now get a handle on the next object (memory array)
+	argh = vpi_scan(args_iter);
+	// now store the command value back in the sim
+	argval.format = vpiIntVal;
+	// Now set the command value
+	vpi_get_value(argh, &argval);
+
+	argval.value.integer = (uint32_t)vpi.nb_bits;
+
+	// And vpi_put_value() it back into the sim
+	vpi_put_value(argh, &argval, NULL, vpiNoDelay);
+
+/*****************vpi.buffer_out to VPI ********/
+
+	// now get a handle on the next object (memory array)
+	argh = vpi_scan(args_iter);
+	vpiHandle array_word;
+
+	// Loop to load the words
+	while (loaded_words < vpi.length) {
+		// now get a handle on the current word we want in the array that was passed to us
+		array_word = vpi_handle_by_index(argh, loaded_words);
+
+		if (array_word != NULL) {
+			argval.value.integer = (uint32_t)vpi.buffer_out[loaded_words];
+			// And vpi_put_value() it back into the sim
+			vpi_put_value(array_word, &argval, NULL, vpiNoDelay);
+		} else
+			return;
+
+		loaded_words++;
+	}
+
+/*******************************************/
+
+	// Cleanup and return
+	vpi_free_object(args_iter);
+}
+
+void send_result_to_server(char *userdata)
+{
+	vpiHandle systfref, args_iter, argh;
+	struct t_vpi_value argval;
+	ssize_t n;
+	struct vpi_cmd vpi;
+
+	int32_t length;
+	int sent_words;
+
+	vpiHandle array_word;
+
+	(void)userdata;
+
+	// Now setup the handles to verilog objects and check things
+	// Obtain a handle to the argument list
+	systfref = vpi_handle(vpiSysTfCall, NULL);
+
+	// Now call iterate with the vpiArgument parameter
+	args_iter = vpi_iterate(vpiArgument, systfref);
+
+	// get a handle on the length variable
+	argh = vpi_scan(args_iter);
+
+	argval.format = vpiIntVal;
+
+	// get the value for the length object
+	vpi_get_value(argh, &argval);
+
+	// now set length
+	length = argval.value.integer;
+
+	// now get a handle on the next object (memory array)
+	argh = vpi_scan(args_iter);
+
+	// check we got passed a memory (array of regs)
+	if (!((vpi_get(vpiType, argh) == vpiMemory)
+#ifdef MODELSIM_VPI
+	|| (vpi_get(vpiType, argh) == vpiRegArray)
+#endif
+#ifdef VCS_VPI
+        || (vpi_get(vpiType, argh) == vpiRegArray)
+#endif
+	)) {
+		vpi_printf("jtag_vpi: ERROR: did not pass a memory to get_command_block_data\n");
+		vpi_printf("jtag_vpi: ERROR: was passed type %d\n", (int)vpi_get(vpiType, argh));
+		return;
+	}
+
+	// check the memory we're writing into is big enough
+	if (vpi_get(vpiSize, argh) < length ) {
+		vpi_printf("jtag_vpi: ERROR: buffer passed to get_command_block_data too small. size is %d words, needs to be %d\n",
+		vpi_get(vpiSize, argh), length);
+		return;
+	}
+
+	// Loop to load the words
+	sent_words = 0;
+	while (sent_words < length) {
+		// Get a handle on the current word we want in the array that was passed to us
+		array_word = vpi_handle_by_index(argh, sent_words);
+
+		if (array_word != NULL) {
+			vpi_get_value(array_word, &argval);
+			vpi.buffer_in[sent_words] = (uint32_t) argval.value.integer;
+		} else
+			return;
+
+		sent_words++;
+	}
+
+	n = write(connfd, &vpi, sizeof(struct vpi_cmd));
+	if (n < (ssize_t)sizeof(struct vpi_cmd))
+		vpi_printf("jtag_vpi: ERROR: error during write to server\n");
+
+	// Cleanup and return
+	vpi_free_object(args_iter);
+}
+
+void register_check_for_command(void)
+{
+	s_vpi_systf_data data = {
+		vpiSysTask,
+		0,
+		"$check_for_command",
+		(void *)check_for_command,
+		0,
+		0,
+		0
+	};
+
+	vpi_register_systf(&data);
+}
+
+void register_send_result_to_server(void)
+{
+	s_vpi_systf_data data = {
+		vpiSysTask,
+		0,
+		"$send_result_to_server",
+		(void *)send_result_to_server,
+		0,
+		0,
+		0
+	};
+
+	vpi_register_systf(&data);
+}
+
+void sim_reset_callback(void)
+{
+  // nothing to do!
+}
+
+void setup_reset_callbacks(void)
+{
+	// here we setup and install callbacks for
+	// the setup and management of connections to
+	// the simulator upon simulation start and
+	// reset
+
+	static s_vpi_time time_s = {vpiScaledRealTime, 0, 0, 0};
+	static s_vpi_value value_s = {.format = vpiBinStrVal};
+
+	static s_cb_data cb_data_s = {
+		cbEndOfReset, // or start of simulation - initing socket fds etc
+		(void *)sim_reset_callback,
+		NULL,
+		&time_s,
+		&value_s,
+		0,
+		NULL
+	};
+
+	cb_data_s.obj = NULL;  /* trigger object */
+
+	cb_data_s.user_data = NULL;
+
+	// actual call to register the callback
+	vpi_register_cb(&cb_data_s);
+}
+
+void sim_endofcompile_callback(void)
+{
+
+}
+
+void setup_endofcompile_callbacks(void)
+{
+	// here we setup and install callbacks for
+	// simulation finish
+
+	static s_vpi_time time_s = {vpiScaledRealTime, 0, 0, 0};
+	static s_vpi_value value_s = {.format = vpiBinStrVal};
+
+	static s_cb_data cb_data_s = {
+		cbEndOfCompile, // end of compile
+		(void *)sim_endofcompile_callback,
+		NULL,
+		&time_s,
+		&value_s,
+		0,
+		NULL
+	};
+
+	cb_data_s.obj = NULL;  /* trigger object */
+
+	cb_data_s.user_data = NULL;
+
+	// actual call to register the callback
+	vpi_register_cb(&cb_data_s);
+}
+
+void sim_finish_callback(void)
+{
+	if(connfd)
+		printf("Closing RSP server\n");
+	close(connfd);
+	close(listenfd);
+}
+
+void setup_finish_callbacks(void)
+{
+	// here we setup and install callbacks for
+	// simulation finish
+
+	static s_vpi_time time_s = {vpiScaledRealTime, 0, 0, 0};
+	static s_vpi_value value_s = {.format = vpiBinStrVal};
+
+	static s_cb_data cb_data_s = {
+		cbEndOfSimulation, // end of simulation
+		(void *)sim_finish_callback,
+		NULL,
+		&time_s,
+		&value_s,
+		0,
+		NULL
+	};
+
+	cb_data_s.obj = NULL;  /* trigger object */
+	cb_data_s.user_data = NULL;
+
+	// actual call to register the callback
+	vpi_register_cb(&cb_data_s);
+}
+
+#ifndef VCS_VPI
+// Register the new system task here
+void (*vlog_startup_routines[])(void) = {
+#ifdef CDS_VPI
+	// this installs a callback on simulator reset - something which
+	// icarus does not do, so we only do it for cadence currently
+	setup_reset_callbacks,
+#endif
+	setup_endofcompile_callbacks,
+	setup_finish_callbacks,
+	register_check_for_command,
+	register_send_result_to_server,
+	0  // last entry must be 0
+};
+
+// Entry point for testing development of the vpi functions
+int main(int argc, char *argv[])
+{
+	(void)argc;
+	(void)argv;
+
+	return 0;
+}
+#endif

--- a/csrc/vcs_main.rocketDTMTestHarness.cc
+++ b/csrc/vcs_main.rocketDTMTestHarness.cc
@@ -1,0 +1,164 @@
+// See LICENSE for license details.
+
+#include "mm.h"
+#include "mm_dramsim2.h"
+#include <assert.h>
+#include <DirectC.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include <sstream>
+#include <iterator>
+
+extern "C" {
+
+extern int vcs_main(int argc, char** argv);
+
+static mm_t* mm[N_MEM_CHANNELS];
+static const char* loadmem;
+static bool dramsim = false;
+static int memory_channel_mux_select = 0;
+
+int main(int argc, char** argv)
+{
+  for (int i = 1; i < argc; i++)
+  {
+    if (!strcmp(argv[i], "+dramsim"))
+      dramsim = true;
+    else if (!strncmp(argv[i], "+loadmem=", 9))
+      loadmem = argv[i]+9;
+    else if (!strncmp(argv[i], "+memory_channel_mux_select=", 27))
+      memory_channel_mux_select = atoi(argv[i]+27);
+  }
+
+  for (int i=0; i<N_MEM_CHANNELS; i++) {
+    mm[i] = dramsim ? (mm_t*)(new mm_dramsim2_t) : (mm_t*)(new mm_magic_t);
+    mm[i]->init(MEM_SIZE / N_MEM_CHANNELS, MEM_DATA_BITS / 8, CACHE_BLOCK_BYTES);
+  }
+
+  if (loadmem) {
+    void *mems[N_MEM_CHANNELS];
+    for (int i = 0; i < N_MEM_CHANNELS; i++)
+      mems[i] = mm[i]->get_data();
+    load_mem(mems, loadmem, CACHE_BLOCK_BYTES, N_MEM_CHANNELS);
+  }
+
+  vcs_main(argc, argv);
+  abort(); // should never get here
+}
+
+void memory_tick(
+  vc_handle channel,
+
+  vc_handle ar_valid,
+  vc_handle ar_ready,
+  vc_handle ar_addr,
+  vc_handle ar_id,
+  vc_handle ar_size,
+  vc_handle ar_len,
+
+  vc_handle aw_valid,
+  vc_handle aw_ready,
+  vc_handle aw_addr,
+  vc_handle aw_id,
+  vc_handle aw_size,
+  vc_handle aw_len,
+
+  vc_handle w_valid,
+  vc_handle w_ready,
+  vc_handle w_strb,
+  vc_handle w_data,
+  vc_handle w_last,
+
+  vc_handle r_valid,
+  vc_handle r_ready,
+  vc_handle r_resp,
+  vc_handle r_id,
+  vc_handle r_data,
+  vc_handle r_last,
+
+  vc_handle b_valid,
+  vc_handle b_ready,
+  vc_handle b_resp,
+  vc_handle b_id)
+{
+  int c = vc_4stVectorRef(channel)->d;
+  assert(c < N_MEM_CHANNELS);
+  mm_t* mmc = mm[c];
+
+  uint32_t write_data[mmc->get_word_size()/sizeof(uint32_t)];
+  for (size_t i = 0; i < mmc->get_word_size()/sizeof(uint32_t); i++)
+    write_data[i] = vc_4stVectorRef(w_data)[i].d;
+
+  uint32_t aw_id_val, ar_id_val;
+
+  if (MEM_ID_BITS == 1) {
+    aw_id_val = vc_getScalar(aw_id);
+    ar_id_val = vc_getScalar(ar_id);
+  } else {
+    aw_id_val = vc_4stVectorRef(aw_id)->d;
+    ar_id_val = vc_4stVectorRef(ar_id)->d;
+  }
+
+  mmc->tick
+  (
+    vc_getScalar(ar_valid),
+    vc_4stVectorRef(ar_addr)->d - MEM_BASE,
+    ar_id_val,
+    vc_4stVectorRef(ar_size)->d,
+    vc_4stVectorRef(ar_len)->d,
+
+    vc_getScalar(aw_valid),
+    vc_4stVectorRef(aw_addr)->d - MEM_BASE,
+    aw_id_val,
+    vc_4stVectorRef(aw_size)->d,
+    vc_4stVectorRef(aw_len)->d,
+
+    vc_getScalar(w_valid),
+    vc_4stVectorRef(w_strb)->d,
+    write_data,
+    vc_getScalar(w_last),
+
+    vc_getScalar(r_ready),
+    vc_getScalar(b_ready)
+  );
+
+  vc_putScalar(ar_ready, mmc->ar_ready());
+  vc_putScalar(aw_ready, mmc->aw_ready());
+  vc_putScalar(w_ready, mmc->w_ready());
+  vc_putScalar(b_valid, mmc->b_valid());
+  vc_putScalar(r_valid, mmc->r_valid());
+  vc_putScalar(r_last, mmc->r_last());
+
+  vec32 d[mmc->get_word_size()/sizeof(uint32_t)];
+
+  d[0].c = 0;
+  d[0].d = mmc->b_resp();
+  vc_put4stVector(b_resp, d);
+
+  d[0].c = 0;
+  d[0].d = mmc->r_resp();
+  vc_put4stVector(r_resp, d);
+
+  if (MEM_ID_BITS > 1) {
+    d[0].c = 0;
+    d[0].d = mmc->b_id();
+    vc_put4stVector(b_id, d);
+
+    d[0].c = 0;
+    d[0].d = mmc->r_id();
+    vc_put4stVector(r_id, d);
+  } else {
+    vc_putScalar(b_id, mmc->b_id());
+    vc_putScalar(r_id, mmc->r_id());
+  }
+
+  for (size_t i = 0; i < mmc->get_word_size()/sizeof(uint32_t); i++)
+  {
+    d[i].c = 0;
+    d[i].d = ((uint32_t*)mmc->r_data())[i];
+  }
+  vc_put4stVector(r_data, d);
+}
+
+}

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -628,4 +628,11 @@ class WithTestRAM extends Config(
       }
       Seq(new TestRAMDevice)
     }
-  })
+  }
+)
+
+class WithAsyncDebugBus extends Config (
+  (pname, site, here) => pname match {
+     case AsyncDebugBus => true
+  }
+)

--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -16,6 +16,14 @@ sim_csrcs = \
 	$(base_dir)/csrc/mm.cc \
 	$(base_dir)/csrc/mm_dramsim2.cc \
 
+ifeq ($(TB), rocketDTMTestHarness)
+	sim_csrcs += $(base_dir)/csrc/jtag_vpi.c
+	sim_vsrcs += $(base_dir)/vsrc/jtag_vpi.v
+	sim_vsrcs += $(base_dir)/vsrc/AsyncFifo.v
+	sim_vsrcs += $(base_dir)/vsrc/DebugTransportModuleJtag.v
+endif
+
+
 #--------------------------------------------------------------------
 # Build Verilog
 #--------------------------------------------------------------------
@@ -30,6 +38,8 @@ verilog: $(sim_vsrcs)
 
 VCS = vcs -full64
 
+
+             
 VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1ns/10ps -quiet \
 	+rad +v2k +vcs+lic+wait \
 	+vc+list -CC "-I$(VCS_HOME)/include" \
@@ -48,18 +58,28 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	+define+RANDOMIZE \
 	+libext+.v \
 
+ifeq ($(TB), rocketDTMTestHarness)
+        VCS_OPTS += +vpi
+	VCS_OPTS += -P $(base_dir)/vsrc/jtag_vpi.tab
+        VCS_OPTS += -CC "-DVCS_VPI"
+endif
+
 #--------------------------------------------------------------------
 # Build the simulator
 #--------------------------------------------------------------------
 
-simv = $(sim_dir)/simv-$(MODEL)-$(CONFIG)
+ifeq ($(TB), rocketDTMTestHarness)
+	TB_ = DTM-
+endif
+
+simv = $(sim_dir)/simv-$(TB_)$(MODEL)-$(CONFIG)
 $(simv) : $(sim_vsrcs) $(sim_csrcs) $(sim_dir)/libdramsim.a $(consts_header)
 	cd $(sim_dir) && \
 	rm -rf csrc && \
 	$(VCS) $(VCS_OPTS) -o $(simv) \
 	-debug_pp \
 
-simv_debug = $(sim_dir)/simv-$(MODEL)-$(CONFIG)-debug
+simv_debug = $(sim_dir)/simv-$(TB_)$(MODEL)-$(CONFIG)-debug
 $(simv_debug) : $(sim_vsrcs) $(sim_csrcs) $(sim_dir)/libdramsim.a $(consts_header)
 	cd $(sim_dir) && \
 	rm -rf csrc && \

--- a/vsrc/AsyncFifo.v
+++ b/vsrc/AsyncFifo.v
@@ -1,0 +1,255 @@
+
+
+module AsyncFifo (
+                  // Write Interface
+
+                   clk_w
+                  , reset_w
+                  , ready_w
+                  , valid_w
+                  , data_w
+
+                  // Read Interface
+                  , clk_r
+                  , reset_r
+                  , ready_r
+                  , valid_r
+                  , data_r
+                  
+                  );
+
+   
+   //--------------------------------------------------------
+   // Parameter Declarations
+   
+   parameter DEPTH_LG_2 = 0; // default is 'mailbox'.
+   parameter WIDTH  = 32;
+
+   localparam DEPTH = 2**DEPTH_LG_2;
+                             
+   //--------------------------------------------------------
+   // I/O Declarations
+
+   // Write Interface
+   input clk_w;
+   input reset_w;
+
+   output ready_w;
+   input  valid_w;
+
+   input [WIDTH - 1 : 0 ] data_w;
+
+   
+   
+   input               clk_r;
+   input               reset_r;
+   output              valid_r;
+   input               ready_r;
+
+   output [WIDTH - 1 : 0] data_r;
+   
+   
+   //--------------------------------------------------------
+   // FIFO Memory Declaration
+
+   generate 
+      if  (DEPTH > 1) begin : mem1_scope
+         reg [WIDTH - 1 : 0] fifoMem [ 0 : DEPTH - 1];
+      end else begin : mem2_scope
+         reg [WIDTH - 1 :0] fifoMem;
+      end
+   endgenerate
+      
+   //--------------------------------------------------------
+   // Reg and Wire Declarations 
+
+   wire                     full_w;
+   wire                     fire_w;
+   
+   wire                     empty_r;
+   wire                     fire_r;
+   
+   
+   // Read & Write Address Pointers
+   generate 
+      if  (DEPTH_LG_2 > 0) begin : reg1_scope
+         reg [DEPTH_LG_2 : 0 ] wrAddrReg_w;
+         wire [DEPTH_LG_2 : 0] wrAddrNxt_w;
+         reg [DEPTH_LG_2 : 0 ] wrAddrGrayReg_w;
+         wire [DEPTH_LG_2 : 0] wrAddrGrayNxt_w;
+         
+         reg [DEPTH_LG_2 : 0 ] rdAddrReg_r;
+         wire [DEPTH_LG_2 : 0] rdAddrNxt_r;
+         reg [DEPTH_LG_2 : 0 ] rdAddrGrayReg_r;
+         wire [DEPTH_LG_2 : 0] rdAddrGrayNxt_r;
+
+         reg [DEPTH_LG_2 : 0 ] wrAddrGrayReg_sync;
+         reg [DEPTH_LG_2 : 0 ] rdAddrGrayReg_sync;
+         
+         reg [DEPTH_LG_2 : 0 ] wrAddrGrayReg_r;
+         reg [DEPTH_LG_2 : 0 ] rdAddrGrayReg_w;         
+      end else begin : reg2_scope
+         
+         reg wrAddrReg_w;
+         wire wrAddrNxt_w;
+         reg  rdAddrReg_r;
+         wire rdAddrNxt_r;
+         
+         
+         reg wrAddrReg_sync;
+         reg rdAddrReg_sync;
+             
+         reg wrAddrReg_r;
+         reg rdAddrReg_w;
+      end
+   endgenerate
+
+  //--------------------------------------------------------
+   // Reg and Wire Declarations 
+
+   
+   // Pointer Logic
+   generate 
+      if  (DEPTH_LG_2 > 0) begin : ptr_logic_scope
+         assign full_w  = ~(reg1_scope.wrAddrGrayReg_w[DEPTH_LG_2]         == reg1_scope.rdAddrGrayReg_w[DEPTH_LG_2]) &
+                           (reg1_scope.wrAddrGrayReg_w[DEPTH_LG_2 - 1 : 0] == reg1_scope.rdAddrGrayReg_w[DEPTH_LG_2 - 1 : 0 ]);
+         
+         assign reg1_scope.wrAddrNxt_w      = reg1_scope.wrAddrReg_w + 1'b1; // OK / expected to overflow
+         assign reg1_scope.wrAddrGrayNext_w = reg1_scope.wrAddrNxt_w ^ (reg1_scope.wrAddrNxt_w >> 1);
+
+         assign reg1_scope.rdAddrNxt_r      = reg1_scope.rdAddrReg_r + 1'b1; // OK / expected to overflow
+         assign reg1_scope.rdAddrGrayNext_r = reg1_scope.rdAddrNxt_r ^ (reg1_scope.rdAddrNxt_r >> 1);
+         
+         assign empty_r = (reg1_scope.wrAddrGrayReg_r == reg1_scope.rdAddrGrayReg_r);
+         
+      end else begin : ptr_logic_scope
+         assign full_w = ~(reg2_scope.wrAddrReg_w == reg2_scope.rdAddrReg_r);
+         
+         assign reg2_scope.wrAddrNxt_w     = ~reg2_scope.wrAddrReg_w ;
+         
+         assign reg2_scope.rdAddrNxt_r     = ~reg2_scope.rdAddrReg_r;
+         
+         assign empty_r = (reg2_scope.wrAddrReg_r == reg2_scope.rdAddrReg_r);
+
+      end
+   endgenerate  
+
+   assign ready_w = ~full_w;
+   assign fire_w  = ready_w & valid_w;
+   
+   // Read Logic
+   assign valid_r = ~empty_r;
+   assign fire_r = ready_r & valid_r;
+ 
+   generate 
+      if  (DEPTH > 1) begin : rw_scope1
+         if (DEPTH > 2) begin : rw_scope2
+  
+            assign data_r = mem1_scope.fifoMem[reg1_scope.rdAddrReg_r[DEPTH_LG_2-1:0]];
+
+            always @(posedge clk_w) begin
+               if (fire_w) begin
+                  mem1_scope.fifoMem[reg1_scope.wrAddrReg_w[DEPTH_LG_2-1:0]] <= data_w;
+               end
+            end
+           
+         end else begin
+
+            assign data_r = mem1_scope.fifoMem[reg1_scope.rdAddrReg_r[0]];
+
+            always @(posedge clk_w) begin
+               if (fire_w) begin
+                  mem1_scope.fifoMem[reg1_scope.wrAddrReg_w[0]] <= data_w;
+               end
+            end
+            
+         end
+      end else begin
+
+         assign data_r = mem2_scope.fifoMem;
+
+         always @(posedge clk_w) begin
+            if (fire_w) begin
+               mem2_scope.fifoMem <= data_w;
+            end
+         end
+         
+      end
+   endgenerate
+   
+   //--------------------------------------------------------
+   // Sequential logic
+   //  
+   generate 
+   if  (DEPTH_LG_2 > 0) begin : seq1_scope
+   always @(posedge clk_w or posedge reset_w) begin
+      if (reset_w) begin
+         reg1_scope.wrAddrReg_w     <= 'b0;
+         reg1_scope.wrAddrGrayReg_w <= 'b0;
+         
+         reg1_scope.rdAddrGrayReg_sync <= 'b0;
+         reg1_scope.rdAddrGrayReg_w    <= 'b0;
+      end else begin
+         if (fire_w) begin
+           reg1_scope.wrAddrReg_w     <= reg1_scope.wrAddrNxt_w;
+           reg1_scope.wrAddrGrayReg_w <= reg1_scope.wrAddrGrayNxt_w;  
+         end
+         reg1_scope.rdAddrGrayReg_sync <= reg1_scope.rdAddrGrayReg_r;
+         reg1_scope.rdAddrGrayReg_w    <= reg1_scope.rdAddrGrayReg_sync;
+      end
+   end
+         
+   always @(posedge clk_r or posedge reset_r) begin
+      if (reset_r) begin
+         reg1_scope.rdAddrReg_r     <= 'b0;
+         reg1_scope.rdAddrGrayReg_r <= 'b0;
+
+         reg1_scope.reg1_scope.wrAddrGrayReg_sync  <= 'b0;
+         reg1_scope.reg1_scope.wrAddrGrayReg_r     <= 'b0;
+      end else begin
+         if (fire_r) begin
+            reg1_scope.rdAddrReg_r     <= reg1_scope.rdAddrNxt_r;
+            reg1_scope.rdAddrGrayReg_r <= reg1_scope.rdAddrGrayNxt_r;
+         end
+         reg1_scope.wrAddrGrayReg_sync <= reg1_scope.wrAddrGrayReg_w;
+         reg1_scope.wrAddrGrayReg_r    <= reg1_scope.wrAddrGrayReg_sync;
+      end
+   end // always @ (posedge clk_r)
+      
+   end else begin : seq2_scope // block: seq1_scope
+        always @(posedge clk_w or posedge reset_w) begin
+      if (reset_w ) begin
+         reg2_scope.wrAddrReg_w     <= 1'b0;
+          
+         reg2_scope.rdAddrReg_sync <= 1'b0;
+         reg2_scope.rdAddrReg_w    <= 1'b0;
+      end else begin
+         if (fire_w) begin
+           reg2_scope.wrAddrReg_w     <= reg2_scope.wrAddrNxt_w;
+         end
+         reg2_scope.rdAddrReg_sync <= reg2_scope.rdAddrReg_r;
+         reg2_scope.rdAddrReg_w    <= reg2_scope.rdAddrReg_sync;
+      end
+   end
+         
+   always @(posedge clk_r or posedge reset_r) begin
+      if (reset_r) begin
+         reg2_scope.rdAddrReg_r     <= 1'b0;
+
+         reg2_scope.wrAddrReg_sync  <= 1'b0;
+         reg2_scope.wrAddrReg_r     <= 1'b0;
+      end else begin
+         if (fire_r) begin
+            reg2_scope.rdAddrReg_r <= reg2_scope.rdAddrNxt_r;
+         end
+         reg2_scope.wrAddrReg_sync <= reg2_scope.wrAddrReg_w;
+         reg2_scope.wrAddrReg_r    <= reg2_scope.wrAddrReg_sync;
+      end
+   end // always @ (posedge clk_r)
+   end // block: seq2_scope
+      
+endgenerate
+   
+
+      
+endmodule // AsyncFifo

--- a/vsrc/DebugTransportModuleJtag.v
+++ b/vsrc/DebugTransportModuleJtag.v
@@ -1,0 +1,300 @@
+
+
+module DebugTransportModuleJtag (
+                   
+                                 //JTAG Interface
+                                 
+                                 TDI,
+                                 TDO,
+                                 TCK,
+                                 TMS,
+                                 TRST,
+                                 
+                                 DRV_TDO,
+
+                                 dtm_req_valid,
+                                 dtm_req_ready,
+                                 dtm_req_data,
+
+                                 dtm_resp_valid,
+                                 dtm_resp_ready,
+                                 dtm_resp_data
+                                                                  
+                                 );
+   //--------------------------------------------------------
+   // Parameter Declarations
+   
+   parameter DEBUG_DATA_BITS  = 34;
+   parameter DEBUG_ADDR_BITS = 5; // Spec allows values are 5-7 
+   parameter DEBUG_OP_BITS = 2; // OP and RESP are the same size.
+      
+   parameter JTAG_VERSION  = 4'h1;
+   parameter JTAG_PART_NUM = 16'h0E31; // E31
+   parameter JTAG_MANUF_ID = 11'h489;  // As Assigned by JEDEC
+   
+   localparam IR_BITS = 5;
+
+   localparam DEBUG_VERSION = 0;
+
+   // JTAG State Machine
+   localparam TEST_LOGIC_RESET  = 4'h0;
+   localparam RUN_TEST_IDLE     = 4'h1;
+   localparam SELECT_DR         = 4'h2;
+   localparam CAPTURE_DR        = 4'h3;
+   localparam SHIFT_DR          = 4'h4;
+   localparam EXIT1_DR          = 4'h5;
+   localparam PAUSE_DR          = 4'h6;
+   localparam EXIT2_DR          = 4'h7;
+   localparam UPDATE_DR         = 4'h8;
+   localparam SELECT_IR         = 4'h9;
+   localparam CAPTURE_IR        = 4'hA;
+   localparam SHIFT_IR          = 4'hB;
+   localparam EXIT1_IR          = 4'hC;
+   localparam PAUSE_IR          = 4'hD;
+   localparam EXIT2_IR          = 4'hE;
+   localparam UPDATE_IR         = 4'hF;
+
+   //RISCV DTM Registers (see RISC-V Debug Specification)
+   // All others are treated as 'BYPASS'.
+   localparam REG_BYPASS       = 5'b11111;
+   localparam REG_IDCODE       = 5'b00001;
+   localparam REG_DEBUG_ACCESS = 5'b10001;
+   localparam REG_DTM_INFO     = 5'b10000;
+
+   localparam DBUS_REG_BITS = DEBUG_OP_BITS + DEBUG_ADDR_BITS + DEBUG_DATA_BITS;
+   localparam DBUS_REQ_BITS = DEBUG_OP_BITS + DEBUG_ADDR_BITS + DEBUG_DATA_BITS;
+   localparam DBUS_RESP_BITS = DEBUG_OP_BITS + DEBUG_DATA_BITS;
+   
+      
+   localparam SHIFT_REG_BITS = DBUS_REG_BITS;
+
+   //--------------------------------------------------------
+   // I/O Declarations
+   
+   //JTAG SIDE
+   input                                TDI;
+   output reg                           TDO;
+   input                                TCK;
+   input                                TMS;
+   input                                TRST;
+
+   // To allow tri-state outside of this block.
+   output reg                           DRV_TDO;
+
+   // RISC-V Core Side
+   
+   output                               dtm_req_valid;
+   input                                dtm_req_ready;
+   output [DBUS_REQ_BITS - 1 :0]        dtm_req_data;
+   
+   input                                dtm_resp_valid;
+   output                               dtm_resp_ready;
+   input [DBUS_RESP_BITS - 1 : 0]        dtm_resp_data;
+   
+   //--------------------------------------------------------
+   // Reg and Wire Declarations 
+   
+   reg [IR_BITS -1 : 0 ]                irReg;
+   
+   wire [31:0]                          idcode;
+   wire [31:0]                          dtminfo;
+   reg [DBUS_REG_BITS - 1 : 0]          dbusReg;
+   reg                                  dbusValidReg;
+   
+   reg [3:0]                            jtagStateReg;
+   
+   reg [SHIFT_REG_BITS -1 : 0]          shiftReg;
+
+   reg                                  doDbusWriteReg;
+   reg                                  doDbusReadReg;
+
+   reg                                  busyReg;
+   reg                                  skipOpReg; // Skip op because we're busy.
+   reg                                  downgradeOpReg; // Downgrade op because prev. op failed.
+   
+
+   wire                                 busy;
+   wire                                 nonzeroResp;
+
+   wire [SHIFT_REG_BITS -1 : 0]         busyResponse;
+   wire [SHIFT_REG_BITS -1 : 0]         nonbusyResponse;
+   
+   //--------------------------------------------------------
+   // Combo Logic
+
+   assign idcode  = {JTAG_VERSION, JTAG_PART_NUM, JTAG_MANUF_ID, 1'h1};
+
+   wire [3:0]                           debugAddrBits = DEBUG_ADDR_BITS;
+   wire [3:0]                           debugVersion = DEBUG_VERSION;
+   
+   assign dtminfo = {24'b0, debugAddrBits, debugVersion};
+   
+   //busy, dtm_resp* is only valid during CAPTURE_DR,
+   //      so these signals should only be used at that time.
+   // This assumes there is only one transaction in flight at a time.
+   assign busy = busyReg & ~dtm_resp_valid;
+   // This is needed especially for the first request.
+   assign nonzeroResp = dtm_resp_valid ? |{dtm_resp_data[DEBUG_OP_BITS-1:0]} : 1'b0;
+   
+   // Interface to DM.
+   // Note that this means dtm_resp_data must only be used during CAPTURE_DR.
+   assign dtm_resp_ready = (jtagStateReg == CAPTURE_DR) &&
+                           (irReg        == REG_DEBUG_ACCESS) &&
+                           dtm_resp_valid;
+      
+   assign dtm_req_valid = dbusValidReg;
+   assign dtm_req_data  = dbusReg;
+   
+   assign busyResponse  = {{(DEBUG_ADDR_BITS +  DEBUG_DATA_BITS){1'b0}},
+                           {(DEBUG_OP_BITS){1'b1}}};                                    // Generalizing 'busy' to 'all-1'
+   
+   assign nonbusyResponse =  {dbusReg[(DEBUG_DATA_BITS + DEBUG_OP_BITS) +: DEBUG_ADDR_BITS] ,     // retain address bits from Req. 
+                              dtm_resp_data[DEBUG_OP_BITS +: DEBUG_DATA_BITS] ,                   // data
+                              dtm_resp_data[0 +: DEBUG_OP_BITS]                                   // response
+                              };
+      
+   //--------------------------------------------------------
+   // Sequential Logic
+
+   // JTAG STATE MACHINE
+   
+   always @(posedge TCK or posedge TRST) begin
+      if (TRST) begin
+         jtagStateReg <= TEST_LOGIC_RESET;
+      end else begin
+         case (jtagStateReg)
+           TEST_LOGIC_RESET  : jtagStateReg <= TMS ? TEST_LOGIC_RESET : RUN_TEST_IDLE;
+           RUN_TEST_IDLE     : jtagStateReg <= TMS ? SELECT_DR        : RUN_TEST_IDLE;
+           SELECT_DR         : jtagStateReg <= TMS ? SELECT_IR        : CAPTURE_DR;
+           CAPTURE_DR        : jtagStateReg <= TMS ? EXIT1_DR         : SHIFT_DR;
+           SHIFT_DR          : jtagStateReg <= TMS ? EXIT1_DR         : SHIFT_DR;
+           EXIT1_DR          : jtagStateReg <= TMS ? UPDATE_DR        : PAUSE_DR;
+           PAUSE_DR          : jtagStateReg <= TMS ? EXIT2_DR         : PAUSE_DR;
+           EXIT2_DR          : jtagStateReg <= TMS ? UPDATE_DR        : SHIFT_DR;
+           UPDATE_DR         : jtagStateReg <= TMS ? SELECT_DR        : RUN_TEST_IDLE;
+           SELECT_IR         : jtagStateReg <= TMS ? TEST_LOGIC_RESET : CAPTURE_IR;
+           CAPTURE_IR        : jtagStateReg <= TMS ? EXIT1_IR         : SHIFT_IR;
+           SHIFT_IR          : jtagStateReg <= TMS ? EXIT1_IR         : SHIFT_IR;
+           EXIT1_IR          : jtagStateReg <= TMS ? UPDATE_IR        : PAUSE_IR;
+           PAUSE_IR          : jtagStateReg <= TMS ? EXIT2_IR         : PAUSE_IR;
+           EXIT2_IR          : jtagStateReg <= TMS ? UPDATE_IR        : SHIFT_IR;
+           UPDATE_IR         : jtagStateReg <= TMS ? SELECT_DR        : RUN_TEST_IDLE; 
+         endcase // case (jtagStateReg)
+      end // else: !if(TRST)
+   end // always @ (posedge TCK or posedge TRST)
+
+   // SHIFT REG 
+   always @(posedge TCK) begin
+      case (jtagStateReg)
+        CAPTURE_IR : shiftReg <= {{(SHIFT_REG_BITS-1){1'b0}}, 1'b1}; //JTAG spec only says must end with 'b01. 
+        SHIFT_IR   : shiftReg <= {{(SHIFT_REG_BITS-IR_BITS){1'b0}}, TDI, shiftReg[IR_BITS-1 : 1]};
+        CAPTURE_DR : case (irReg) 
+                       REG_BYPASS       : shiftReg <= {(SHIFT_REG_BITS){1'b0}};
+                       REG_IDCODE       : shiftReg <= {{(SHIFT_REG_BITS-32){1'b0}}, idcode};
+                       REG_DTM_INFO     : shiftReg <= {{(SHIFT_REG_BITS-32){1'b0}}, dtminfo};
+                       REG_DEBUG_ACCESS : shiftReg <= busy ? busyResponse : nonbusyResponse;
+                       default : //BYPASS
+                         shiftReg <= {(SHIFT_REG_BITS){1'b0}};
+                     endcase
+        SHIFT_DR   : case (irReg) 
+                       REG_BYPASS   : shiftReg <= {{(SHIFT_REG_BITS- 1){1'b0}}, TDI};
+                       REG_IDCODE   : shiftReg <= {{(SHIFT_REG_BITS-32){1'b0}}, TDI, shiftReg[31:1]};
+                       REG_DTM_INFO : shiftReg <= {{(SHIFT_REG_BITS-32){1'b0}}, TDI, shiftReg[31:1]};
+                       REG_DEBUG_ACCESS : shiftReg <= {TDI, shiftReg[SHIFT_REG_BITS -1 : 1 ]};
+                       default: // BYPASS
+                        shiftReg <= {{(SHIFT_REG_BITS- 1){1'b0}} , TDI};
+                     endcase // case (irReg)  
+      endcase // case (jtagStateReg)
+   end
+
+   // IR 
+   always @(negedge TCK or posedge TRST) begin
+      if (TRST) begin
+         irReg <= REG_IDCODE;
+      end else if (jtagStateReg == TEST_LOGIC_RESET) begin
+         irReg <= REG_IDCODE;
+      end else if (jtagStateReg == UPDATE_IR) begin
+         irReg <= shiftReg[IR_BITS-1:0];
+      end
+   end
+  
+   // Busy. We become busy when we first try to send a request.
+   // We stop being busy when we accept a response.
+   // This means that busyReg will still be set when we check it,
+   // so the logic for checking busy looks ahead.
+   
+   always @(posedge TCK or posedge TRST) begin
+      if (TRST) begin
+         busyReg <= 1'b0;
+      end else if (dtm_req_valid) begin //UPDATE_DR onwards
+         busyReg <= 1'b1;
+      end else if (dtm_resp_valid & dtm_resp_ready) begin //only in CAPTURE_DR
+         busyReg <= 1'b0;
+      end
+   end // always @ (posedge TCK or posedge TRST)
+
+
+   // Downgrade/Skip. We make the decision to downgrade or skip
+   // during every CAPTURE_DR, and use the result in UPDATE_DR.
+   always @(posedge TCK or posedge TRST) begin
+      if (TRST) begin
+         skipOpReg      <= 1'b0;
+         downgradeOpReg <= 1'b0;
+      end else if (irReg == REG_DEBUG_ACCESS) begin
+         case(jtagStateReg)
+           CAPTURE_DR: begin
+              skipOpReg      <= busy;
+              downgradeOpReg <= (~busy & nonzeroResp);
+           end
+           UPDATE_DR: begin
+              skipOpReg      <= 1'b0;
+              downgradeOpReg <= 1'b0;
+           end
+         endcase // case (jtagStateReg)
+      end
+   end // always @ (posedge TCK or posedge TRST)
+   
+   
+   //dbusReg, dbusValidReg.
+   always @(negedge TCK or posedge TRST) begin
+      if (TRST) begin
+         dbusReg <= {(DBUS_REG_BITS) {1'b0}};
+         dbusValidReg <= 1'b0;
+      end else if (jtagStateReg == UPDATE_DR) begin
+         if (irReg == REG_DEBUG_ACCESS) begin
+            if (skipOpReg) begin
+               // do nothing.
+            end else if (downgradeOpReg) begin
+               dbusReg      <= {(DBUS_REG_BITS){1'b0}}; // NOP has encoding 2'b00.
+               dbusValidReg <= 1'b1;
+            end else begin 
+               dbusReg      <= shiftReg[DBUS_REG_BITS-1:0];
+               dbusValidReg <= 1'b1;
+            end
+         end
+      end else if (dtm_req_ready) begin
+         dbusValidReg <= 1'b0;
+      end
+   end // always @ (negedge TCK or posedge TRST)
+        
+   //TDO
+   always @(negedge TCK or posedge TRST) begin
+      if (TRST) begin
+         TDO     <= 1'b0;
+         DRV_TDO <= 1'b0;
+      end else if (jtagStateReg == SHIFT_IR) begin
+         TDO     <= shiftReg[0];
+         DRV_TDO <= 1'b1;
+      end else if (jtagStateReg == SHIFT_DR) begin
+         TDO     <= shiftReg[0];
+         DRV_TDO <= 1'b1;
+      end else begin
+         TDO     <= 1'b0;
+         DRV_TDO <= 1'b0;
+      end
+   end // always @ (negedge TCK or posedge TRST)
+   
+     
+endmodule
+
+   

--- a/vsrc/jtag_vpi.tab
+++ b/vsrc/jtag_vpi.tab
@@ -1,0 +1,2 @@
+$send_result_to_server call=send_result_to_server
+$check_for_command call=check_for_command

--- a/vsrc/jtag_vpi.v
+++ b/vsrc/jtag_vpi.v
@@ -1,0 +1,290 @@
+/*
+ * TCP/IP controlled VPI JTAG Interface.
+ * Based on Julius Baxter's work on jp_vpi.c
+ *
+ * Copyright (C) 2012 Franck Jullien, <franck.jullien@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation  and/or other materials provided with the distribution.
+ * 3. Neither the names of the copyright holders nor the names of any
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+`define CMD_RESET		0
+`define CMD_TMS_SEQ		1
+`define CMD_SCAN_CHAIN		2
+`define CMD_SCAN_CHAIN_FLIP_TMS	3
+`define CMD_STOP_SIMU		4
+
+module jtag_vpi
+#(	parameter DEBUG_INFO = 0,
+	parameter TP = 1,
+	parameter TCK_HALF_PERIOD = 50, // Clock half period (Clock period = 100 ns => 10 MHz)
+        parameter  CMD_DELAY = 1000
+)   
+(
+	output reg	tms,
+	output reg	tck,
+	output reg	tdi,
+	input		tdo,
+	input		enable,
+	input		init_done);
+
+integer		cmd;
+integer		length;
+integer		nb_bits;
+
+reg [31:0] 	buffer_out [0:4095];   // Data storage from the jtag server
+reg [31:0] 	buffer_in  [0:4095];   // Data storage to the jtag server
+
+integer		flip_tms;
+
+reg [31:0]	data_out;
+reg [31:0]	data_in;
+
+integer		debug;
+
+assign		tms_o = tms;
+assign		tck_o = tck;
+assign		tdi_o = tdi;
+
+initial
+begin
+	tck		<= #TP 1'b0;
+	tdi		<= #TP 1'bz;
+	tms		<= #TP 1'b0;
+
+	data_out	<= 32'h0;
+	data_in		<= 32'h0;
+
+	// Insert a #delay here because we need to
+	// wait until the PC isn't pointing to flash anymore
+	// (this is around 20k ns if the flash_crash boot code
+	// is being booted from, else much bigger, around 10mil ns)
+	wait(init_done)
+		if($test$plusargs("jtag_vpi_enable")) main;
+end
+
+task main;
+begin
+	$display("JTAG debug module with VPI interface enabled\n");
+
+	reset_tap;
+	goto_run_test_idle_from_reset;
+
+	while (1) begin
+
+		// Check for incoming command
+		// wait until a command is sent
+		// poll with a delay here
+		cmd = -1;
+
+		while (cmd == -1)
+		begin
+                     #CMD_DELAY $check_for_command(cmd, length, nb_bits, buffer_out);
+		end
+
+		// now switch on the command
+		case (cmd)
+
+		`CMD_RESET :
+		begin
+			if (DEBUG_INFO)
+				$display("%t ----> CMD_RESET %h\n", $time, length);
+			reset_tap;
+			goto_run_test_idle_from_reset;
+		end
+
+		`CMD_TMS_SEQ :
+		begin
+			if (DEBUG_INFO)
+				$display("%t ----> CMD_TMS_SEQ\n", $time);
+			do_tms_seq;
+		end
+
+		`CMD_SCAN_CHAIN :
+		begin
+			if (DEBUG_INFO)
+				$display("%t ----> CMD_SCAN_CHAIN\n", $time);
+			flip_tms = 0;
+			do_scan_chain;
+			$send_result_to_server(length, buffer_in);
+		end
+
+		`CMD_SCAN_CHAIN_FLIP_TMS :
+		begin
+			if(DEBUG_INFO)
+				$display("%t ----> CMD_SCAN_CHAIN\n", $time);
+			flip_tms = 1;
+			do_scan_chain;
+			$send_result_to_server(length, buffer_in);
+		end
+
+		`CMD_STOP_SIMU :
+		begin
+			if(DEBUG_INFO)
+				$display("%t ----> End of simulation\n", $time);
+			$finish();
+		end
+
+		default:
+		begin
+			$display("Somehow got to the default case in the command case statement.");
+			$display("Command was: %x", cmd);
+			$display("Exiting...");
+			$finish();
+		end
+
+		endcase // case (cmd)
+
+	end // while (1)
+end
+
+endtask // main
+
+
+// Generation of the TCK signal
+task gen_clk;
+input [31:0] number;
+integer i;
+
+begin
+	for (i = 0; i < number; i = i + 1)
+	begin
+		#TCK_HALF_PERIOD tck <= 1;
+		#TCK_HALF_PERIOD tck <= 0;
+	end
+end
+
+endtask
+
+// TAP reset
+task reset_tap;
+begin
+	if (DEBUG_INFO)
+		$display("(%0t) Task reset_tap", $time);
+	tms <= #1 1'b1;
+	gen_clk(5);
+end
+
+endtask
+
+
+// Goes to RunTestIdle state
+task goto_run_test_idle_from_reset;
+begin
+	if (DEBUG_INFO)
+		$display("(%0t) Task goto_run_test_idle_from_reset", $time);
+	tms <= #1 1'b0;
+	gen_clk(1);
+end
+
+endtask
+
+// 
+task do_tms_seq;
+
+integer		i,j;
+reg [31:0]	data;
+integer		nb_bits_rem;
+integer		nb_bits_in_this_byte;
+
+begin
+	if (DEBUG_INFO)
+		$display("(%0t) Task do_tms_seq of %d bits (length = %d)", $time, nb_bits, length);
+
+	// Number of bits to send in the last byte
+	nb_bits_rem = nb_bits % 8;
+
+	for (i = 0; i < length; i = i + 1)
+	begin
+		// If we are in the last byte, we have to send only
+		// nb_bits_rem bits. If not, we send the whole byte.
+		nb_bits_in_this_byte = (i == (length - 1)) ? nb_bits_rem : 8;
+
+		data = buffer_out[i];
+		for (j = 0; j < nb_bits_in_this_byte; j = j + 1)
+		begin
+			tms <= #1 1'b0;
+			if (data[j] == 1) begin
+				tms <= #1 1'b1;
+                        end
+			gen_clk(1);
+		end
+	end
+
+	tms <= #1 1'b0;
+end
+
+endtask
+
+
+// 
+task do_scan_chain;
+
+integer		_bit;
+integer		nb_bits_rem;
+integer		nb_bits_in_this_byte;
+integer		index;
+
+begin
+	if(DEBUG_INFO)
+		$display("(%0t) Task do_scan_chain of %d bits (length = %d)", $time, nb_bits, length);
+
+	// Number of bits to send in the last byte
+	nb_bits_rem = nb_bits % 8;
+
+	for (index = 0; index < length; index = index + 1)
+	begin
+		// If we are in the last byte, we have to send only
+		// nb_bits_rem bits if it's not zero.
+		// If not, we send the whole byte.
+		nb_bits_in_this_byte = (index == (length - 1)) ? ((nb_bits_rem == 0) ? 8 : nb_bits_rem) : 8;
+
+		data_out = buffer_out[index];
+		for (_bit = 0; _bit < nb_bits_in_this_byte; _bit = _bit + 1)
+		begin
+			tdi <= 1'b0;
+			if (data_out[_bit] == 1'b1) begin
+				tdi <= 1'b1;
+			end
+
+			// On the last bit, set TMS to '1'
+			if (((_bit == (nb_bits_in_this_byte - 1)) && (index == (length - 1))) && (flip_tms == 1)) begin
+				tms <= 1'b1;
+			end
+
+			#TCK_HALF_PERIOD tck <= 1;
+			data_in[_bit] <= tdo;
+			#TCK_HALF_PERIOD tck <= 0;
+		end
+		buffer_in[index] = data_in;
+	end
+
+	tdi <= 1'b0;
+	tms <= 1'b0;
+end
+
+endtask
+
+endmodule

--- a/vsrc/rocketDTMTestHarness.v
+++ b/vsrc/rocketDTMTestHarness.v
@@ -1,0 +1,293 @@
+// See LICENSE for license details.
+
+extern "A" void memory_tick
+(
+  input  reg [31:0]               channel,
+
+  input  reg                      ar_valid,
+  output reg                      ar_ready,
+  input  reg [`MEM_ADDR_BITS-1:0] ar_addr,
+  input  reg [`MEM_ID_BITS-1:0]   ar_id,
+  input  reg [2:0]                ar_size,
+  input  reg [7:0]                ar_len,
+
+  input  reg                      aw_valid,
+  output reg                      aw_ready,
+  input  reg [`MEM_ADDR_BITS-1:0] aw_addr,
+  input  reg [`MEM_ID_BITS-1:0]   aw_id,
+  input  reg [2:0]                aw_size,
+  input  reg [7:0]                aw_len,
+
+  input  reg                      w_valid,
+  output reg                      w_ready,
+  input  reg [`MEM_STRB_BITS-1:0] w_strb,
+  input  reg [`MEM_DATA_BITS-1:0] w_data,
+  input  reg                      w_last,
+
+  output reg                      r_valid,
+  input  reg                      r_ready,
+  output reg [1:0]                r_resp,
+  output reg [`MEM_ID_BITS-1:0]   r_id,
+  output reg [`MEM_DATA_BITS-1:0] r_data,
+  output reg                      r_last,
+
+  output reg                      b_valid,
+  input  reg                      b_ready,
+  output reg [1:0]                b_resp,
+  output reg [`MEM_ID_BITS-1:0]   b_id
+);
+
+module rocketDTMTestHarness;
+
+  reg [31:0] seed;
+  initial seed = $get_initial_random_seed();
+
+  //-----------------------------------------------
+  // Instantiate the processor
+
+  reg clk   = 1'b0;
+  reg reset = 1'b1;
+  reg r_reset = 1'b1;
+  reg start = 1'b0;
+
+  always #`CLOCK_PERIOD clk = ~clk;
+
+  reg [  31:0] n_mem_channel = `N_MEM_CHANNELS;
+  reg [  31:0] mem_width = `MEM_DATA_BITS;
+  reg [  63:0] max_cycles = 0;
+  reg [  63:0] trace_count = 0;
+  reg [1023:0] loadmem = 0;
+  reg [1023:0] vcdplusfile = 0;
+  reg [1023:0] vcdfile = 0;
+  reg          verbose = 0;
+  wire         printf_cond = verbose && !reset;
+  integer      stderr = 32'h80000002;
+
+`include `TBVFRAG
+
+   
+   
+  always @(posedge clk)
+  begin
+    r_reset <= reset;
+  end
+
+  reg [31:0] exit = 0;
+
+   //-----------------------------------------------
+  // Instantiate DTM and Synchronizers
+                
+  // JTAG Interface
+
+   wire       debug_TDI;
+   wire       debug_TDO;
+   wire       debug_TCK;
+   wire       debug_TMS;
+   wire       debug_TRST;
+   wire       debug_DRV_TDO;
+
+   //=================================================
+   // JTAG VPI Server
+
+   wire      cheater_TCK;
+   
+   
+   jtag_vpi #(	
+        .DEBUG_INFO(0),
+	//parameter TP = 1,
+	.TCK_HALF_PERIOD(5),
+        .CMD_DELAY(10)        
+)   // Clock half period (Clock period = 10 ns => 100 MHz)
+   jtag_vpi (
+	.tms(debug_TMS),
+	.tck(debug_TCK),
+	.tdi(debug_TDI),
+	.tdo(debug_TDO),
+	.enable(~reset),
+	.init_done(~reset)
+ );
+
+             
+   //=================================================
+   // DTM <-> Synchronizers Interface 
+  
+   localparam DEBUG_ADDR_BITS = 5;
+   localparam DEBUG_DATA_BITS = 34;
+   localparam DEBUG_OP_BITS = 2;
+
+   
+   wire      dtm_req_ready;
+   wire      dtm_req_valid;
+   wire [DEBUG_OP_BITS + DEBUG_ADDR_BITS + DEBUG_DATA_BITS - 1 : 0 ] dtm_req_data;
+   
+   wire                                                              dtm_resp_ready;
+   wire                                                              dtm_resp_valid;
+   wire [DEBUG_OP_BITS + DEBUG_DATA_BITS - 1 :0 ]                    dtm_resp_data;
+   
+   
+   DebugTransportModuleJtag #(.DEBUG_OP_BITS(DEBUG_OP_BITS),
+                                 .DEBUG_ADDR_BITS(DEBUG_ADDR_BITS),
+                                 .DEBUG_DATA_BITS(DEBUG_DATA_BITS)
+                                 ) debugTransportModuleJtag0 (
+                                                              
+                                                           //JTAG Interface
+                                                           
+                                                              .TDI(debug_TDI),
+                                                              .TDO(debug_TDO),
+                                                              .TCK(debug_TCK),
+                                                              .TMS(debug_TMS),
+                                                              .TRST(debug_TRST),
+
+                                                              .DRV_TDO(debug_DRV_TDO),
+                                                              
+                                                              .dtm_req_ready(dtm_req_ready),
+                                                              .dtm_req_valid(dtm_req_valid),
+                                                              .dtm_req_data(dtm_req_data),
+                                                              
+                                                              .dtm_resp_ready(dtm_resp_ready),
+                                                              .dtm_resp_valid(dtm_resp_valid),
+                                                              .dtm_resp_data(dtm_resp_data)
+                                                                                                        
+                                                              );
+  
+`ifdef VERILOG_DEBUG_SYNC
+   
+  AsyncFifo #(.DEPTH_LG_2(0),
+                  .WIDTH(DEBUG_OP_BITS + DEBUG_ADDR_BITS + DEBUG_DATA_BITS))
+      debugBusReqFifo(
+                      // Write Interface
+                      
+                      .clk_w(~debug_TCK),
+                      .reset_w(debug_TRST),
+                      .ready_w(dtm_req_ready), 
+                      .valid_w(dtm_req_valid), 
+                      .data_w(dtm_req_data),   
+
+                      .clk_r(clk),
+                      .reset_r(reset),
+                      .ready_r(debug_req_ready), 
+                      .valid_r(debug_req_valid),
+                      .data_r({debug_req_bits_addr, debug_req_bits_data, debug_req_bits_op})
+                      
+                      );
+      
+      AsyncFifo #(.DEPTH_LG_2(0),
+                  .WIDTH(DEBUG_OP_BITS + DEBUG_DATA_BITS))
+                  debugBusRespFifo(
+                                   .clk_w(clk),
+                                   .reset_w(reset),
+                                   .ready_w(debug_resp_ready),
+                                   .valid_w(debug_resp_valid),
+                                   .data_w({debug_resp_bits_data, debug_resp_bits_resp}),
+
+                                   .clk_r(debug_TCK),
+                                   .reset_r(debug_TRST),
+                                   .ready_r(dtm_resp_ready),
+                                   .valid_r(dtm_resp_valid),
+                                   .data_r(dtm_resp_data) 
+                                   );
+
+   
+   // This is cheating / potentially incorrect!!! It needs to be more
+   // clearly specified as to what the behavior of TRST is.
+   assign debug_TRST = reset;
+
+   // The TCK cheat is not needed for this side of the ifdef
+   //  because both DTM and synchronizer
+   // logic is asynchronously reset as needed.
+   
+`else // !`ifdef VERILOG_DEBUG_SYNC
+  
+   // This is cheating / potentially incorrect!!! It needs to be more
+   // clearly specified as to what the behavior of TRST is.
+   assign debug_TRST = reset;
+
+   // This is TOTAL cheating!!! The synchronizer
+   // logic should be asynchronously reset, or we should
+   // specify the TCK/TRST requirements for a synchronous reset.
+   assign debug_clk = reset ? clk : debug_TCK;
+
+   assign debug_reset = debug_TRST;
+      
+   assign debug_req_valid     = dtm_req_valid;
+   assign {debug_req_bits_addr, debug_req_bits_data, debug_req_bits_op} = dtm_req_data;
+   
+   assign dtm_req_ready = debug_req_ready;
+
+   assign dtm_resp_valid     = debug_resp_valid;
+   assign dtm_resp_data = {debug_resp_bits_data, debug_resp_bits_resp};
+
+   assign debug_resp_ready    = dtm_resp_ready;
+      
+`endif // !`ifdef VERILOG_DEBUG_SYNC
+   
+   
+
+  //-----------------------------------------------
+  // Start the simulation
+
+  // Read input arguments and initialize
+  initial
+  begin
+    $value$plusargs("max-cycles=%d", max_cycles);
+    verbose = $test$plusargs("verbose");
+`ifdef DEBUG
+    if ($value$plusargs("vcdplusfile=%s", vcdplusfile))
+    begin
+      $vcdplusfile(vcdplusfile);
+      $vcdpluson(0);
+      $vcdplusmemon(0);
+    end
+
+    if ($value$plusargs("vcdfile=%s", vcdfile))
+    begin
+      $dumpfile(vcdfile);
+      $dumpvars(0, dut);
+      $dumpon;
+    end
+`define VCDPLUSCLOSE $vcdplusclose; $dumpoff;
+`else
+`define VCDPLUSCLOSE
+`endif
+
+    // Strobe reset
+    #777.7 reset = 0;
+
+  end
+
+  reg [255:0] reason = 0;
+  always @(posedge clk)
+  begin
+    if (max_cycles > 0 && trace_count > max_cycles)
+      reason = "timeout";
+    if (exit > 1)
+      $sformat(reason, "tohost = %d", exit >> 1);
+
+    if (reason)
+    begin
+      $fdisplay(stderr, "*** FAILED *** (%s) after %d simulation cycles", reason, trace_count);
+      `VCDPLUSCLOSE
+      $fatal;
+    end
+
+    if (exit == 1)
+    begin
+      if (verbose)
+        $fdisplay(stderr, "Completed after %d simulation cycles", trace_count);
+      `VCDPLUSCLOSE
+      $finish;
+    end
+  end
+
+  always @(posedge clk)
+  begin
+    trace_count = trace_count + 1;
+`ifdef GATE_LEVEL
+    if (verbose)
+    begin
+      $fdisplay(stderr, "C: %10d", trace_count-1);
+    end
+`endif
+  end
+
+endmodule


### PR DESCRIPTION
This adds the Verilog for the JTAG Debug Transport Module & Asynchronous FIFO, and infrastructure to test it. The testing infrastructure is intended to be driven by an OpenOCD instance which connects to the VCS simulation over a socket interface. The riscv-tests/debug/gdbserver.py automates the communication between all the different processes.

The Client JTAG VPI code is from @fjullien https://github.com/fjullien/jtag_vpi.

Questions to be addressed before accepting this PR:
- how to include openOCD install/download as part of the make flow
- what small subset of tests to be run automatically
- Do we need emulator support before adding this
- Are we happy with this factoring of the Makeflow (adding "TB=rocketDTMTestHarness" is the way to indicate you want to build the sim this way)
--------------------------------------------------------------------
To compile the VCS simulation which includes the JTAG DTM:

cd vsim
make CONFIG=<AnyRV32Config> TB=rocketDTMTestHarness

to run (simulation will be listening for incoming connections):
./simv-DTM-Top-<AnyRV32Config> +jtag_vpi_enable

--------------------------------------------------------------------
To run an actual test using GDB->OpenOCD->JTAG VPI -> Sim:

Install openocd with --enable-jtag_vpi flag at the ./configure step.

riscv-tools/riscv-tests/debug/gdbserver.py --freedom-e300-sim --cmd "/path/to/openocd/install/bin/openocd --s /path/to/openocd/install/share/openocd/scripts" --run "path/to/simv-DTM-Top-<AnyRV32Config>" SimpleRegisterTest.test_s0

