### PR TITLE
Refactor top-level to separate coreplex from platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_install:
   - export CXX=g++-4.8 CC=gcc-4.8
 
 script:
-  - make vsim-verilog -C regression SUITE=$SUITE TORTURE_CONFIG=default CHISEL_VERSION=$CHISEL_VERSION
   - make emulator-ndebug -C regression SUITE=$SUITE TORTURE_CONFIG=default CHISEL_VERSION=$CHISEL_VERSION
   - make emulator-regression-tests -C regression SUITE=$SUITE TORTURE_CONFIG=default CHISEL_VERSION=$CHISEL_VERSION
 

--- a/Makefrag
+++ b/Makefrag
@@ -27,7 +27,7 @@ CHISEL_ARGS := --W0W --minimumCompatibility 3.0.0 --backend $(BACKEND) --configN
 endif
 
 src_path = src/main/scala
-default_submodules = . junctions uncore hardfloat rocket groundtest context-dependent-environments
+default_submodules = . junctions uncore hardfloat rocket groundtest coreplex context-dependent-environments
 chisel_srcs = $(foreach submodule,$(default_submodules) $(ROCKETCHIP_ADDONS),$(wildcard $(base_dir)/$(submodule)/$(src_path)/*.scala))
 chisel_srcs += $(foreach submodule,$(default_submodules) $(ROCKETCHIP_ADDONS),$(wildcard $(base_dir)/$(submodule)/$(src_path)/*/*.scala))
 

--- a/Makefrag
+++ b/Makefrag
@@ -82,3 +82,6 @@ $(consts_header_debug): $(params_file_debug)
 	sed -r 's/\(([A-Za-z0-9_]+),([A-Za-z0-9_]+)\)/#define \1 \2/' $< >> $@
 	echo "#define TBFRAG \"$(MODEL).$(CONFIG).tb.cpp\"" >> $@
 	echo "#endif // __CONST_H__" >> $@
+
+clean-run-output:
+	rm -f $(output_dir)/{*.out,*.run,*.vpd}

--- a/coreplex/build.sbt
+++ b/coreplex/build.sbt
@@ -1,0 +1,10 @@
+organization := "edu.berkeley.cs"
+
+version := "1.0"
+
+name := "coreplex"
+
+scalaVersion := "2.11.6"
+
+libraryDependencies ++= (Seq("chisel", "uncore", "junctions", "rocket", "groundtest").map {
+  dep: String => sys.props.get(dep + "Version") map { "edu.berkeley.cs" %% dep % _ }}).flatten

--- a/coreplex/src/main/scala/Configs.scala
+++ b/coreplex/src/main/scala/Configs.scala
@@ -1,0 +1,408 @@
+// See LICENSE for license details.
+
+package coreplex
+
+import Chisel._
+import junctions._
+import uncore.tilelink._
+import uncore.coherence._
+import uncore.agents._
+import uncore.devices._
+import uncore.converters._
+import rocket._
+import rocket.Util._
+import scala.math.max
+import scala.collection.mutable.{LinkedHashSet, ListBuffer}
+import DefaultTestSuites._
+import cde.{Parameters, Config, Dump, Knob, CDEMatchError}
+
+object ConfigUtils {
+  def max_int(values: Int*): Int = {
+    values.reduce((a, b) => max(a, b))
+  }
+}
+import ConfigUtils._
+
+class BaseCoreplexConfig extends Config (
+  topDefinitions = { (pname,site,here) => 
+    type PF = PartialFunction[Any,Any]
+    def findBy(sname:Any):Any = here[PF](site[Any](sname))(pname)
+    lazy val innerDataBits = 64
+    lazy val innerDataBeats = (8 * site(CacheBlockBytes)) / innerDataBits
+    pname match {
+      //Memory Parameters
+      case PAddrBits => 32
+      case PgIdxBits => 12
+      case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
+      case PgLevelBits => site(PgIdxBits) - log2Up(site(XLen)/8)
+      case VPNBits => site(PgLevels) * site(PgLevelBits)
+      case PPNBits => site(PAddrBits) - site(PgIdxBits)
+      case VAddrBits => site(VPNBits) + site(PgIdxBits)
+      case ASIdBits => 7
+      //Params used by all caches
+      case NSets => findBy(CacheName)
+      case NWays => findBy(CacheName)
+      case RowBits => findBy(CacheName)
+      case NTLBEntries => findBy(CacheName)
+      case CacheIdBits => findBy(CacheName)
+      case SplitMetadata => findBy(CacheName)
+      case "L1I" => {
+        case NSets => Knob("L1I_SETS") //64
+        case NWays => Knob("L1I_WAYS") //4
+        case RowBits => site(TLKey("L1toL2")).dataBitsPerBeat
+        case NTLBEntries => 8
+        case CacheIdBits => 0
+        case SplitMetadata => false
+      }:PF
+      case "L1D" => {
+        case NSets => Knob("L1D_SETS") //64
+        case NWays => Knob("L1D_WAYS") //4
+        case RowBits => site(TLKey("L1toL2")).dataBitsPerBeat
+        case NTLBEntries => 8
+        case CacheIdBits => 0
+        case SplitMetadata => false
+      }:PF
+      case ECCCode => None
+      case Replacer => () => new RandomReplacement(site(NWays))
+      case AmoAluOperandBits => site(XLen)
+      //L1InstCache
+      case BtbKey => BtbParameters()
+      //L1DataCache
+      case WordBits => site(XLen)
+      case StoreDataQueueDepth => 17
+      case ReplayQueueDepth => 16
+      case NMSHRs => Knob("L1D_MSHRS")
+      case LRSCCycles => 32 
+      //L2 Memory System Params
+      case NAcquireTransactors => 7
+      case L2StoreDataQueueDepth => 1
+      case L2DirectoryRepresentation => new NullRepresentation(site(NTiles))
+      case BuildL2CoherenceManager => (id: Int, p: Parameters) =>
+        Module(new L2BroadcastHub()(p.alterPartial({
+          case InnerTLId => "L1toL2"
+          case OuterTLId => "L2toMC" })))
+      case NCachedTileLinkPorts => 1
+      case NUncachedTileLinkPorts => 1
+      //Tile Constants
+      case BuildTiles => {
+        val (rvi, rvu) =
+          if (site(XLen) == 64) ((if (site(UseVM)) rv64i else rv64pi), rv64u)
+          else ((if (site(UseVM)) rv32i else rv32pi), rv32u)
+        TestGeneration.addSuites(rvi.map(_("p")))
+        TestGeneration.addSuites((if(site(UseVM)) List("v") else List()).flatMap(env => rvu.map(_(env))))
+        TestGeneration.addSuite(if (site(UseVM)) benchmarks else emptyBmarks)
+        List.fill(site(NTiles)){ (r: Bool, p: Parameters) =>
+          Module(new RocketTile(resetSignal = r)(p.alterPartial({
+            case TLId => "L1toL2"
+            case NUncachedTileLinkPorts => 1 + site(RoccNMemChannels)
+          })))
+        }
+      }
+      case BuildRoCC => Nil
+      case RoccNMemChannels => site(BuildRoCC).map(_.nMemChannels).foldLeft(0)(_ + _)
+      case RoccNPTWPorts => site(BuildRoCC).map(_.nPTWPorts).foldLeft(0)(_ + _)
+      case RoccNCSRs => site(BuildRoCC).map(_.csrs.size).foldLeft(0)(_ + _)
+      //Rocket Core Constants
+      case FetchWidth => if (site(UseCompressed)) 2 else 1
+      case RetireWidth => 1
+      case UseVM => true
+      case UseUser => true
+      case UseDebug => true
+      case NBreakpoints => 1
+      case UsePerfCounters => true
+      case FastLoadWord => true
+      case FastLoadByte => false
+      case MulUnroll => 8
+      case DivEarlyOut => true
+      case XLen => 64
+      case UseFPU => {
+        val env = if(site(UseVM)) List("p","v") else List("p")
+        TestGeneration.addSuite(rv32udBenchmarks)
+        if(site(FDivSqrt)) {
+          TestGeneration.addSuites(env.map(rv64uf))
+          TestGeneration.addSuites(env.map(rv64ud))
+        } else {
+          TestGeneration.addSuites(env.map(rv64ufNoDiv))
+          TestGeneration.addSuites(env.map(rv64udNoDiv))
+        }
+        true
+      }
+      case UseAtomics => {
+        val env = if(site(UseVM)) List("p","v") else List("p")
+        TestGeneration.addSuites(env.map(if (site(XLen) == 64) rv64ua else rv32ua))
+        true
+      }
+      case UseCompressed => {
+        val env = if(site(UseVM)) List("p","v") else List("p")
+        TestGeneration.addSuites(env.map(if (site(XLen) == 64) rv64uc else rv32uc))
+        true
+      }
+      case PLICKey => PLICConfig(site(NTiles), site(UseVM), site(NExtInterrupts), 0)
+      case DMKey => new DefaultDebugModuleConfig(site(NTiles), site(XLen))
+      case FDivSqrt => true
+      case SFMALatency => 2
+      case DFMALatency => 3
+      case CoreInstBits => if (site(UseCompressed)) 16 else 32
+      case CoreDataBits => site(XLen)
+      case NCustomMRWCSRs => 0
+      case ResetVector => BigInt(0x1000)
+      case MtvecInit => BigInt(0x1010)
+      case MtvecWritable => true
+      //Uncore Paramters
+      case RTCPeriod => 100 // gives 10 MHz RTC assuming 1 GHz uncore clock
+      case LNEndpoints => site(TLKey(site(TLId))).nManagers + site(TLKey(site(TLId))).nClients
+      case LNHeaderBits => log2Ceil(site(TLKey(site(TLId))).nManagers) +
+                             log2Up(site(TLKey(site(TLId))).nClients)
+      case TLKey("L1toL2") => {
+        val useMEI = site(NTiles) <= 1 && site(NCachedTileLinkPorts) <= 1
+        TileLinkParameters(
+          coherencePolicy = (
+            if (useMEI) new MEICoherence(site(L2DirectoryRepresentation))
+            else new MESICoherence(site(L2DirectoryRepresentation))),
+          nManagers = site(NBanksPerMemoryChannel)*site(NMemoryChannels) + 1 /* MMIO */,
+          nCachingClients = site(NCachedTileLinkPorts),
+          nCachelessClients = (if (site(ExportBusPort)) 1 else 0) + site(NUncachedTileLinkPorts),
+          maxClientXacts = max_int(
+              // L1 cache
+              site(NMSHRs) + 1 /* IOMSHR */,
+              // RoCC
+              if (site(BuildRoCC).isEmpty) 1 else site(RoccMaxTaggedMemXacts)),
+          maxClientsPerPort = if (site(BuildRoCC).isEmpty) 1 else 2,
+          maxManagerXacts = site(NAcquireTransactors) + 2,
+          dataBeats = innerDataBeats,
+          dataBits = site(CacheBlockBytes)*8)
+      }
+      case TLKey("L2toMC") => 
+        TileLinkParameters(
+          coherencePolicy = new MEICoherence(
+            new NullRepresentation(site(NBanksPerMemoryChannel))),
+          nManagers = 1,
+          nCachingClients = site(NBanksPerMemoryChannel),
+          nCachelessClients = 0,
+          maxClientXacts = 1,
+          maxClientsPerPort = site(NAcquireTransactors) + 2,
+          maxManagerXacts = 1,
+          dataBeats = innerDataBeats,
+          dataBits = site(CacheBlockBytes)*8)
+      case TLKey("Outermost") => site(TLKey("L2toMC")).copy(
+        maxClientXacts = site(NAcquireTransactors) + 2,
+        maxClientsPerPort = site(NBanksPerMemoryChannel),
+        dataBeats = site(MIFDataBeats))
+      case TLKey("L2toMMIO") => {
+        TileLinkParameters(
+          coherencePolicy = new MICoherence(
+            new NullRepresentation(site(NBanksPerMemoryChannel))),
+          nManagers = site(GlobalAddrMap).subMap("io").numSlaves,
+          nCachingClients = 0,
+          nCachelessClients = 1,
+          maxClientXacts = 4,
+          maxClientsPerPort = 1,
+          maxManagerXacts = 1,
+          dataBeats = innerDataBeats,
+          dataBits = site(CacheBlockBytes) * 8)
+      }
+      case TLKey("MMIO_Outermost") => site(TLKey("L2toMMIO")).copy(dataBeats = site(MIFDataBeats))
+
+      case BootROMFile => "./bootrom/bootrom.img"
+      case NTiles => Knob("NTILES")
+      case NBanksPerMemoryChannel => Knob("NBANKS_PER_MEM_CHANNEL")
+      case BankIdLSB => 0
+      case CacheBlockBytes => Dump("CACHE_BLOCK_BYTES", 64)
+      case CacheBlockOffsetBits => log2Up(here(CacheBlockBytes))
+      case EnableL2Logging => false
+      case ExtraCoreplexPorts => (p: Parameters) => new Bundle
+      case RegressionTestNames => LinkedHashSet(
+        "rv64ud-v-fcvt",
+        "rv64ud-p-fdiv",
+        "rv64ud-v-fadd",
+        "rv64uf-v-fadd",
+        "rv64um-v-mul",
+        "rv64mi-p-breakpoint",
+        "rv64uc-v-rvc",
+        "rv64ud-v-structural",
+        "rv64si-p-wfi",
+        "rv64um-v-divw",
+        "rv64ua-v-lrsc",
+        "rv64ui-v-fence_i",
+        "rv64ud-v-fcvt_w",
+        "rv64uf-v-fmin",
+        "rv64ui-v-sb",
+        "rv64ua-v-amomax_d",
+        "rv64ud-v-move",
+        "rv64ud-v-fclass",
+        "rv64ua-v-amoand_d",
+        "rv64ua-v-amoxor_d",
+        "rv64si-p-sbreak",
+        "rv64ud-v-fmadd",
+        "rv64uf-v-ldst",
+        "rv64um-v-mulh",
+        "rv64si-p-dirty")
+      case _ => throw new CDEMatchError
+  }},
+  knobValues = {
+    case "NTILES" => 1
+    case "NBANKS_PER_MEM_CHANNEL" => 1
+    case "L1D_MSHRS" => 2
+    case "L1D_SETS" => 64
+    case "L1D_WAYS" => 4
+    case "L1I_SETS" => 64
+    case "L1I_WAYS" => 4
+    case _ => throw new CDEMatchError
+  }
+)
+
+class WithNCores(n: Int) extends Config(
+  knobValues = { case"NTILES" => n; case _ => throw new CDEMatchError })
+
+class WithNBanksPerMemChannel(n: Int) extends Config(
+  knobValues = {
+    case "NBANKS_PER_MEM_CHANNEL" => n
+    case _ => throw new CDEMatchError
+  })
+
+class WithL2Cache extends Config(
+  (pname,site,here) => pname match {
+    case "L2_CAPACITY_IN_KB" => Knob("L2_CAPACITY_IN_KB")
+    case "L2Bank" => {
+      case NSets => (((here[Int]("L2_CAPACITY_IN_KB")*1024) /
+                        site(CacheBlockBytes)) /
+                          (site(NBanksPerMemoryChannel)*site(NMemoryChannels))) /
+                            site(NWays)
+      case NWays => Knob("L2_WAYS")
+      case RowBits => site(TLKey(site(TLId))).dataBitsPerBeat
+      case CacheIdBits => log2Ceil(site(NMemoryChannels) * site(NBanksPerMemoryChannel))
+      case SplitMetadata => Knob("L2_SPLIT_METADATA")
+    }: PartialFunction[Any,Any] 
+    case NAcquireTransactors => 2
+    case NSecondaryMisses => 4
+    case L2DirectoryRepresentation => new FullRepresentation(site(NTiles))
+    case BuildL2CoherenceManager => (id: Int, p: Parameters) =>
+      Module(new L2HellaCacheBank()(p.alterPartial({
+        case CacheId => id
+        case CacheName => "L2Bank"
+        case InnerTLId => "L1toL2"
+        case OuterTLId => "L2toMC"})))
+    case L2Replacer => () => new SeqRandom(site(NWays))
+    case _ => throw new CDEMatchError
+  },
+  knobValues = { case "L2_WAYS" => 8; case "L2_CAPACITY_IN_KB" => 2048; case "L2_SPLIT_METADATA" => false; case _ => throw new CDEMatchError }
+)
+
+class WithBufferlessBroadcastHub extends Config(
+  (pname, site, here) => pname match {
+    case BuildL2CoherenceManager => (id: Int, p: Parameters) =>
+      Module(new BufferlessBroadcastHub()(p.alterPartial({
+        case InnerTLId => "L1toL2"
+        case OuterTLId => "L2toMC" })))
+  })
+
+/**
+ * WARNING!!! IGNORE AT YOUR OWN PERIL!!!
+ *
+ * There is a very restrictive set of conditions under which the stateless
+ * bridge will function properly. There can only be a single tile. This tile
+ * MUST use the blocking data cache (L1D_MSHRS == 0) and MUST NOT have an
+ * uncached channel capable of writes (i.e. a RoCC accelerator).
+ *
+ * This is because the stateless bridge CANNOT generate probes, so if your
+ * system depends on coherence between channels in any way,
+ * DO NOT use this configuration.
+ */
+class WithStatelessBridge extends Config (
+  topDefinitions = (pname, site, here) => pname match {
+    case BuildL2CoherenceManager => (id: Int, p: Parameters) =>
+      Module(new ManagerToClientStatelessBridge()(p.alterPartial({
+        case InnerTLId => "L1toL2"
+        case OuterTLId => "L2toMC" })))
+  },
+  knobValues = {
+    case "L1D_MSHRS" => 0
+    case _ => throw new CDEMatchError
+  }
+)
+
+class WithPLRU extends Config(
+  (pname, site, here) => pname match {
+    case L2Replacer => () => new SeqPLRU(site(NSets), site(NWays))
+    case _ => throw new CDEMatchError
+  })
+
+class WithL2Capacity(size_kb: Int) extends Config(
+  knobValues = {
+    case "L2_CAPACITY_IN_KB" => size_kb
+    case _ => throw new CDEMatchError
+  })
+
+class WithNL2Ways(n: Int) extends Config(
+  knobValues = {
+    case "L2_WAYS" => n
+    case _ => throw new CDEMatchError
+  })
+
+class WithRV32 extends Config(
+  (pname,site,here) => pname match {
+    case XLen => 32
+    case UseVM => false
+    case UseUser => false
+    case UseAtomics => false
+    case UseFPU => false
+    case RegressionTestNames => LinkedHashSet(
+      "rv32mi-p-ma_addr",
+      "rv32mi-p-csr",
+      "rv32ui-p-sh",
+      "rv32ui-p-lh",
+      "rv32mi-p-sbreak",
+      "rv32ui-p-sll")
+    case _ => throw new CDEMatchError
+  }
+)
+
+class WithBlockingL1 extends Config (
+  knobValues = {
+    case "L1D_MSHRS" => 0
+    case _ => throw new CDEMatchError
+  }
+)
+
+class WithSmallCores extends Config (
+    topDefinitions = { (pname,site,here) => pname match {
+      case UseFPU => false
+      case MulUnroll => 1
+      case DivEarlyOut => false  
+      case NTLBEntries => 4
+      case BtbKey => BtbParameters(nEntries = 0)
+      case StoreDataQueueDepth => 2
+      case ReplayQueueDepth => 2
+      case NAcquireTransactors => 2
+      case _ => throw new CDEMatchError
+    }},
+  knobValues = {
+    case "L1D_SETS" => 64
+    case "L1D_WAYS" => 1
+    case "L1I_SETS" => 64
+    case "L1I_WAYS" => 1
+    case "L1D_MSHRS" => 0
+    case _ => throw new CDEMatchError
+  }
+)
+
+class WithRoccExample extends Config(
+  (pname, site, here) => pname match {
+    case BuildRoCC => Seq(
+      RoccParameters(
+        opcodes = OpcodeSet.custom0,
+        generator = (p: Parameters) => Module(new AccumulatorExample()(p))),
+      RoccParameters(
+        opcodes = OpcodeSet.custom1,
+        generator = (p: Parameters) => Module(new TranslatorExample()(p)),
+        nPTWPorts = 1),
+      RoccParameters(
+        opcodes = OpcodeSet.custom2,
+        generator = (p: Parameters) => Module(new CharacterCountExample()(p))))
+
+    case RoccMaxTaggedMemXacts => 1
+    case _ => throw new CDEMatchError
+  })
+
+class WithSplitL2Metadata extends Config(
+  knobValues = { case "L2_SPLIT_METADATA" => true; case _ => throw new CDEMatchError })

