### PR TITLE
Add sbt pack plugin

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -2,6 +2,7 @@ import sbt._
 import Keys._
 import complete._
 import complete.DefaultParsers._
+import xerial.sbt.Pack._
 
 object BuildSettings extends Build {
 
@@ -28,7 +29,7 @@ object BuildSettings extends Build {
   lazy val make = inputKey[Unit]("trigger backend-specific makefile command")
   val setMake = NotSpace ~ ( Space ~> NotSpace )
 
-  val chipSettings = Seq(
+  val chipSettings = packAutoSettings ++ Seq(
     addons := {
       val a = sys.env.getOrElse("ROCKETCHIP_ADDONS", "")
       println(s"Using addons: $a")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.8.0")


### PR DESCRIPTION
The sbt pack plugin allows us to dump out jar files for all of the rocketchip libraries (chisel, cde, uncore, junctions, rocket, groundtest, and rocketchip), making it easier for us to use them in external projects.