### PR TITLE
Add STOP_COND guard during simulation reset

### DIFF
--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -45,6 +45,7 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	+incdir+$(generated_dir) \
 	+define+CLOCK_PERIOD=0.5 $(sim_vsrcs) $(sim_csrcs) \
 	+define+PRINTF_COND=$(TB).printf_cond \
+	+define+STOP_COND=$(TB).stop_cond \
 	+define+RANDOMIZE \
 	+libext+.v \
 

--- a/vsrc/rocketTestHarness.v
+++ b/vsrc/rocketTestHarness.v
@@ -77,6 +77,7 @@ module rocketTestHarness;
   reg [1023:0] vcdfile = 0;
   reg          verbose = 0;
   wire         printf_cond = verbose && !reset;
+  wire         stop_cond = !reset;
   integer      stderr = 32'h80000002;
 
 `include `TBVFRAG


### PR DESCRIPTION
The generated verilog now includes a STOP_COND guard on conditions
that can cause the test to exit.  Enabling this flag during reset
prevents inadvertant exit due to spurious glitching near the start
of execution, before reset has had time to propagate everywhere.

I don't know how to add this in verilator, but presumably that
would be worth doing as well.