--- a/coreplex/src/main/scala/Coreplex.scala
+++ b/coreplex/src/main/scala/Coreplex.scala
@@ -1,4 +1,4 @@
-package rocketchip
+package coreplex
 
 import Chisel._
 import cde.{Parameters, Field}
@@ -38,8 +38,8 @@ case object BootROMFile extends Field[String]
 case object ExportMMIOPort extends Field[Boolean]
 /** Expose an additional bus master port */
 case object ExportBusPort extends Field[Boolean]
-/** Function for building Coreplex */
-case object BuildCoreplex extends Field[Parameters => Coreplex]
+/** Extra top-level ports exported from the coreplex */
+case object ExtraCoreplexPorts extends Field[Parameters => Bundle]
 
 trait HasCoreplexParameters {
   implicit val p: Parameters
@@ -234,6 +234,7 @@ class CoreplexIO(implicit val p: Parameters) extends ParameterizedBundle()(p)
   val mmio = if(p(ExportMMIOPort)) Some(new ClientUncachedTileLinkIO()(outermostMMIOParams)) else None
   val interrupts = Vec(p(NExtInterrupts), Bool()).asInput
   val debug = new DebugBusIO()(p).flip
+  val extra = p(ExtraCoreplexPorts)(p)
 }
 
 abstract class Coreplex(implicit val p: Parameters) extends Module

--- a/coreplex/src/main/scala/TestConfigs.scala
+++ b/coreplex/src/main/scala/TestConfigs.scala
@@ -1,0 +1,246 @@
+package coreplex
+
+import Chisel._
+import groundtest._
+import rocket._
+import uncore.tilelink._
+import uncore.coherence._
+import uncore.agents._
+import uncore.devices.NTiles
+import uncore.unittests._
+import junctions._
+import junctions.unittests._
+import scala.collection.mutable.LinkedHashSet
+import cde.{Parameters, Config, Dump, Knob, CDEMatchError}
+import scala.math.max
+import ConfigUtils._
+
+class WithGroundTest extends Config(
+  (pname, site, here) => pname match {
+    case TLKey("L1toL2") => {
+      val useMEI = site(NTiles) <= 1 && site(NCachedTileLinkPorts) <= 1
+      TileLinkParameters(
+        coherencePolicy = (
+          if (useMEI) new MEICoherence(site(L2DirectoryRepresentation))
+          else new MESICoherence(site(L2DirectoryRepresentation))),
+        nManagers = site(NBanksPerMemoryChannel)*site(NMemoryChannels) + 1,
+        nCachingClients = site(NCachedTileLinkPorts),
+        nCachelessClients = site(NUncachedTileLinkPorts),
+        maxClientXacts = ((site(NMSHRs) + 1) +:
+                           site(GroundTestKey).map(_.maxXacts))
+                             .reduce(max(_, _)),
+        maxClientsPerPort = 1,
+        maxManagerXacts = site(NAcquireTransactors) + 2,
+        dataBeats = 8,
+        dataBits = site(CacheBlockBytes)*8)
+    }
+    case BuildTiles => {
+      val groundtest = if (site(XLen) == 64)
+        DefaultTestSuites.groundtest64
+      else
+        DefaultTestSuites.groundtest32
+      TestGeneration.addSuite(groundtest("p"))
+      TestGeneration.addSuite(DefaultTestSuites.emptyBmarks)
+      (0 until site(NTiles)).map { i =>
+        val tileSettings = site(GroundTestKey)(i)
+        (r: Bool, p: Parameters) => {
+          Module(new GroundTestTile(resetSignal = r)(p.alterPartial({
+            case TLId => "L1toL2"
+            case GroundTestId => i
+            case NCachedTileLinkPorts => if(tileSettings.cached > 0) 1 else 0
+            case NUncachedTileLinkPorts => tileSettings.uncached
+            case RoccNCSRs => tileSettings.csrs
+          })))
+        }
+      }
+    }
+    case UseFPU => false
+    case UseAtomics => false
+    case UseCompressed => false
+    case RegressionTestNames => LinkedHashSet("rv64ui-p-simple")
+    case _ => throw new CDEMatchError
+  })
+
+class WithComparator extends Config(
+  (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(uncached = site(ComparatorKey).targets.size)
+    }
+    case BuildGroundTest =>
+      (p: Parameters) => Module(new ComparatorCore()(p))
+    case ComparatorKey => ComparatorParameters(
+      targets    = Seq("mem", "io:ext:testram").map(name =>
+                    site(GlobalAddrMap)(name).start.longValue),
+      width      = 8,
+      operations = 1000,
+      atomics    = site(UseAtomics),
+      prefetches = site("COMPARATOR_PREFETCHES"))
+    case UseFPU => false
+    case UseAtomics => false
+    case "COMPARATOR_PREFETCHES" => false
+    case _ => throw new CDEMatchError
+  })
+
+class WithAtomics extends Config(
+  (pname, site, here) => pname match {
+    case UseAtomics => true
+    case _ => throw new CDEMatchError
+  })
+
+class WithPrefetches extends Config(
+  (pname, site, here) => pname match {
+    case "COMPARATOR_PREFETCHES" => true
+    case _ => throw new CDEMatchError
+  })
+
+class WithMemtest extends Config(
+  (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(1, 1)
+    }
+    case GeneratorKey => GeneratorParameters(
+      maxRequests = 128,
+      startAddress = site(GlobalAddrMap)("mem").start)
+    case BuildGroundTest =>
+      (p: Parameters) => Module(new GeneratorTest()(p))
+    case _ => throw new CDEMatchError
+  })
+
+class WithNGenerators(nUncached: Int, nCached: Int) extends Config(
+  (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(nUncached, nCached)
+    }
+    case _ => throw new CDEMatchError
+  })
+
+class WithCacheFillTest extends Config(
+  (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(uncached = 1)
+    }
+    case BuildGroundTest =>
+      (p: Parameters) => Module(new CacheFillTest()(p))
+    case _ => throw new CDEMatchError
+  },
+  knobValues = {
+    case "L2_WAYS" => 4
+    case "L2_CAPACITY_IN_KB" => 4
+    case _ => throw new CDEMatchError
+  })
+
+class WithBroadcastRegressionTest extends Config(
+  (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(1, 1, maxXacts = 3)
+    }
+    case BuildGroundTest =>
+      (p: Parameters) => Module(new RegressionTest()(p))
+    case GroundTestRegressions =>
+      (p: Parameters) => RegressionTests.broadcastRegressions(p)
+    case _ => throw new CDEMatchError
+  })
+
+class WithCacheRegressionTest extends Config(
+  (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(1, 1, maxXacts = 5)
+    }
+    case BuildGroundTest =>
+      (p: Parameters) => Module(new RegressionTest()(p))
+    case GroundTestRegressions =>
+      (p: Parameters) => RegressionTests.cacheRegressions(p)
+    case _ => throw new CDEMatchError
+  })
+
+class WithNastiConverterTest extends Config(
+  (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(uncached = 1)
+    }
+    case GeneratorKey => GeneratorParameters(
+      maxRequests = 128,
+      startAddress = site(GlobalAddrMap)("mem").start)
+    case BuildGroundTest =>
+      (p: Parameters) => Module(new NastiConverterTest()(p))
+    case _ => throw new CDEMatchError
+  })
+
+class WithTraceGen extends Config(
+  topDefinitions = (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(uncached = 1, cached = 1)
+    }
+    case BuildGroundTest =>
+      (p: Parameters) => Module(new GroundTestTraceGenerator()(p))
+    case GeneratorKey => GeneratorParameters(
+      maxRequests = 256,
+      startAddress = 0)
+    case AddressBag => {
+      val nSets = 32 // L2 NSets
+      val nWays = 1
+      val blockOffset = site(CacheBlockOffsetBits)
+      val baseAddr = site(GlobalAddrMap)("mem").start
+      val nBeats = site(MIFDataBeats)
+      List.tabulate(4 * nWays) { i =>
+        Seq.tabulate(nBeats) { j => (j * 8) + ((i * nSets) << blockOffset) }
+      }.flatten.map(addr => baseAddr + BigInt(addr))
+    }
+    case UseAtomics => true
+    case _ => throw new CDEMatchError
+  },
+  knobValues = {
+    case "L1D_SETS" => 16
+    case "L1D_WAYS" => 1
+  })
+
+class WithPCIeMockupTest extends Config(
+  (pname, site, here) => pname match {
+    case NTiles => 2
+    case GroundTestKey => Seq(
+      GroundTestTileSettings(1, 1),
+      GroundTestTileSettings(1))
+    case GeneratorKey => GeneratorParameters(
+      maxRequests = 128,
+      startAddress = site(GlobalAddrMap)("mem").start)
+    case BuildGroundTest =>
+      (p: Parameters) => {
+        val id = p(GroundTestId)
+        if (id == 0) Module(new GeneratorTest()(p))
+        else Module(new NastiConverterTest()(p))
+      }
+    case _ => throw new CDEMatchError
+  })
+
+class WithDirectMemtest extends Config(
+  (pname, site, here) => {
+    val nGens = 8
+    pname match {
+      case GroundTestKey => Seq(GroundTestTileSettings(uncached = nGens))
+      case GeneratorKey => GeneratorParameters(
+        maxRequests = 1024,
+        startAddress = 0)
+      case BuildGroundTest =>
+        (p: Parameters) => Module(new GeneratorTest()(p))
+      case _ => throw new CDEMatchError
+    }
+  })
+
+class WithDirectComparator extends Config(
+  (pname, site, here) => pname match {
+    case GroundTestKey => Seq.fill(site(NTiles)) {
+      GroundTestTileSettings(uncached = site(ComparatorKey).targets.size)
+    }
+    case BuildGroundTest =>
+      (p: Parameters) => Module(new ComparatorCore()(p))
+    case ComparatorKey => ComparatorParameters(
+      targets    = Seq(0L, 0x100L),
+      width      = 8,
+      operations = 1000,
+      atomics    = site(UseAtomics),
+      prefetches = site("COMPARATOR_PREFETCHES"))
+    case UseFPU => false
+    case UseAtomics => false
+    case "COMPARATOR_PREFETCHES" => false
+    case _ => throw new CDEMatchError
+  })

--- a/coreplex/src/main/scala/Testing.scala
+++ b/coreplex/src/main/scala/Testing.scala
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-package rocketchip
+package coreplex
 
 import Chisel._
 import scala.collection.mutable.{LinkedHashSet,LinkedHashMap}
@@ -183,57 +183,4 @@ object DefaultTestSuites {
     List("ad","ae","af","ag","ai","ak","al","am","an","ap","aq","ar","at","av","ay","az",
          "bb","bc","bf","bh","bj","bk","bm","bo","br","bs","ce","cf","cg","ci","ck","cl",
          "cm","cs","cv","cy","dc","df","dm","do","dr","ds","du","dv").map(_+"_matmul")): _*))
-}
-
-object TestGenerator extends App {
-  val projectName = args(0)
-  val topModuleName = args(1)
-  val configClassName = args(2)
-
-  val aggregateConfigs = configClassName.split('_')
-
-  val finalConfig = aggregateConfigs.foldRight(new Config()) { case (currentConfigName, finalConfig) =>
-    val currentConfig = try {
-      Class.forName(s"$projectName.$currentConfigName").newInstance.asInstanceOf[Config]
-    } catch {
-      case e: java.lang.ClassNotFoundException =>
-        throwException("Unable to find part \"" + currentConfigName +
-          "\" of configClassName \"" + configClassName +
-          "\", did you misspell it?", e)
-    }
-    currentConfig ++ finalConfig
-  }
-  val world = finalConfig.toInstance
-
-  val paramsFromConfig: Parameters = Parameters.root(world)
-
-  val gen = () => 
-    Class.forName(s"$projectName.$topModuleName")
-      .getConstructor(classOf[cde.Parameters])
-      .newInstance(paramsFromConfig)
-      .asInstanceOf[Module]
-
-  chiselMain.run(args.drop(3), gen)
-  //Driver.elaborate(gen, configName = configClassName)
-
-  TestGeneration.addSuite(new RegressionTestSuite(paramsFromConfig(RegressionTestNames)))
-
-  TestGeneration.generateMakefrag(topModuleName, configClassName)
-  TestBenchGeneration.generateVerilogFragment(
-    topModuleName, configClassName, paramsFromConfig)
-  TestBenchGeneration.generateCPPFragment(
-    topModuleName, configClassName, paramsFromConfig)
-
-  val pdFile = TestGeneration.createOutputFile(s"$topModuleName.$configClassName.prm")
-  pdFile.write(ParameterDump.getDump)
-  pdFile.close
-  val v = TestGeneration.createOutputFile(configClassName + ".knb")
-  v.write(world.getKnobs)
-  v.close
-  val d = new java.io.FileOutputStream(Driver.targetDir + "/" + configClassName + ".cfg")
-  d.write(paramsFromConfig(ConfigString))
-  d.close
-  val w = TestGeneration.createOutputFile(configClassName + ".cst")
-  w.write(world.getConstraints)
-  w.close
 }

--- a/coreplex/src/main/scala/UnitTest.scala
+++ b/coreplex/src/main/scala/UnitTest.scala
@@ -1,4 +1,4 @@
-package rocketchip
+package coreplex
 
 import Chisel._
 import junctions.unittests.UnitTestSuite

--- a/junctions/src/main/scala/addrmap.scala
+++ b/junctions/src/main/scala/addrmap.scala
@@ -91,7 +91,6 @@ class AddrMap(entriesIn: Seq[AddrMapEntry], val start: BigInt = BigInt(0)) exten
       if (r.start != 0) {
         val align = BigInt(1) << log2Ceil(r.size)
         require(r.start >= base, s"region $name base address 0x${r.start.toString(16)} overlaps previous base 0x${base.toString(16)}")
-        require(r.start % align == 0, s"region $name base address 0x${r.start.toString(16)} not aligned to 0x${align.toString(16)}")
         base = r.start
       } else {
         base = (base + r.size - 1) / r.size * r.size

--- a/junctions/src/main/scala/unittests/UnitTest.scala
+++ b/junctions/src/main/scala/unittests/UnitTest.scala
@@ -38,6 +38,8 @@ class UnitTestSuite(implicit p: Parameters) extends Module {
   }
 
   val timer = Module(new Timer(1000, tests.size))
+  timer.io.start.valid := Bool(false)
+  timer.io.stop.valid := Bool(false)
 
   tests.zipWithIndex.foreach { case (mod, i) =>
     mod.io.start := (state === s_start) && test_idx === UInt(i)

--- a/project/build.scala
+++ b/project/build.scala
@@ -23,7 +23,8 @@ object BuildSettings extends Build {
   lazy val uncore     = project.dependsOn(junctions)
   lazy val rocket     = project.dependsOn(hardfloat, uncore)
   lazy val groundtest = project.dependsOn(rocket)
-  lazy val rocketchip = (project in file(".")).settings(chipSettings).dependsOn(groundtest)
+  lazy val coreplex   = project.dependsOn(groundtest)
+  lazy val rocketchip = (project in file(".")).settings(chipSettings).dependsOn(coreplex)
 
   lazy val addons = settingKey[Seq[String]]("list of addons used for this build")
   lazy val make = inputKey[Unit]("trigger backend-specific makefile command")

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -155,6 +155,7 @@ stamps/%/emulator-bmark-tests.stamp: stamps/other-submodules.stamp $(RISCV)/inst
 
 stamps/%/emulator-regression-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
+	$(MAKE) -C $(abspath $(TOP))/emulator CONFIG=$* RISCV=$(abspath $(RISCV)) CHISEL_VERSION=$(CHISEL_VERSION) clean-run-output
 	$(MAKE) -C $(abspath $(TOP))/emulator CONFIG=$* RISCV=$(abspath $(RISCV)) CHISEL_VERSION=$(CHISEL_VERSION) run-regression-tests-fast
 	date > $@
 
@@ -170,22 +171,8 @@ stamps/%/vsim-bmark-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.
 
 stamps/%/vsim-regression-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
+	$(MAKE) -C $(abspath $(TOP))/vsim CONFIG=$* RISCV=$(abspath $(RISCV)) CHISEL_VERSION=$(CHISEL_VERSION) clean-run-output
 	$(MAKE) -C $(abspath $(TOP))/vsim CONFIG=$* RISCV=$(abspath $(RISCV)) CHISEL_VERSION=$(CHISEL_VERSION) run-regression-tests-fast
-	date > $@
-
-stamps/%/fsim-asm-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
-	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/fsim CONFIG=$* RISCV=$(abspath $(RISCV)) CHISEL_VERSION=$(CHISEL_VERSION) run-asm-tests-fast
-	date > $@
-
-stamps/%/fsim-bmark-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
-	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/fsim CONFIG=$* RISCV=$(abspath $(RISCV)) CHISEL_VERSION=$(CHISEL_VERSION) run-bmark-tests-fast
-	date > $@
-
-stamps/%/fsim-regression-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
-	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/fsim CONFIG=$* RISCV=$(abspath $(RISCV)) CHISEL_VERSION=$(CHISEL_VERSION) run-regression-tests-fast
 	date > $@
 
 # The torture tests run subtly differently on the different targets, so they

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -312,7 +312,7 @@ class BaseConfig extends Config (
         TileLinkParameters(
           coherencePolicy = new MICoherence(
             new NullRepresentation(site(NBanksPerMemoryChannel))),
-          nManagers = globalAddrMap.subMap("io").flatten.size,
+          nManagers = globalAddrMap.subMap("io").numSlaves,
           nCachingClients = 0,
           nCachelessClients = 1,
           maxClientXacts = 4,

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -4,27 +4,18 @@ package rocketchip
 
 import Chisel._
 import junctions._
-import uncore.tilelink._
-import uncore.coherence._
+import rocket._
 import uncore.agents._
+import uncore.tilelink._
 import uncore.devices._
 import uncore.converters._
-import rocket._
-import rocket.Util._
-import groundtest._
+import coreplex._
 import scala.math.max
 import scala.collection.mutable.{LinkedHashSet, ListBuffer}
 import DefaultTestSuites._
 import cde.{Parameters, Config, Dump, Knob, CDEMatchError}
 
-object ConfigUtils {
-  def max_int(values: Int*): Int = {
-    values.reduce((a, b) => max(a, b))
-  }
-}
-import ConfigUtils._
-
-class BaseConfig extends Config (
+class BasePlatformConfig extends Config (
   topDefinitions = { (pname,site,here) => 
     type PF = PartialFunction[Any,Any]
     def findBy(sname:Any):Any = here[PF](site[Any](sname))(pname)
@@ -116,14 +107,6 @@ class BaseConfig extends Config (
     lazy val innerDataBeats = (8 * site(CacheBlockBytes)) / innerDataBits
     pname match {
       //Memory Parameters
-      case PAddrBits => 32
-      case PgIdxBits => 12
-      case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
-      case PgLevelBits => site(PgIdxBits) - log2Up(site(XLen)/8)
-      case VPNBits => site(PgLevels) * site(PgLevelBits)
-      case PPNBits => site(PAddrBits) - site(PgIdxBits)
-      case VAddrBits => site(VPNBits) + site(PgIdxBits)
-      case ASIdBits => 7
       case MIFTagBits => Dump("MIF_TAG_BITS", 5)
       case MIFDataBits => Dump("MIF_DATA_BITS", 64)
       case MIFAddrBits => Dump("MIF_ADDR_BITS",
@@ -136,107 +119,9 @@ class BaseConfig extends Config (
           addrBits = Dump("MEM_ADDR_BITS", site(PAddrBits)),
           idBits = Dump("MEM_ID_BITS", site(MIFTagBits)))
       }
-      //Params used by all caches
-      case NSets => findBy(CacheName)
-      case NWays => findBy(CacheName)
-      case RowBits => findBy(CacheName)
-      case NTLBEntries => findBy(CacheName)
-      case CacheIdBits => findBy(CacheName)
-      case SplitMetadata => findBy(CacheName)
-      case "L1I" => {
-        case NSets => Knob("L1I_SETS") //64
-        case NWays => Knob("L1I_WAYS") //4
-        case RowBits => site(TLKey("L1toL2")).dataBitsPerBeat
-        case NTLBEntries => 8
-        case CacheIdBits => 0
-        case SplitMetadata => false
-      }:PF
-      case "L1D" => {
-        case NSets => Knob("L1D_SETS") //64
-        case NWays => Knob("L1D_WAYS") //4
-        case RowBits => site(TLKey("L1toL2")).dataBitsPerBeat
-        case NTLBEntries => 8
-        case CacheIdBits => 0
-        case SplitMetadata => false
-      }:PF
-      case ECCCode => None
-      case Replacer => () => new RandomReplacement(site(NWays))
-      case AmoAluOperandBits => site(XLen)
-      //L1InstCache
-      case BtbKey => BtbParameters()
-      //L1DataCache
-      case WordBits => site(XLen)
-      case StoreDataQueueDepth => 17
-      case ReplayQueueDepth => 16
-      case NMSHRs => Knob("L1D_MSHRS")
-      case LRSCCycles => 32 
-      //L2 Memory System Params
-      case NAcquireTransactors => 7
-      case L2StoreDataQueueDepth => 1
-      case L2DirectoryRepresentation => new NullRepresentation(site(NTiles))
-      case BuildL2CoherenceManager => (id: Int, p: Parameters) =>
-        Module(new L2BroadcastHub()(p.alterPartial({
-          case InnerTLId => "L1toL2"
-          case OuterTLId => "L2toMC" })))
-      case NCachedTileLinkPorts => 1
-      case NUncachedTileLinkPorts => 1
-      //Tile Constants
-      case BuildTiles => {
-        val (rvi, rvu) =
-          if (site(XLen) == 64) ((if (site(UseVM)) rv64i else rv64pi), rv64u)
-          else ((if (site(UseVM)) rv32i else rv32pi), rv32u)
-        TestGeneration.addSuites(rvi.map(_("p")))
-        TestGeneration.addSuites((if(site(UseVM)) List("v") else List()).flatMap(env => rvu.map(_(env))))
-        TestGeneration.addSuite(if (site(UseVM)) benchmarks else emptyBmarks)
-        List.fill(site(NTiles)){ (r: Bool, p: Parameters) =>
-          Module(new RocketTile(resetSignal = r)(p.alterPartial({
-            case TLId => "L1toL2"
-            case NUncachedTileLinkPorts => 1 + site(RoccNMemChannels)
-          })))
-        }
-      }
-      case BuildRoCC => Nil
       case BuildCoreplex => (p: Parameters) => Module(new DefaultCoreplex(p))
-      case RoccNMemChannels => site(BuildRoCC).map(_.nMemChannels).foldLeft(0)(_ + _)
-      case RoccNPTWPorts => site(BuildRoCC).map(_.nPTWPorts).foldLeft(0)(_ + _)
-      case RoccNCSRs => site(BuildRoCC).map(_.csrs.size).foldLeft(0)(_ + _)
-      //Rocket Core Constants
-      case FetchWidth => if (site(UseCompressed)) 2 else 1
-      case RetireWidth => 1
-      case UseVM => true
-      case UseUser => true
-      case UseDebug => true
-      case AsyncDebugBus => false
-      case NBreakpoints => 1
-      case UsePerfCounters => true
-      case FastLoadWord => true
-      case FastLoadByte => false
-      case MulUnroll => 8
-      case DivEarlyOut => true
-      case XLen => 64
-      case UseFPU => {
-        val env = if(site(UseVM)) List("p","v") else List("p")
-        TestGeneration.addSuite(rv32udBenchmarks)
-        if(site(FDivSqrt)) {
-          TestGeneration.addSuites(env.map(rv64uf))
-          TestGeneration.addSuites(env.map(rv64ud))
-        } else {
-          TestGeneration.addSuites(env.map(rv64ufNoDiv))
-          TestGeneration.addSuites(env.map(rv64udNoDiv))
-        }
-        true
-      }
-      case UseAtomics => {
-        val env = if(site(UseVM)) List("p","v") else List("p")
-        TestGeneration.addSuites(env.map(if (site(XLen) == 64) rv64ua else rv32ua))
-        true
-      }
-      case UseCompressed => {
-        val env = if(site(UseVM)) List("p","v") else List("p")
-        TestGeneration.addSuites(env.map(if (site(XLen) == 64) rv64uc else rv32uc))
-        true
-      }
       case NExtInterrupts => 2
+      case AsyncDebugBus => false
       case AsyncMMIOChannels => false
       case ExtraDevices => Nil
       case ExtraTopPorts => (p: Parameters) => new Bundle
@@ -248,22 +133,9 @@ class BaseConfig extends Config (
       case AsyncBusChannels => false
       case NExtBusAXIChannels => 0
       case ExportBusPort => site(NExtBusAXIChannels) > 0
-      case PLICKey => PLICConfig(site(NTiles), site(UseVM), site(NExtInterrupts), 0)
-      case DMKey => new DefaultDebugModuleConfig(site(NTiles), site(XLen))
-      case FDivSqrt => true
-      case SFMALatency => 2
-      case DFMALatency => 3
-      case CoreInstBits => if (site(UseCompressed)) 16 else 32
-      case CoreDataBits => site(XLen)
-      case NCustomMRWCSRs => 0
-      case ResetVector => BigInt(0x1000)
-      case MtvecInit => BigInt(0x1010)
-      case MtvecWritable => true
-      //Uncore Paramters
-      case RTCPeriod => 100 // gives 10 MHz RTC assuming 1 GHz uncore clock
-      case LNEndpoints => site(TLKey(site(TLId))).nManagers + site(TLKey(site(TLId))).nClients
-      case LNHeaderBits => log2Ceil(site(TLKey(site(TLId))).nManagers) +
-                             log2Up(site(TLKey(site(TLId))).nClients)
+      case ConnectExtraPorts =>
+        (out: Bundle, in: Bundle, p: Parameters) => out <> in
+
       case HastiId => "Ext"
       case HastiKey("TL") =>
         HastiParameters(
@@ -273,231 +145,20 @@ class BaseConfig extends Config (
         HastiParameters(
           addrBits = site(PAddrBits),
           dataBits = site(XLen))
-      case TLKey("L1toL2") => {
-        val useMEI = site(NTiles) <= 1 && site(NCachedTileLinkPorts) <= 1
-        TileLinkParameters(
-          coherencePolicy = (
-            if (useMEI) new MEICoherence(site(L2DirectoryRepresentation))
-            else new MESICoherence(site(L2DirectoryRepresentation))),
-          nManagers = site(NBanksPerMemoryChannel)*site(NMemoryChannels) + 1 /* MMIO */,
-          nCachingClients = site(NCachedTileLinkPorts),
-          nCachelessClients = site(NExtBusAXIChannels) + site(NUncachedTileLinkPorts),
-          maxClientXacts = max_int(
-              // L1 cache
-              site(NMSHRs) + 1 /* IOMSHR */,
-              // RoCC
-              if (site(BuildRoCC).isEmpty) 1 else site(RoccMaxTaggedMemXacts)),
-          maxClientsPerPort = if (site(BuildRoCC).isEmpty) 1 else 2,
-          maxManagerXacts = site(NAcquireTransactors) + 2,
-          dataBeats = innerDataBeats,
-          dataBits = site(CacheBlockBytes)*8)
-      }
-      case TLKey("L2toMC") => 
-        TileLinkParameters(
-          coherencePolicy = new MEICoherence(
-            new NullRepresentation(site(NBanksPerMemoryChannel))),
-          nManagers = 1,
-          nCachingClients = site(NBanksPerMemoryChannel),
-          nCachelessClients = 0,
-          maxClientXacts = 1,
-          maxClientsPerPort = site(NAcquireTransactors) + 2,
-          maxManagerXacts = 1,
-          dataBeats = innerDataBeats,
-          dataBits = site(CacheBlockBytes)*8)
-      case TLKey("Outermost") => site(TLKey("L2toMC")).copy(
-        maxClientXacts = site(NAcquireTransactors) + 2,
-        maxClientsPerPort = site(NBanksPerMemoryChannel),
-        dataBeats = site(MIFDataBeats))
-      case TLKey("L2toMMIO") => {
-        TileLinkParameters(
-          coherencePolicy = new MICoherence(
-            new NullRepresentation(site(NBanksPerMemoryChannel))),
-          nManagers = globalAddrMap.subMap("io").numSlaves,
-          nCachingClients = 0,
-          nCachelessClients = 1,
-          maxClientXacts = 4,
-          maxClientsPerPort = 1,
-          maxManagerXacts = 1,
-          dataBeats = innerDataBeats,
-          dataBits = site(CacheBlockBytes) * 8)
-      }
-      case BootROMFile => "./bootrom/bootrom.img"
-      case TLKey("MMIO_Outermost") => site(TLKey("L2toMMIO")).copy(dataBeats = site(MIFDataBeats))
-      case NTiles => Knob("NTILES")
       case AsyncMemChannels => false
       case NMemoryChannels => Dump("N_MEM_CHANNELS", 1)
       case TMemoryChannels => BusType.AXI
-      case NBanksPerMemoryChannel => Knob("NBANKS_PER_MEM_CHANNEL")
-      case NOutstandingMemReqsPerChannel => site(NBanksPerMemoryChannel)*(site(NAcquireTransactors)+2)
-      case BankIdLSB => 0
-      case CacheBlockBytes => Dump("CACHE_BLOCK_BYTES", 64)
-      case CacheBlockOffsetBits => log2Up(here(CacheBlockBytes))
       case ConfigString => makeConfigString()
       case GlobalAddrMap => globalAddrMap
-      case EnableL2Logging => false
-      case ExportGroundTestStatus => false
-      case RegressionTestNames => LinkedHashSet(
-        "rv64ud-v-fcvt",
-        "rv64ud-p-fdiv",
-        "rv64ud-v-fadd",
-        "rv64uf-v-fadd",
-        "rv64um-v-mul",
-        "rv64mi-p-breakpoint",
-        "rv64uc-v-rvc",
-        "rv64ud-v-structural",
-        "rv64si-p-wfi",
-        "rv64um-v-divw",
-        "rv64ua-v-lrsc",
-        "rv64ui-v-fence_i",
-        "rv64ud-v-fcvt_w",
-        "rv64uf-v-fmin",
-        "rv64ui-v-sb",
-        "rv64ua-v-amomax_d",
-        "rv64ud-v-move",
-        "rv64ud-v-fclass",
-        "rv64ua-v-amoand_d",
-        "rv64ua-v-amoxor_d",
-        "rv64si-p-sbreak",
-        "rv64ud-v-fmadd",
-        "rv64uf-v-ldst",
-        "rv64um-v-mulh",
-        "rv64si-p-dirty")
       case _ => throw new CDEMatchError
-  }},
-  knobValues = {
-    case "NTILES" => 1
-    case "NBANKS_PER_MEM_CHANNEL" => 1
-    case "L1D_MSHRS" => 2
-    case "L1D_SETS" => 64
-    case "L1D_WAYS" => 4
-    case "L1I_SETS" => 64
-    case "L1I_WAYS" => 4
-    case _ => throw new CDEMatchError
-  }
-)
+  }})
+
+class BaseConfig extends Config(new BaseCoreplexConfig ++ new BasePlatformConfig)
 class DefaultConfig extends Config(new WithBlockingL1 ++ new BaseConfig)
 
-class WithNCores(n: Int) extends Config(
-  knobValues = { case"NTILES" => n; case _ => throw new CDEMatchError })
-
-class WithNBanksPerMemChannel(n: Int) extends Config(
-  knobValues = {
-    case "NBANKS_PER_MEM_CHANNEL" => n;
-    case _ => throw new CDEMatchError
-  })
-
-class WithNMemoryChannels(n: Int) extends Config(
-  (pname,site,here) => pname match {
-    case NMemoryChannels => Dump("N_MEM_CHANNELS", n)
-    case _ => throw new CDEMatchError
-  }
-)
-
-class WithL2Cache extends Config(
-  (pname,site,here) => pname match {
-    case "L2_CAPACITY_IN_KB" => Knob("L2_CAPACITY_IN_KB")
-    case "L2Bank" => {
-      case NSets => (((here[Int]("L2_CAPACITY_IN_KB")*1024) /
-                        site(CacheBlockBytes)) /
-                          (site(NBanksPerMemoryChannel)*site(NMemoryChannels))) /
-                            site(NWays)
-      case NWays => Knob("L2_WAYS")
-      case RowBits => site(TLKey(site(TLId))).dataBitsPerBeat
-      case CacheIdBits => log2Ceil(site(NMemoryChannels) * site(NBanksPerMemoryChannel))
-      case SplitMetadata => Knob("L2_SPLIT_METADATA")
-    }: PartialFunction[Any,Any] 
-    case NAcquireTransactors => 2
-    case NSecondaryMisses => 4
-    case L2DirectoryRepresentation => new FullRepresentation(site(NTiles))
-    case BuildL2CoherenceManager => (id: Int, p: Parameters) =>
-      Module(new L2HellaCacheBank()(p.alterPartial({
-        case CacheId => id
-        case CacheName => "L2Bank"
-        case InnerTLId => "L1toL2"
-        case OuterTLId => "L2toMC"})))
-    case L2Replacer => () => new SeqRandom(site(NWays))
-    case _ => throw new CDEMatchError
-  },
-  knobValues = { case "L2_WAYS" => 8; case "L2_CAPACITY_IN_KB" => 2048; case "L2_SPLIT_METADATA" => false; case _ => throw new CDEMatchError }
-)
-
-class WithBufferlessBroadcastHub extends Config(
-  (pname, site, here) => pname match {
-    case BuildL2CoherenceManager => (id: Int, p: Parameters) =>
-      Module(new BufferlessBroadcastHub()(p.alterPartial({
-        case InnerTLId => "L1toL2"
-        case OuterTLId => "L2toMC" })))
-  })
-
-/**
- * WARNING!!! IGNORE AT YOUR OWN PERIL!!!
- *
- * There is a very restrictive set of conditions under which the stateless
- * bridge will function properly. There can only be a single tile. This tile
- * MUST use the blocking data cache (L1D_MSHRS == 0) and MUST NOT have an
- * uncached channel capable of writes (i.e. a RoCC accelerator).
- *
- * This is because the stateless bridge CANNOT generate probes, so if your
- * system depends on coherence between channels in any way,
- * DO NOT use this configuration.
- */
-class WithStatelessBridge extends Config (
-  topDefinitions = (pname, site, here) => pname match {
-    case BuildL2CoherenceManager => (id: Int, p: Parameters) =>
-      Module(new ManagerToClientStatelessBridge()(p.alterPartial({
-        case InnerTLId => "L1toL2"
-        case OuterTLId => "L2toMC" })))
-  },
-  knobValues = {
-    case "L1D_MSHRS" => 0
-    case _ => throw new CDEMatchError
-  }
-)
-
-class WithPLRU extends Config(
-  (pname, site, here) => pname match {
-    case L2Replacer => () => new SeqPLRU(site(NSets), site(NWays))
-    case _ => throw new CDEMatchError
-  })
-
-class WithL2Capacity(size_kb: Int) extends Config(
-  knobValues = {
-    case "L2_CAPACITY_IN_KB" => size_kb
-    case _ => throw new CDEMatchError
-  })
-
-class WithNL2Ways(n: Int) extends Config(
-  knobValues = {
-    case "L2_WAYS" => n
-    case _ => throw new CDEMatchError
-  })
-
 class DefaultL2Config extends Config(new WithL2Cache ++ new BaseConfig)
-class DefaultL2FPGAConfig extends Config(
-  new WithL2Capacity(64) ++ new WithL2Cache ++ new DefaultFPGAConfig)
-
 class DefaultBufferlessConfig extends Config(
   new WithBufferlessBroadcastHub ++ new BaseConfig)
-
-class PLRUL2Config extends Config(new WithPLRU ++ new DefaultL2Config)
-
-class WithRV32 extends Config(
-  (pname,site,here) => pname match {
-    case XLen => 32
-    case UseVM => false
-    case UseUser => false
-    case UseAtomics => false
-    case UseFPU => false
-    case RegressionTestNames => LinkedHashSet(
-      "rv32mi-p-ma_addr",
-      "rv32mi-p-csr",
-      "rv32ui-p-sh",
-      "rv32ui-p-lh",
-      "rv32mi-p-sbreak",
-      "rv32ui-p-sll")
-    case _ => throw new CDEMatchError
-  }
-)
 
 class FPGAConfig extends Config (
   (pname,site,here) => pname match {
@@ -507,9 +168,15 @@ class FPGAConfig extends Config (
   }
 )
 
-class WithBlockingL1 extends Config (
-  knobValues = {
-    case "L1D_MSHRS" => 0
+class DefaultFPGAConfig extends Config(new FPGAConfig ++ new BaseConfig)
+class DefaultL2FPGAConfig extends Config(
+  new WithL2Capacity(64) ++ new WithL2Cache ++ new DefaultFPGAConfig)
+
+class PLRUL2Config extends Config(new WithPLRU ++ new DefaultL2Config)
+
+class WithNMemoryChannels(n: Int) extends Config(
+  (pname,site,here) => pname match {
+    case NMemoryChannels => Dump("N_MEM_CHANNELS", n)
     case _ => throw new CDEMatchError
   }
 )
@@ -525,30 +192,6 @@ class WithTL extends Config(
     case TMemoryChannels     => BusType.TL
     case NExtMMIOTLChannels  => 1
   })
-
-class DefaultFPGAConfig extends Config(new FPGAConfig ++ new BaseConfig)
-
-class WithSmallCores extends Config (
-    topDefinitions = { (pname,site,here) => pname match {
-      case UseFPU => false
-      case MulUnroll => 1
-      case DivEarlyOut => false  
-      case NTLBEntries => 4
-      case BtbKey => BtbParameters(nEntries = 0)
-      case StoreDataQueueDepth => 2
-      case ReplayQueueDepth => 2
-      case NAcquireTransactors => 2
-      case _ => throw new CDEMatchError
-    }},
-  knobValues = {
-    case "L1D_SETS" => 64
-    case "L1D_WAYS" => 1
-    case "L1I_SETS" => 64
-    case "L1I_WAYS" => 1
-    case "L1D_MSHRS" => 0
-    case _ => throw new CDEMatchError
-  }
-)
 
 class DefaultFPGASmallConfig extends Config(new WithSmallCores ++ new DefaultFPGAConfig)
 class DefaultSmallConfig extends Config(new WithSmallCores ++ new BaseConfig)
@@ -569,24 +212,6 @@ class DualChannelDualBankConfig extends Config(
 class DualChannelDualBankL2Config extends Config(
   new WithNMemoryChannels(2) ++ new WithNBanksPerMemChannel(2) ++
   new WithL2Cache ++ new BaseConfig)
-
-class WithRoccExample extends Config(
-  (pname, site, here) => pname match {
-    case BuildRoCC => Seq(
-      RoccParameters(
-        opcodes = OpcodeSet.custom0,
-        generator = (p: Parameters) => Module(new AccumulatorExample()(p))),
-      RoccParameters(
-        opcodes = OpcodeSet.custom1,
-        generator = (p: Parameters) => Module(new TranslatorExample()(p)),
-        nPTWPorts = 1),
-      RoccParameters(
-        opcodes = OpcodeSet.custom2,
-        generator = (p: Parameters) => Module(new CharacterCountExample()(p))))
-
-    case RoccMaxTaggedMemXacts => 1
-    case _ => throw new CDEMatchError
-  })
 
 class RoccExampleConfig extends Config(new WithRoccExample ++ new BaseConfig)
 
@@ -611,7 +236,6 @@ class OctoChannelBenchmarkConfig extends Config(new WithNMemoryChannels(8) ++ ne
 
 class EightChannelConfig extends Config(new WithNMemoryChannels(8) ++ new BaseConfig)
 
-class WithSplitL2Metadata extends Config(knobValues = { case "L2_SPLIT_METADATA" => true; case _ => throw new CDEMatchError })
 class SplitL2MetadataTestConfig extends Config(new WithSplitL2Metadata ++ new DefaultL2Config)
 
 class DualCoreConfig extends Config(

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -41,7 +41,7 @@ class BaseConfig extends Config (
       val memSize = 0x10000000L
 
       val intern = AddrMapEntry("int", internalIOAddrMap)
-      val extern = AddrMapEntry("ext", MemRange(0x50000000L, 0x30000000L, MemAttr(AddrMapProt.RWX)))
+      val extern = AddrMapEntry("ext", site(ExtAddrMap).toRange)
       val ioMap = if (site(ExportMMIOPort)) AddrMap(intern, extern) else AddrMap(intern)
 
       val addrMap = AddrMap(

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -94,12 +94,12 @@ class BasePlatformConfig extends Config (
         res append  "    };\n"
         res append  "  };\n"
       }
+      res append  "};\n"
       for (device <- site(ExtraDevices)) {
         val deviceName = device.addrMapEntry.name
         val deviceRegion = addrMap("io:ext:" + deviceName)
         res.append(device.makeConfigString(deviceRegion))
       }
-      res append  "};\n"
       res append '\u0000'
       res.toString.getBytes
     }

--- a/src/main/scala/Coreplex.scala
+++ b/src/main/scala/Coreplex.scala
@@ -192,8 +192,11 @@ class OuterMemorySystem(implicit p: Parameters) extends AbstractOuterMemorySyste
 
   // TODO: the code to print this stuff should live somewhere else
   println("Generated Address Map")
-  for ((name, region) <- p(GlobalAddrMap).flatten) {
-    println(f"\t$name%s ${region.start}%x - ${region.start + region.size - 1}%x")
+  for (entry <- p(GlobalAddrMap).flatten) {
+    val name = entry.name
+    val start = entry.region.start
+    val end = entry.region.start + entry.region.size - 1
+    println(f"\t$name%s $start%x - $end%x")
   }
   println("Generated Configuration String")
   println(new String(p(ConfigString)))

--- a/src/main/scala/Coreplex.scala
+++ b/src/main/scala/Coreplex.scala
@@ -1,0 +1,255 @@
+package rocketchip
+
+import Chisel._
+import cde.{Parameters, Field}
+import junctions._
+import uncore.tilelink._
+import uncore.coherence._
+import uncore.agents._
+import uncore.devices._
+import uncore.util._
+import uncore.converters._
+import rocket._
+import rocket.Util._
+import java.nio.{ByteBuffer,ByteOrder}
+import java.nio.file.{Files, Paths}
+
+/** Number of memory channels */
+case object NMemoryChannels extends Field[Int]
+/** Number of banks per memory channel */
+case object NBanksPerMemoryChannel extends Field[Int]
+/** Least significant bit of address used for bank partitioning */
+case object BankIdLSB extends Field[Int]
+/** Function for building some kind of coherence manager agent */
+case object BuildL2CoherenceManager extends Field[(Int, Parameters) => CoherenceAgent]
+/** Function for building some kind of tile connected to a reset signal */
+case object BuildTiles extends Field[Seq[(Bool, Parameters) => Tile]]
+/** A string describing on-chip devices, readable by target software */
+case object ConfigString extends Field[Array[Byte]]
+/** Number of external interrupt sources */
+case object NExtInterrupts extends Field[Int]
+/** Interrupt controller configuration */
+case object PLICKey extends Field[PLICConfig]
+/** Number of clock cycles per RTC tick */
+case object RTCPeriod extends Field[Int]
+/** The file to read the BootROM contents from */
+case object BootROMFile extends Field[String]
+/** Export an external MMIO slave port */
+case object ExportMMIOPort extends Field[Boolean]
+/** Expose an additional bus master port */
+case object ExportBusPort extends Field[Boolean]
+/** Function for building Coreplex */
+case object BuildCoreplex extends Field[Parameters => Coreplex]
+
+/** Wrapper around everything that isn't a Tile.
+  *
+  * Usually this is clocked and/or place-and-routed separately from the Tiles.
+  */
+class Uncore(implicit val p: Parameters) extends Module
+    with HasTopLevelParameters {
+
+  val io = new Bundle {
+    val mem  = Vec(nMemChannels, new ClientUncachedTileLinkIO()(outermostParams))
+    val tiles_cached = Vec(nCachedTilePorts, new ClientTileLinkIO).flip
+    val tiles_uncached = Vec(nUncachedTilePorts, new ClientUncachedTileLinkIO).flip
+    val prci = Vec(nTiles, new PRCITileIO).asOutput
+    val bus = if (exportBus) Some(new ClientUncachedTileLinkIO().flip) else None
+    val mmio = if (exportMMIO) Some(new ClientUncachedTileLinkIO()(outermostMMIOParams)) else None
+    val interrupts = Vec(p(NExtInterrupts), Bool()).asInput
+    val debug = new DebugBusIO()(p).flip
+  }
+
+  val outmemsys = if (nCachedTilePorts + nUncachedTilePorts > 0)
+    Module(new OuterMemorySystem) // NoC, LLC and SerDes
+  else Module(new DummyOuterMemorySystem)
+  outmemsys.io.incoherent foreach (_ := false)
+  outmemsys.io.tiles_uncached <> io.tiles_uncached
+  outmemsys.io.tiles_cached <> io.tiles_cached
+  if (exportBus) { outmemsys.io.bus.get <> io.bus.get }
+  io.mem <> outmemsys.io.mem
+
+  buildMMIONetwork(p.alterPartial({case TLId => "L2toMMIO"}))
+
+  def makeBootROM()(implicit p: Parameters) = {
+    val romdata = Files.readAllBytes(Paths.get(p(BootROMFile)))
+    val rom = ByteBuffer.wrap(romdata)
+
+    rom.order(ByteOrder.LITTLE_ENDIAN)
+
+    // for now, have the reset vector jump straight to memory
+    val resetToMemDist = p(GlobalAddrMap)("mem").start - p(ResetVector)
+    require(resetToMemDist == (resetToMemDist.toInt >> 12 << 12))
+    val configStringAddr = p(ResetVector).toInt + rom.capacity
+
+    require(rom.getInt(12) == 0,
+      "Config string address position should not be occupied by code")
+    rom.putInt(12, configStringAddr)
+    rom.array() ++ p(ConfigString).toSeq
+  }
+
+  def buildMMIONetwork(implicit p: Parameters) = {
+    val ioAddrMap = p(GlobalAddrMap).subMap("io")
+
+    val mmioNetwork = Module(new TileLinkRecursiveInterconnect(1, ioAddrMap))
+    mmioNetwork.io.in.head <> outmemsys.io.mmio
+
+    val plic = Module(new PLIC(p(PLICKey)))
+    plic.io.tl <> mmioNetwork.port("int:plic")
+    for (i <- 0 until io.interrupts.size) {
+      val gateway = Module(new LevelGateway)
+      gateway.io.interrupt := io.interrupts(i)
+      plic.io.devices(i) <> gateway.io.plic
+    }
+
+    val debugModule = Module(new DebugModule)
+    debugModule.io.tl <> mmioNetwork.port("int:debug")
+    debugModule.io.db <> io.debug
+
+    val prci = Module(new PRCI)
+    prci.io.tl <> mmioNetwork.port("int:prci")
+    io.prci := prci.io.tiles
+    prci.io.rtcTick := Counter(p(RTCPeriod)).inc() // placeholder for real RTC
+
+    for (i <- 0 until nTiles) {
+      prci.io.interrupts(i).meip := plic.io.harts(plic.cfg.context(i, 'M'))
+      if (p(UseVM))
+        prci.io.interrupts(i).seip := plic.io.harts(plic.cfg.context(i, 'S'))
+      prci.io.interrupts(i).debug := debugModule.io.debugInterrupts(i)
+
+      io.prci(i).reset := reset
+    }
+
+    val bootROM = Module(new ROMSlave(makeBootROM()))
+    bootROM.io <> mmioNetwork.port("int:bootrom")
+
+    io.mmio.map { ext => ext <> mmioNetwork.port("ext") }
+  }
+}
+
+abstract class AbstractOuterMemorySystem(implicit val p: Parameters)
+    extends Module with HasTopLevelParameters {
+  val io = new Bundle {
+    val tiles_cached = Vec(nCachedTilePorts, new ClientTileLinkIO).flip
+    val tiles_uncached = Vec(nUncachedTilePorts, new ClientUncachedTileLinkIO).flip
+    val bus = if (exportBus) Some(new ClientUncachedTileLinkIO().flip) else None
+    val incoherent = Vec(nCachedTilePorts, Bool()).asInput
+    val mem  = Vec(nMemChannels, new ClientUncachedTileLinkIO()(outermostParams))
+    val mmio = new ClientUncachedTileLinkIO()(p.alterPartial({case TLId => "L2toMMIO"}))
+  }
+}
+
+/** Use in place of OuterMemorySystem if there are no clients to connect. */
+class DummyOuterMemorySystem(implicit p: Parameters) extends AbstractOuterMemorySystem()(p) {
+  require(nCachedTilePorts + nUncachedTilePorts == 0)
+  require(io.bus.isEmpty)
+
+  io.mem.foreach { tl =>
+    tl.acquire.valid := Bool(false)
+    tl.grant.ready := Bool(false)
+  }
+
+  io.mmio.acquire.valid := Bool(false)
+  io.mmio.grant.ready := Bool(false)
+}
+
+/** The whole outer memory hierarchy, including a NoC, some kind of coherence
+  * manager agent, and a converter from TileLink to MemIO.
+  */ 
+class OuterMemorySystem(implicit p: Parameters) extends AbstractOuterMemorySystem()(p) {
+  // Create a simple L1toL2 NoC between the tiles and the banks of outer memory
+  // Cached ports are first in client list, making sharerToClientId just an indentity function
+  // addrToBank is sed to hash physical addresses (of cache blocks) to banks (and thereby memory channels)
+  def sharerToClientId(sharerId: UInt) = sharerId
+  def addrToBank(addr: UInt): UInt = {
+    val isMemory = p(GlobalAddrMap).isInRegion("mem", addr << log2Up(p(CacheBlockBytes)))
+    Mux(isMemory,
+      if (nBanks > 1) addr(lsb + log2Up(nBanks) - 1, lsb) else UInt(0),
+      UInt(nBanks))
+  }
+  val preBuffering = TileLinkDepths(1,1,2,2,0)
+  val l1tol2net = Module(new PortedTileLinkCrossbar(addrToBank, sharerToClientId, preBuffering))
+
+  // Create point(s) of coherence serialization
+  val managerEndpoints = List.tabulate(nBanks){id => p(BuildL2CoherenceManager)(id, p)}
+  managerEndpoints.foreach { _.incoherent := io.incoherent }
+
+  val mmioManager = Module(new MMIOTileLinkManager()(p.alterPartial({
+    case TLId => "L1toL2"
+    case InnerTLId => "L1toL2"
+    case OuterTLId => "L2toMMIO"
+  })))
+  io.mmio <> mmioManager.io.outer
+
+  // Wire the tiles to the TileLink client ports of the L1toL2 network,
+  // and coherence manager(s) to the other side
+  l1tol2net.io.clients_cached <> io.tiles_cached
+  l1tol2net.io.clients_uncached <> io.tiles_uncached ++ io.bus
+  l1tol2net.io.managers <> managerEndpoints.map(_.innerTL) :+ mmioManager.io.inner
+
+  // Create a converter between TileLinkIO and MemIO for each channel
+  val outerTLParams = p.alterPartial({ case TLId => "L2toMC" })
+  val backendBuffering = TileLinkDepths(0,0,0,0,0)
+
+  // TODO: the code to print this stuff should live somewhere else
+  println("Generated Address Map")
+  for ((name, region) <- p(GlobalAddrMap).flatten) {
+    println(f"\t$name%s ${region.start}%x - ${region.start + region.size - 1}%x")
+  }
+  println("Generated Configuration String")
+  println(new String(p(ConfigString)))
+
+  val mem_ic = Module(new TileLinkMemoryInterconnect(nBanksPerMemChannel, nMemChannels)(outermostParams))
+
+  for ((bank, icPort) <- managerEndpoints zip mem_ic.io.in) {
+    val unwrap = Module(new ClientTileLinkIOUnwrapper()(outerTLParams))
+    unwrap.io.in <> ClientTileLinkEnqueuer(bank.outerTL, backendBuffering)(outerTLParams)
+    TileLinkWidthAdapter(icPort, unwrap.io.out)
+  }
+
+  io.mem <> mem_ic.io.out
+}
+
+abstract class Coreplex(implicit val p: Parameters) extends Module
+    with HasTopLevelParameters {
+  val io = new Bundle {
+    val mem  = Vec(nMemChannels, new ClientUncachedTileLinkIO()(outermostParams))
+    val bus = if (p(ExportBusPort)) Some(new ClientUncachedTileLinkIO().flip) else None
+    val mmio = if(p(ExportMMIOPort)) Some(new ClientUncachedTileLinkIO()(outermostMMIOParams)) else None
+    val interrupts = Vec(p(NExtInterrupts), Bool()).asInput
+    val debug = new DebugBusIO()(p).flip
+  }
+}
+
+class DefaultCoreplex(topParams: Parameters) extends Coreplex()(topParams) {
+  // Build an Uncore and a set of Tiles
+  val tileResets = Wire(Vec(nTiles, Bool()))
+  val tileList = p(BuildTiles).zip(tileResets).map {
+    case (tile, rst) => tile(rst, p)
+  }
+  val nCachedPorts = tileList.map(tile => tile.io.cached.size).reduce(_ + _)
+  val nUncachedPorts = tileList.map(tile => tile.io.uncached.size).reduce(_ + _)
+
+  val innerTLParams = p.alterPartial({
+    case HastiId => "TL"
+    case TLId => "L1toL2"
+    case NCachedTileLinkPorts => nCachedPorts
+    case NUncachedTileLinkPorts => nUncachedPorts
+  })
+
+  val uncore = Module(new Uncore()(innerTLParams))
+
+  (uncore.io.prci, tileResets, tileList).zipped.foreach {
+    case (prci, rst, tile) =>
+      rst := prci.reset
+      tile.io.prci <> prci
+  }
+
+  // Connect the uncore to the tile memory ports, HostIO and MemIO
+  uncore.io.tiles_cached <> tileList.map(_.io.cached).flatten
+  uncore.io.tiles_uncached <> tileList.map(_.io.uncached).flatten
+  uncore.io.interrupts <> io.interrupts
+  uncore.io.debug <> io.debug
+  if (exportBus) { uncore.io.bus.get <> io.bus.get }
+  if (exportMMIO) { io.mmio.get <> uncore.io.mmio.get }
+  io.mem <> uncore.io.mem
+}

--- a/src/main/scala/Devices.scala
+++ b/src/main/scala/Devices.scala
@@ -12,9 +12,9 @@ abstract class Device {
   def builder(port: ClientUncachedTileLinkIO, extra: Bundle, p: Parameters): Unit
   def addrMapEntry: AddrMapEntry
   def makeConfigString(region: MemRegion): String = {
-    s"  ${addrMapEntry.name} {\n" +
-    s"    addr 0x${region.start.toString(16)};\n" +
-    s"    size 0x${region.size.toString(16)}; \n" +
-     "  }\n"
+    s"${addrMapEntry.name} {\n" +
+    s"  addr 0x${region.start.toString(16)};\n" +
+    s"  size 0x${region.size.toString(16)}; \n" +
+     "}\n"
   }
 }

--- a/src/main/scala/Generator.scala
+++ b/src/main/scala/Generator.scala
@@ -1,0 +1,61 @@
+// See LICENSE for license details.
+
+package rocketchip
+
+import Chisel._
+import scala.collection.mutable.{LinkedHashSet,LinkedHashMap}
+import cde.{Parameters, ParameterDump, Config, Field, CDEMatchError}
+import coreplex._
+
+object TestGenerator extends App {
+  val projectName = args(0)
+  val topModuleName = args(1)
+  val configClassName = args(2)
+
+  val aggregateConfigs = configClassName.split('_')
+
+  val finalConfig = aggregateConfigs.foldRight(new Config()) { case (currentConfigName, finalConfig) =>
+    val currentConfig = try {
+      Class.forName(s"$projectName.$currentConfigName").newInstance.asInstanceOf[Config]
+    } catch {
+      case e: java.lang.ClassNotFoundException =>
+        throwException("Unable to find part \"" + currentConfigName +
+          "\" of configClassName \"" + configClassName +
+          "\", did you misspell it?", e)
+    }
+    currentConfig ++ finalConfig
+  }
+  val world = finalConfig.toInstance
+
+  val paramsFromConfig: Parameters = Parameters.root(world)
+
+  val gen = () => 
+    Class.forName(s"$projectName.$topModuleName")
+      .getConstructor(classOf[cde.Parameters])
+      .newInstance(paramsFromConfig)
+      .asInstanceOf[Module]
+
+  chiselMain.run(args.drop(3), gen)
+  //Driver.elaborate(gen, configName = configClassName)
+
+  TestGeneration.addSuite(new RegressionTestSuite(paramsFromConfig(RegressionTestNames)))
+
+  TestGeneration.generateMakefrag(topModuleName, configClassName)
+  TestBenchGeneration.generateVerilogFragment(
+    topModuleName, configClassName, paramsFromConfig)
+  TestBenchGeneration.generateCPPFragment(
+    topModuleName, configClassName, paramsFromConfig)
+
+  val pdFile = TestGeneration.createOutputFile(s"$topModuleName.$configClassName.prm")
+  pdFile.write(ParameterDump.getDump)
+  pdFile.close
+  val v = TestGeneration.createOutputFile(configClassName + ".knb")
+  v.write(world.getKnobs)
+  v.close
+  val d = new java.io.FileOutputStream(Driver.targetDir + "/" + configClassName + ".cfg")
+  d.write(paramsFromConfig(ConfigString))
+  d.close
+  val w = TestGeneration.createOutputFile(configClassName + ".cst")
+  w.write(world.getConstraints)
+  w.close
+}

--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -40,7 +40,6 @@ case object AsyncMMIOChannels extends Field[Boolean]
 
 /** External address map settings */
 case object ExtMMIOPorts extends Field[Seq[AddrMapEntry]]
-case object ExtAddrMap extends Field[AddrMap]
 
 /** Utility trait for quick access to some relevant parameters */
 trait HasTopLevelParameters {
@@ -225,7 +224,7 @@ class Periphery(implicit val p: Parameters) extends Module
   }
 
   def buildMMIONetwork(implicit p: Parameters) = {
-    val extAddrMap = p(ExtAddrMap)
+    val extAddrMap = p(GlobalAddrMap).subMap("io:ext")
 
     val mmioNetwork = Module(new TileLinkRecursiveInterconnect(1, extAddrMap))
     mmioNetwork.io.in.head <> io.mmio_in.get

--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -6,15 +6,10 @@ import Chisel._
 import cde.{Parameters, Field}
 import junctions._
 import uncore.tilelink._
-import uncore.coherence._
-import uncore.agents._
 import uncore.devices._
 import uncore.util._
 import uncore.converters._
 import rocket._
-import rocket.Util._
-import java.nio.{ByteBuffer,ByteOrder}
-import java.nio.file.{Files, Paths}
 
 /** Top-level parameters of RocketChip, values set in e.g. PublicConfigs.scala */
 
@@ -27,38 +22,25 @@ object BusType {
   val busTypes = Seq(AXI, AHB, TL)
 }
 
-/** Number of memory channels */
-case object AsyncMemChannels extends Field[Boolean]
-case object NMemoryChannels extends Field[Int]
+/** Memory channel controls */
 case object TMemoryChannels extends Field[BusType.EnumVal]
-/** Number of banks per memory channel */
-case object NBanksPerMemoryChannel extends Field[Int]
-/** Least significant bit of address used for bank partitioning */
-case object BankIdLSB extends Field[Int]
 /** Number of outstanding memory requests */
 case object NOutstandingMemReqsPerChannel extends Field[Int]
-/** Number of exteral MMIO ports */
-case object AsyncMMIOChannels extends Field[Boolean]
-case object ExtMMIOPorts extends Field[AddrMap]
+/** External MMIO controls */
 case object NExtMMIOAXIChannels extends Field[Int]
 case object NExtMMIOAHBChannels extends Field[Int]
 case object NExtMMIOTLChannels  extends Field[Int]
-case object AsyncBusChannels extends Field[Boolean]
+/** External Bus controls */
 case object NExtBusAXIChannels extends Field[Int]
-/** Function for building some kind of coherence manager agent */
-case object BuildL2CoherenceManager extends Field[(Int, Parameters) => CoherenceAgent]
-/** Function for building some kind of tile connected to a reset signal */
-case object BuildTiles extends Field[Seq[(Bool, Parameters) => Tile]]
-/** A string describing on-chip devices, readable by target software */
-case object ConfigString extends Field[Array[Byte]]
-/** Number of external interrupt sources */
-case object NExtInterrupts extends Field[Int]
-/** Interrupt controller configuration */
-case object PLICKey extends Field[PLICConfig]
-/** Number of clock cycles per RTC tick */
-case object RTCPeriod extends Field[Int]
+/** Async configurations */
+case object AsyncBusChannels extends Field[Boolean]
 case object AsyncDebugBus extends Field[Boolean]
-case object BootROMFile extends Field[String]
+case object AsyncMemChannels extends Field[Boolean]
+case object AsyncMMIOChannels extends Field[Boolean]
+
+/** External address map settings */
+case object ExtMMIOPorts extends Field[Seq[AddrMapEntry]]
+case object ExtAddrMap extends Field[AddrMap]
 
 /** Utility trait for quick access to some relevant parameters */
 trait HasTopLevelParameters {
@@ -81,6 +63,8 @@ trait HasTopLevelParameters {
   lazy val xLen = p(XLen)
   lazy val outermostParams = p.alterPartial({ case TLId => "Outermost" })
   lazy val outermostMMIOParams = p.alterPartial({ case TLId => "MMIO_Outermost" })
+  lazy val exportBus = p(ExportBusPort)
+  lazy val exportMMIO = p(ExportMMIOPort)
 }
 
 class MemBackupCtrlIO extends Bundle {
@@ -148,34 +132,14 @@ class Top(topParams: Parameters) extends Module with HasTopLevelParameters {
   implicit val p = topParams
   val io = new TopIO
 
-  // Build an Uncore and a set of Tiles
-  val tileResets = Wire(Vec(nTiles, Bool()))
-  val tileList = p(BuildTiles).zip(tileResets).map {
-    case (tile, rst) => tile(rst, p)
-  }
-  val nCachedPorts = tileList.map(tile => tile.io.cached.size).reduce(_ + _)
-  val nUncachedPorts = tileList.map(tile => tile.io.uncached.size).reduce(_ + _)
+  val coreplex = p(BuildCoreplex)(p)
+  val periphery = Module(new Periphery)
 
-  val innerTLParams = p.alterPartial({
-    case HastiId => "TL"
-    case TLId => "L1toL2"
-    case NCachedTileLinkPorts => nCachedPorts
-    case NUncachedTileLinkPorts => nUncachedPorts
-  })
+  if (exportMMIO) { periphery.io.mmio_in.get <> coreplex.io.mmio.get }
+  periphery.io.mem_in <> coreplex.io.mem
+  if (exportBus) { coreplex.io.bus.get <> periphery.io.bus_out.get }
 
-  val uncore = Module(new Uncore()(innerTLParams))
-
-  (uncore.io.prci, tileResets, tileList).zipped.foreach {
-    case (prci, rst, tile) =>
-      rst := prci.reset
-      tile.io.prci <> prci
-  }
-
-  // Connect the uncore to the tile memory ports, HostIO and MemIO
-  uncore.io.tiles_cached <> tileList.map(_.io.cached).flatten
-  uncore.io.tiles_uncached <> tileList.map(_.io.uncached).flatten
-  uncore.io.interrupts <> io.interrupts
-  uncore.io.debugBus <>
+  coreplex.io.debug <>
     (if (p(AsyncDebugBus))
       AsyncDebugBusFrom(io.debug_clk.get, io.debug_rst.get, io.debug)
     else io.debug)
@@ -192,62 +156,49 @@ class Top(topParams: Parameters) extends Module with HasTopLevelParameters {
 
   io.mmio_axi <>
     (if (p(AsyncMMIOChannels))
-      asyncAxiTo(io.mmio_clk.get, io.mmio_rst.get, uncore.io.mmio_axi)
-    else uncore.io.mmio_axi)
-  io.mmio_ahb <> uncore.io.mmio_ahb
-  io.mmio_tl <> uncore.io.mmio_tl
+      asyncAxiTo(io.mmio_clk.get, io.mmio_rst.get, periphery.io.mmio_axi)
+    else periphery.io.mmio_axi)
+  io.mmio_ahb <> periphery.io.mmio_ahb
+  io.mmio_tl <> periphery.io.mmio_tl
 
   io.mem_axi <>
     (if (p(AsyncMemChannels))
-      asyncAxiTo(io.mem_clk.get, io.mem_rst.get, uncore.io.mem_axi)
-    else uncore.io.mem_axi)
-  io.mem_ahb <> uncore.io.mem_ahb
-  io.mem_tl <> uncore.io.mem_tl
+      asyncAxiTo(io.mem_clk.get, io.mem_rst.get, periphery.io.mem_axi)
+    else periphery.io.mem_axi)
+  io.mem_ahb <> periphery.io.mem_ahb
+  io.mem_tl <> periphery.io.mem_tl
 
-  uncore.io.bus_axi <>
+  periphery.io.bus_axi <>
     (if (p(AsyncBusChannels))
       asyncAxiFrom(io.bus_clk.get, io.bus_rst.get, io.bus_axi)
     else io.bus_axi)
 
-  io.extra <> uncore.io.extra
+  io.extra <> periphery.io.extra
 }
 
-/** Wrapper around everything that isn't a Tile.
-  *
-  * Usually this is clocked and/or place-and-routed separately from the Tiles.
-  */
-class Uncore(implicit val p: Parameters) extends Module
+class Periphery(implicit val p: Parameters) extends Module
     with HasTopLevelParameters {
-
   val io = new Bundle {
+    val mem_in  = Vec(nMemChannels, new ClientUncachedTileLinkIO()(outermostParams)).flip
+    val bus_out = if (exportBus) Some(new ClientUncachedTileLinkIO) else None
+    val mmio_in = if (exportMMIO) Some(new ClientUncachedTileLinkIO()(outermostMMIOParams).flip) else None
     val mem_axi = Vec(nMemAXIChannels, new NastiIO)
     val mem_ahb = Vec(nMemAHBChannels, new HastiMasterIO)
     val mem_tl  = Vec(nMemTLChannels,  new ClientUncachedTileLinkIO()(outermostParams))
-    val tiles_cached = Vec(nCachedTilePorts, new ClientTileLinkIO).flip
-    val tiles_uncached = Vec(nUncachedTilePorts, new ClientUncachedTileLinkIO).flip
-    val prci = Vec(nTiles, new PRCITileIO).asOutput
     val bus_axi = Vec(p(NExtBusAXIChannels), new NastiIO).flip
     val mmio_axi = Vec(p(NExtMMIOAXIChannels), new NastiIO)
     val mmio_ahb = Vec(p(NExtMMIOAHBChannels), new HastiMasterIO)
     val mmio_tl  = Vec(p(NExtMMIOTLChannels),  new ClientUncachedTileLinkIO()(outermostMMIOParams))
-    val interrupts = Vec(p(NExtInterrupts), Bool()).asInput
-    val debugBus = new DebugBusIO()(p).flip
     val extra = p(ExtraTopPorts)(p)
   }
 
-  val outmemsys = if (nCachedTilePorts + nUncachedTilePorts > 0)
-    Module(new OuterMemorySystem) // NoC, LLC and SerDes
-  else Module(new DummyOuterMemorySystem)
-  outmemsys.io.incoherent foreach (_ := false)
-  outmemsys.io.tiles_uncached <> io.tiles_uncached
-  outmemsys.io.tiles_cached <> io.tiles_cached
-
-  buildMMIONetwork(p.alterPartial({case TLId => "L2toMMIO"}))
-
-  io.mem_axi <> outmemsys.io.mem_axi
-  io.mem_ahb <> outmemsys.io.mem_ahb
-  io.mem_tl  <> outmemsys.io.mem_tl
-  outmemsys.io.bus_axi <> io.bus_axi
+  io.bus_out.map { tl_out =>
+    val conv = Module(new TileLinkIONastiIOConverter)
+    val arb = Module(new NastiArbiter(p(NExtBusAXIChannels)))
+    arb.io.master <> io.bus_axi
+    conv.io.nasti <> conv.io.tl
+    tl_out <> conv.io.tl
+  }
 
   def connectExternalMMIO(ports: Seq[ClientUncachedTileLinkIO])(implicit p: Parameters) {
     val mmio_axi_start = 0
@@ -273,189 +224,41 @@ class Uncore(implicit val p: Parameters) extends Module
     }
   }
 
-  def makeBootROM()(implicit p: Parameters) = {
-    val romdata = Files.readAllBytes(Paths.get(p(BootROMFile)))
-    val rom = ByteBuffer.wrap(romdata)
-
-    rom.order(ByteOrder.LITTLE_ENDIAN)
-
-    // for now, have the reset vector jump straight to memory
-    val resetToMemDist = p(GlobalAddrMap)("mem").start - p(ResetVector)
-    require(resetToMemDist == (resetToMemDist.toInt >> 12 << 12))
-    val configStringAddr = p(ResetVector).toInt + rom.capacity
-
-    require(rom.getInt(12) == 0,
-      "Config string address position should not be occupied by code")
-    rom.putInt(12, configStringAddr)
-    rom.array() ++ p(ConfigString).toSeq
-  }
-
   def buildMMIONetwork(implicit p: Parameters) = {
-    val ioAddrMap = p(GlobalAddrMap).subMap("io")
+    val extAddrMap = p(ExtAddrMap)
 
-    val mmioNetwork = Module(new TileLinkRecursiveInterconnect(1, ioAddrMap))
-    mmioNetwork.io.in.head <> outmemsys.io.mmio
-
-    val plic = Module(new PLIC(p(PLICKey)))
-    plic.io.tl <> mmioNetwork.port("int:plic")
-    for (i <- 0 until io.interrupts.size) {
-      val gateway = Module(new LevelGateway)
-      gateway.io.interrupt := io.interrupts(i)
-      plic.io.devices(i) <> gateway.io.plic
-    }
-
-    val debugModule = Module(new DebugModule)
-    debugModule.io.tl <> mmioNetwork.port("int:debug")
-    debugModule.io.db <> io.debugBus
-
-    val prci = Module(new PRCI)
-    prci.io.tl <> mmioNetwork.port("int:prci")
-    io.prci := prci.io.tiles
-    prci.io.rtcTick := Counter(p(RTCPeriod)).inc() // placeholder for real RTC
-
-    for (i <- 0 until nTiles) {
-      prci.io.interrupts(i).meip := plic.io.harts(plic.cfg.context(i, 'M'))
-      if (p(UseVM))
-        prci.io.interrupts(i).seip := plic.io.harts(plic.cfg.context(i, 'S'))
-      prci.io.interrupts(i).debug := debugModule.io.debugInterrupts(i)
-
-      io.prci(i).reset := reset
-    }
-
-    val bootROM = Module(new ROMSlave(makeBootROM()))
-    bootROM.io <> mmioNetwork.port("int:bootrom")
+    val mmioNetwork = Module(new TileLinkRecursiveInterconnect(1, extAddrMap))
+    mmioNetwork.io.in.head <> io.mmio_in.get
 
     for (device <- p(ExtraDevices)) {
-      device.builder(mmioNetwork.port("int:" + device.addrMapEntry.name), io.extra, p)
+      device.builder(mmioNetwork.port(device.addrMapEntry.name), io.extra, p)
     }
 
-    val ext = p(ExtMMIOPorts).entries.map(port => TileLinkWidthAdapter(mmioNetwork.port(port.name), "MMIO_Outermost"))
+    val ext = p(ExtMMIOPorts).map(
+      port => TileLinkWidthAdapter(mmioNetwork.port(port.name), "MMIO_Outermost"))
     connectExternalMMIO(ext)(outermostMMIOParams)
   }
-}
 
-abstract class AbstractOuterMemorySystem(implicit val p: Parameters)
-    extends Module with HasTopLevelParameters {
-  val io = new Bundle {
-    val tiles_cached = Vec(nCachedTilePorts, new ClientTileLinkIO).flip
-    val tiles_uncached = Vec(nUncachedTilePorts, new ClientUncachedTileLinkIO).flip
-    val incoherent = Vec(nCachedTilePorts, Bool()).asInput
-    val mem_axi = Vec(nMemAXIChannels, new NastiIO)
-    val mem_ahb = Vec(nMemAHBChannels, new HastiMasterIO)
-    val mem_tl  = Vec(nMemTLChannels,  new ClientUncachedTileLinkIO()(outermostParams))
-    val bus_axi = Vec(p(NExtBusAXIChannels), new NastiIO).flip
-    val mmio = new ClientUncachedTileLinkIO()(p.alterPartial({case TLId => "L2toMMIO"}))
-  }
-}
-
-/** Use in place of OuterMemorySystem if there are no clients to connect. */
-class DummyOuterMemorySystem(implicit p: Parameters) extends AbstractOuterMemorySystem()(p) {
-  require(nCachedTilePorts + nUncachedTilePorts == 0)
-
-  io.mem_axi.foreach { axi =>
-    axi.ar.valid := Bool(false)
-    axi.aw.valid := Bool(false)
-    axi.w.valid := Bool(false)
-    axi.r.ready := Bool(false)
-    axi.b.ready := Bool(false)
+  if (exportMMIO) {
+    buildMMIONetwork(p.alterPartial({case TLId => "L2toMMIO"}))
   }
 
-  io.mem_ahb.foreach { ahb =>
-    ahb.htrans := UInt(0)
-    ahb.hmastlock := Bool(false)
-    ahb.hwrite := Bool(false)
-    ahb.haddr := UInt(0)
-    ahb.hburst := UInt(0)
-    ahb.hsize := UInt(0)
-    ahb.hprot := UInt(0)
-  }
-
-  io.mem_tl.foreach { tl =>
-    tl.acquire.valid := Bool(false)
-    tl.grant.ready := Bool(false)
-  }
-
-  io.mmio.acquire.valid := Bool(false)
-  io.mmio.grant.ready := Bool(false)
-}
-
-/** The whole outer memory hierarchy, including a NoC, some kind of coherence
-  * manager agent, and a converter from TileLink to MemIO.
-  */ 
-class OuterMemorySystem(implicit p: Parameters) extends AbstractOuterMemorySystem()(p) {
-  // Create a simple L1toL2 NoC between the tiles and the banks of outer memory
-  // Cached ports are first in client list, making sharerToClientId just an indentity function
-  // addrToBank is sed to hash physical addresses (of cache blocks) to banks (and thereby memory channels)
-  def sharerToClientId(sharerId: UInt) = sharerId
-  def addrToBank(addr: UInt): UInt = {
-    val isMemory = p(GlobalAddrMap).isInRegion("mem", addr << log2Up(p(CacheBlockBytes)))
-    Mux(isMemory,
-      if (nBanks > 1) addr(lsb + log2Up(nBanks) - 1, lsb) else UInt(0),
-      UInt(nBanks))
-  }
-  val preBuffering = TileLinkDepths(1,1,2,2,0)
-  val l1tol2net = Module(new PortedTileLinkCrossbar(addrToBank, sharerToClientId, preBuffering))
-
-  // Create point(s) of coherence serialization
-  val managerEndpoints = List.tabulate(nBanks){id => p(BuildL2CoherenceManager)(id, p)}
-  managerEndpoints.foreach { _.incoherent := io.incoherent }
-
-  val mmioManager = Module(new MMIOTileLinkManager()(p.alterPartial({
-    case TLId => "L1toL2"
-    case InnerTLId => "L1toL2"
-    case OuterTLId => "L2toMMIO"
-  })))
-  io.mmio <> mmioManager.io.outer
-
-  val bus_in = io.bus_axi.map { ext_nasti =>
-    val converter = Module(new TileLinkIONastiIOConverter)
-    converter.io.nasti <> ext_nasti
-    converter.io.tl
-  }
-
-  // Wire the tiles to the TileLink client ports of the L1toL2 network,
-  // and coherence manager(s) to the other side
-  l1tol2net.io.clients_cached <> io.tiles_cached
-  l1tol2net.io.clients_uncached <> io.tiles_uncached ++ bus_in
-  l1tol2net.io.managers <> managerEndpoints.map(_.innerTL) :+ mmioManager.io.inner
-
-  // Create a converter between TileLinkIO and MemIO for each channel
-  val outerTLParams = p.alterPartial({ case TLId => "L2toMC" })
-  val outermostTLParams = p.alterPartial({case TLId => "Outermost"})
-  val backendBuffering = TileLinkDepths(0,0,0,0,0)
-
-  // TODO: the code to print this stuff should live somewhere else
-  println("Generated Address Map")
-  for ((name, region) <- p(GlobalAddrMap).flatten) {
-    println(f"\t$name%s ${region.start}%x - ${region.start + region.size - 1}%x")
-  }
-  println("Generated Configuration String")
-  println(new String(p(ConfigString)))
-
-  val mem_ic = Module(new TileLinkMemoryInterconnect(nBanksPerMemChannel, nMemChannels)(outermostTLParams))
-
-  for ((bank, icPort) <- managerEndpoints zip mem_ic.io.in) {
-    val unwrap = Module(new ClientTileLinkIOUnwrapper()(outerTLParams))
-    unwrap.io.in <> ClientTileLinkEnqueuer(bank.outerTL, backendBuffering)(outerTLParams)
-    TileLinkWidthAdapter(icPort, unwrap.io.out)
-  }
-
-  for ((nasti, tl) <- io.mem_axi zip mem_ic.io.out) {
-    TopUtils.connectTilelinkNasti(nasti, tl)(outermostTLParams)
+  for ((nasti, tl) <- io.mem_axi zip io.mem_in) {
+    TopUtils.connectTilelinkNasti(nasti, tl)(outermostParams)
     // Memory cache type should be normal non-cacheable bufferable
     // TODO why is this happening here?  Would 0000 (device) be OK instead?
     nasti.ar.bits.cache := UInt("b0011")
     nasti.aw.bits.cache := UInt("b0011")
   }
-  
+
   // Abuse the fact that zip takes the shorter of the two lists
-  for ((ahb, tl) <- io.mem_ahb zip mem_ic.io.out) {
+  for ((ahb, tl) <- io.mem_ahb zip io.mem_in) {
     val bridge = Module(new AHBBridge(false)) // no atomics
     ahb <> bridge.io.ahb
     bridge.io.tl <> tl
   }
 
-  for ((mem_tl, tl) <- io.mem_tl zip mem_ic.io.out) {
+  for ((mem_tl, tl) <- io.mem_tl zip io.mem_in) {
     TopUtils.connectTilelink(mem_tl, tl)
   }
 }

--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -10,6 +10,7 @@ import uncore.devices._
 import uncore.util._
 import uncore.converters._
 import rocket._
+import coreplex._
 
 /** Top-level parameters of RocketChip, values set in e.g. PublicConfigs.scala */
 
@@ -24,8 +25,6 @@ object BusType {
 
 /** Memory channel controls */
 case object TMemoryChannels extends Field[BusType.EnumVal]
-/** Number of outstanding memory requests */
-case object NOutstandingMemReqsPerChannel extends Field[Int]
 /** External MMIO controls */
 case object NExtMMIOAXIChannels extends Field[Int]
 case object NExtMMIOAHBChannels extends Field[Int]
@@ -37,9 +36,12 @@ case object AsyncBusChannels extends Field[Boolean]
 case object AsyncDebugBus extends Field[Boolean]
 case object AsyncMemChannels extends Field[Boolean]
 case object AsyncMMIOChannels extends Field[Boolean]
-
 /** External address map settings */
 case object ExtMMIOPorts extends Field[Seq[AddrMapEntry]]
+/** Function for building Coreplex */
+case object BuildCoreplex extends Field[Parameters => Coreplex]
+/** Function for connecting coreplex extra ports to top-level extra ports */
+case object ConnectExtraPorts extends Field[(Bundle, Bundle, Parameters) => Unit]
 
 /** Utility trait for quick access to some relevant parameters */
 trait HasTopLevelParameters {
@@ -162,6 +164,7 @@ class Top(topParams: Parameters) extends Module with HasTopLevelParameters {
     else io.bus_axi)
 
   io.extra <> periphery.io.extra
+  p(ConnectExtraPorts)(io.extra, coreplex.io.extra, p)
 }
 
 class Periphery(implicit val p: Parameters) extends Module

--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -44,22 +44,11 @@ case object ExtMMIOPorts extends Field[Seq[AddrMapEntry]]
 /** Utility trait for quick access to some relevant parameters */
 trait HasTopLevelParameters {
   implicit val p: Parameters
-  lazy val nTiles = p(NTiles)
-  lazy val nCachedTilePorts = p(NCachedTileLinkPorts)
-  lazy val nUncachedTilePorts = p(NUncachedTileLinkPorts)
-  lazy val csrAddrBits = 12
   lazy val tMemChannels = p(TMemoryChannels)
   lazy val nMemChannels = p(NMemoryChannels)
   lazy val nMemAXIChannels = if (tMemChannels == BusType.AXI) nMemChannels else 0
   lazy val nMemAHBChannels = if (tMemChannels == BusType.AHB) nMemChannels else 0
   lazy val nMemTLChannels  = if (tMemChannels == BusType.TL)  nMemChannels else 0
-  lazy val nBanksPerMemChannel = p(NBanksPerMemoryChannel)
-  lazy val nBanks = nMemChannels*nBanksPerMemChannel
-  lazy val lsb = p(BankIdLSB)
-  lazy val nMemReqs = p(NOutstandingMemReqsPerChannel)
-  lazy val mifAddrBits = p(MIFAddrBits)
-  lazy val mifDataBeats = p(MIFDataBeats)
-  lazy val xLen = p(XLen)
   lazy val outermostParams = p.alterPartial({ case TLId => "Outermost" })
   lazy val outermostMMIOParams = p.alterPartial({ case TLId => "MMIO_Outermost" })
   lazy val exportBus = p(ExportBusPort)

--- a/src/main/scala/TestBench.scala
+++ b/src/main/scala/TestBench.scala
@@ -5,6 +5,7 @@ package rocketchip
 import Chisel._
 import cde.Parameters
 import uncore.devices.{DbBusConsts, DMKey}
+import coreplex._
 
 object TestBenchGeneration {
   def generateVerilogFragment(

--- a/src/main/scala/TestConfigs.scala
+++ b/src/main/scala/TestConfigs.scala
@@ -168,23 +168,14 @@ class WithNastiConverterTest extends Config(
 
 class WithUnitTest extends Config(
   (pname, site, here) => pname match {
-    case BuildTiles => {
+    case BuildCoreplex => {
       val groundtest = if (site(XLen) == 64)
         DefaultTestSuites.groundtest64
       else
         DefaultTestSuites.groundtest32
       TestGeneration.addSuite(groundtest("p"))
       TestGeneration.addSuite(DefaultTestSuites.emptyBmarks)
-      (0 until site(NTiles)).map { i =>
-        (r: Bool, p: Parameters) => {
-          Module(new UnitTestTile(resetSignal = r)(p.alterPartial({
-            case TLId => "L1toL2"
-            case NCachedTileLinkPorts => 0
-            case NUncachedTileLinkPorts => 0
-            case RoccNCSRs => 0
-          })))
-        }
-      }
+      (p: Parameters) => Module(new UnitTestCoreplex(p))
     }
     case UnitTests => (testParams: Parameters) =>
       JunctionsUnitTests(testParams) ++ UncoreUnitTests(testParams)

--- a/src/main/scala/TestConfigs.scala
+++ b/src/main/scala/TestConfigs.scala
@@ -13,158 +13,8 @@ import junctions.unittests._
 import scala.collection.mutable.LinkedHashSet
 import cde.{Parameters, Config, Dump, Knob, CDEMatchError}
 import scala.math.max
+import coreplex._
 import ConfigUtils._
-
-class WithGroundTest extends Config(
-  (pname, site, here) => pname match {
-    case TLKey("L1toL2") => {
-      val useMEI = site(NTiles) <= 1 && site(NCachedTileLinkPorts) <= 1
-      TileLinkParameters(
-        coherencePolicy = (
-          if (useMEI) new MEICoherence(site(L2DirectoryRepresentation))
-          else new MESICoherence(site(L2DirectoryRepresentation))),
-        nManagers = site(NBanksPerMemoryChannel)*site(NMemoryChannels) + 1,
-        nCachingClients = site(NCachedTileLinkPorts),
-        nCachelessClients = site(NUncachedTileLinkPorts),
-        maxClientXacts = ((site(NMSHRs) + 1) +:
-                           site(GroundTestKey).map(_.maxXacts))
-                             .reduce(max(_, _)),
-        maxClientsPerPort = 1,
-        maxManagerXacts = site(NAcquireTransactors) + 2,
-        dataBeats = 8,
-        dataBits = site(CacheBlockBytes)*8)
-    }
-    case BuildTiles => {
-      val groundtest = if (site(XLen) == 64)
-        DefaultTestSuites.groundtest64
-      else
-        DefaultTestSuites.groundtest32
-      TestGeneration.addSuite(groundtest("p"))
-      TestGeneration.addSuite(DefaultTestSuites.emptyBmarks)
-      (0 until site(NTiles)).map { i =>
-        val tileSettings = site(GroundTestKey)(i)
-        (r: Bool, p: Parameters) => {
-          Module(new GroundTestTile(resetSignal = r)(p.alterPartial({
-            case TLId => "L1toL2"
-            case GroundTestId => i
-            case NCachedTileLinkPorts => if(tileSettings.cached > 0) 1 else 0
-            case NUncachedTileLinkPorts => tileSettings.uncached
-            case RoccNCSRs => tileSettings.csrs
-          })))
-        }
-      }
-    }
-    case UseFPU => false
-    case UseAtomics => false
-    case UseCompressed => false
-    case RegressionTestNames => LinkedHashSet("rv64ui-p-simple")
-    case _ => throw new CDEMatchError
-  })
-
-class WithComparator extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(uncached = site(ComparatorKey).targets.size)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new ComparatorCore()(p))
-    case ComparatorKey => ComparatorParameters(
-      targets    = Seq("mem", "io:ext:testram").map(name =>
-                    site(GlobalAddrMap)(name).start.longValue),
-      width      = 8,
-      operations = 1000,
-      atomics    = site(UseAtomics),
-      prefetches = site("COMPARATOR_PREFETCHES"))
-    case UseFPU => false
-    case UseAtomics => false
-    case "COMPARATOR_PREFETCHES" => false
-    case _ => throw new CDEMatchError
-  })
-
-class WithAtomics extends Config(
-  (pname, site, here) => pname match {
-    case UseAtomics => true
-    case _ => throw new CDEMatchError
-  })
-
-class WithPrefetches extends Config(
-  (pname, site, here) => pname match {
-    case "COMPARATOR_PREFETCHES" => true
-    case _ => throw new CDEMatchError
-  })
-
-class WithMemtest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(1, 1)
-    }
-    case GeneratorKey => GeneratorParameters(
-      maxRequests = 128,
-      startAddress = site(GlobalAddrMap)("mem").start)
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new GeneratorTest()(p))
-    case _ => throw new CDEMatchError
-  })
-
-class WithNGenerators(nUncached: Int, nCached: Int) extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(nUncached, nCached)
-    }
-    case _ => throw new CDEMatchError
-  })
-
-class WithCacheFillTest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(uncached = 1)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new CacheFillTest()(p))
-    case _ => throw new CDEMatchError
-  },
-  knobValues = {
-    case "L2_WAYS" => 4
-    case "L2_CAPACITY_IN_KB" => 4
-    case _ => throw new CDEMatchError
-  })
-
-class WithBroadcastRegressionTest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(1, 1, maxXacts = 3)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new RegressionTest()(p))
-    case GroundTestRegressions =>
-      (p: Parameters) => RegressionTests.broadcastRegressions(p)
-    case _ => throw new CDEMatchError
-  })
-
-class WithCacheRegressionTest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(1, 1, maxXacts = 5)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new RegressionTest()(p))
-    case GroundTestRegressions =>
-      (p: Parameters) => RegressionTests.cacheRegressions(p)
-    case _ => throw new CDEMatchError
-  })
-
-class WithNastiConverterTest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(uncached = 1)
-    }
-    case GeneratorKey => GeneratorParameters(
-      maxRequests = 128,
-      startAddress = site(GlobalAddrMap)("mem").start)
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new NastiConverterTest()(p))
-    case _ => throw new CDEMatchError
-  })
 
 class WithUnitTest extends Config(
   (pname, site, here) => pname match {
@@ -185,34 +35,6 @@ class WithUnitTest extends Config(
     case UseCompressed => false
     case RegressionTestNames => LinkedHashSet("rv64ui-p-simple")
     case _ => throw new CDEMatchError
-  })
-
-class WithTraceGen extends Config(
-  topDefinitions = (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(uncached = 1, cached = 1)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new GroundTestTraceGenerator()(p))
-    case GeneratorKey => GeneratorParameters(
-      maxRequests = 256,
-      startAddress = 0)
-    case AddressBag => {
-      val nSets = 32 // L2 NSets
-      val nWays = 1
-      val blockOffset = site(CacheBlockOffsetBits)
-      val baseAddr = site(GlobalAddrMap)("mem").start
-      val nBeats = site(MIFDataBeats)
-      List.tabulate(4 * nWays) { i =>
-        Seq.tabulate(nBeats) { j => (j * 8) + ((i * nSets) << blockOffset) }
-      }.flatten.map(addr => baseAddr + BigInt(addr))
-    }
-    case UseAtomics => true
-    case _ => throw new CDEMatchError
-  },
-  knobValues = {
-    case "L1D_SETS" => 16
-    case "L1D_WAYS" => 1
   })
 
 class GroundTestConfig extends Config(new WithGroundTest ++ new BaseConfig)
@@ -276,68 +98,22 @@ class MIF32BitComparatorConfig extends Config(
 class MIF32BitMemtestConfig extends Config(
   new WithMIFDataBits(32) ++ new MemtestConfig)
 
-class WithPCIeMockupTest extends Config(
-  (pname, site, here) => pname match {
-    case NTiles => 2
-    case GroundTestKey => Seq(
-      GroundTestTileSettings(1, 1),
-      GroundTestTileSettings(1))
-    case GeneratorKey => GeneratorParameters(
-      maxRequests = 128,
-      startAddress = site(GlobalAddrMap)("mem").start)
-    case BuildGroundTest =>
-      (p: Parameters) => {
-        val id = p(GroundTestId)
-        if (id == 0) Module(new GeneratorTest()(p))
-        else Module(new NastiConverterTest()(p))
-      }
-    case _ => throw new CDEMatchError
-  })
-
 class PCIeMockupTestConfig extends Config(
   new WithPCIeMockupTest ++ new GroundTestConfig)
 
 class WithDirectGroundTest extends Config(
   (pname, site, here) => pname match {
+    case ExportGroundTestStatus => true
+    case BuildCoreplex => (p: Parameters) => Module(new DirectGroundTestCoreplex(p))
+    case ExtraCoreplexPorts => (p: Parameters) =>
+      if (p(ExportGroundTestStatus)) new GroundTestStatus else new Bundle
+    case ExtraTopPorts => (p: Parameters) =>
+      if (p(ExportGroundTestStatus)) new GroundTestStatus else new Bundle
     case TLKey("Outermost") => site(TLKey("L2toMC")).copy(
       maxClientXacts = site(GroundTestKey)(0).maxXacts,
       maxClientsPerPort = site(NBanksPerMemoryChannel),
       dataBeats = site(MIFDataBeats))
-    case MIFTagBits => Dump("MIF_TAG_BITS", 2)
     case NBanksPerMemoryChannel => site(GroundTestKey)(0).uncached
-    case _ => throw new CDEMatchError
-  })
-
-class WithDirectMemtest extends Config(
-  (pname, site, here) => {
-    val nGens = 8
-    pname match {
-      case GroundTestKey => Seq(GroundTestTileSettings(uncached = nGens))
-      case GeneratorKey => GeneratorParameters(
-        maxRequests = 1024,
-        startAddress = 0)
-      case BuildGroundTest =>
-        (p: Parameters) => Module(new GeneratorTest()(p))
-      case _ => throw new CDEMatchError
-    }
-  })
-
-class WithDirectComparator extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(uncached = site(ComparatorKey).targets.size)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new ComparatorCore()(p))
-    case ComparatorKey => ComparatorParameters(
-      targets    = Seq(0L, 0x100L),
-      width      = 8,
-      operations = 1000,
-      atomics    = site(UseAtomics),
-      prefetches = site("COMPARATOR_PREFETCHES"))
-    case UseFPU => false
-    case UseAtomics => false
-    case "COMPARATOR_PREFETCHES" => false
     case _ => throw new CDEMatchError
   })
 

--- a/src/main/scala/TestConfigs.scala
+++ b/src/main/scala/TestConfigs.scala
@@ -69,7 +69,10 @@ class WithComparator extends Config(
     case BuildGroundTest =>
       (p: Parameters) => Module(new ComparatorCore()(p))
     case ComparatorKey => ComparatorParameters(
-      targets    = Seq("mem", "io:int:testram").map(name => site(GlobalAddrMap)(name).start.longValue),
+      targets    = Seq(
+        site(GlobalAddrMap)("mem"),
+        site(ExtAddrMap)("testram"))
+          .map(entry => entry.start.longValue),
       width      = 8,
       operations = 1000,
       atomics    = site(UseAtomics),

--- a/src/main/scala/TestConfigs.scala
+++ b/src/main/scala/TestConfigs.scala
@@ -69,10 +69,8 @@ class WithComparator extends Config(
     case BuildGroundTest =>
       (p: Parameters) => Module(new ComparatorCore()(p))
     case ComparatorKey => ComparatorParameters(
-      targets    = Seq(
-        site(GlobalAddrMap)("mem"),
-        site(ExtAddrMap)("testram"))
-          .map(entry => entry.start.longValue),
+      targets    = Seq("mem", "io:ext:testram").map(name =>
+                    site(GlobalAddrMap)(name).start.longValue),
       width      = 8,
       operations = 1000,
       atomics    = site(UseAtomics),

--- a/src/main/scala/UnitTest.scala
+++ b/src/main/scala/UnitTest.scala
@@ -3,14 +3,18 @@ package rocketchip
 import Chisel._
 import junctions.unittests.UnitTestSuite
 import rocket.Tile
+import uncore.tilelink.TLId
 import cde.Parameters
 
-class UnitTestTile(clockSignal: Clock = null, resetSignal: Bool = null)
-    (implicit p: Parameters) extends Tile(clockSignal, resetSignal)(p) {
+class UnitTestCoreplex(topParams: Parameters) extends Coreplex()(topParams) {
+  require(!exportMMIO)
+  require(!exportBus)
+  require(nMemChannels == 0)
 
-  require(io.cached.size == 0)
-  require(io.uncached.size == 0)
+  io.debug.req.ready := Bool(false)
+  io.debug.resp.valid := Bool(false)
 
-  val tests = Module(new UnitTestSuite)
+  val l1params = p.alterPartial({ case TLId => "L1toL2" })
+  val tests = Module(new UnitTestSuite()(l1params))
   when (tests.io.finished) { stop() }
 }

--- a/uncore/src/main/scala/converters/Nasti.scala
+++ b/uncore/src/main/scala/converters/Nasti.scala
@@ -108,7 +108,8 @@ class NastiIOTileLinkIOConverter(implicit p: Parameters) extends TLModule()(p)
     get_id_ready)
 
   val w_inflight = Reg(init = Bool(false))
-  val w_id = Reg(init = UInt(0, nastiXIdBits))
+  val w_id_reg = Reg(init = UInt(0, nastiXIdBits))
+  val w_id = Mux(w_inflight, w_id_reg, put_id_mapper.io.req.out_id)
 
   // For Put/PutBlock, make sure aw and w channel are both ready before
   // we send the first beat
@@ -191,7 +192,7 @@ class NastiIOTileLinkIOConverter(implicit p: Parameters) extends TLModule()(p)
 
   when (!w_inflight && io.tl.acquire.fire() && is_multibeat) {
     w_inflight := Bool(true)
-    w_id := put_id_mapper.io.req.out_id
+    w_id_reg := w_id
   }
 
   when (w_inflight) {

--- a/uncore/src/main/scala/tilelink/Definitions.scala
+++ b/uncore/src/main/scala/tilelink/Definitions.scala
@@ -399,6 +399,10 @@ object Acquire {
   }
 
   def fullWriteMask(implicit p: Parameters) = SInt(-1, width = p(TLKey(p(TLId))).writeMaskBits).asUInt
+  def fullOperandSize(implicit p: Parameters) = {
+    val dataBits = p(TLKey(p(TLId))).dataBitsPerBeat
+    UInt(log2Ceil(dataBits / 8))
+  }
 
   // Most generic constructor
   def apply(
@@ -477,6 +481,7 @@ object Get {
       client_xact_id = client_xact_id,
       addr_block = addr_block,
       addr_beat = addr_beat,
+      operand_size = Acquire.fullOperandSize,
       opcode = M_XRD,
       alloc = alloc)
   }
@@ -519,6 +524,7 @@ object GetBlock {
       a_type = Acquire.getBlockType,
       client_xact_id = client_xact_id, 
       addr_block = addr_block,
+      operand_size = Acquire.fullOperandSize,
       opcode = M_XRD,
       alloc = alloc)
   }

--- a/uncore/src/main/scala/tilelink/Interconnect.scala
+++ b/uncore/src/main/scala/tilelink/Interconnect.scala
@@ -276,7 +276,7 @@ class TileLinkRecursiveInterconnect(val nInner: Int, addrMap: AddrMap)
           xbarOut.acquire.ready := Bool(false)
           xbarOut.grant.valid := Bool(false)
           None
-        case submap: AddrMap =>
+        case submap: AddrMap if !submap.collapse =>
           val ic = Module(new TileLinkRecursiveInterconnect(1, submap))
           ic.io.in.head <> xbarOut
           ic.io.out

--- a/uncore/src/main/scala/unittests/Drivers.scala
+++ b/uncore/src/main/scala/unittests/Drivers.scala
@@ -313,18 +313,18 @@ class PutAtomicDriver(implicit p: Parameters) extends Driver()(p) {
     client_xact_id = UInt(0),
     addr_block = UInt(0),
     addr_beat = UInt(0),
-    // Put 15 in bytes 3:2
-    data = UInt(15 << 16),
-    wmask = Some(UInt(0x0c)))
+    // Put 15 in bytes 7:4
+    data = UInt(15L << 32),
+    wmask = Some(UInt(0xf0)))
 
   val amo_acquire = PutAtomic(
     client_xact_id = UInt(0),
     addr_block = UInt(0),
     addr_beat = UInt(0),
-    addr_byte = UInt(2),
+    addr_byte = UInt(4),
     atomic_opcode = M_XA_ADD,
-    operand_size = UInt(log2Ceil(16 / 8)),
-    data = UInt(3 << 16))
+    operand_size = UInt(log2Ceil(32 / 8)),
+    data = UInt(3L << 32))
 
   val get_acquire = Get(
     client_xact_id = UInt(0),
@@ -351,8 +351,8 @@ class PutAtomicDriver(implicit p: Parameters) extends Driver()(p) {
     when (state === s_get) { state := s_done }
   }
 
-  assert(!io.mem.grant.valid || !io.mem.grant.bits.hasData() ||
-         io.mem.grant.bits.data(31, 16) === UInt(18))
+  assert(!io.mem.grant.valid || state =/= s_get ||
+         io.mem.grant.bits.data(63, 32) === UInt(18))
 }
 
 class PrefetchDriver(implicit p: Parameters) extends Driver()(p) {


### PR DESCRIPTION
This commit refactors things so that the coreplex is a distinct module.

The tiles, L2 agents, and tilelink networks, and internal devices (PLIC, PRCI, BootROM, Debug) reside in the coreplex.

All converters, external-facing devices, and clock crossers now reside outside.