### PR TITLE
Allow coreplex to take in more than 1 bus port

### DIFF
--- a/coreplex/src/main/scala/Configs.scala
+++ b/coreplex/src/main/scala/Configs.scala
@@ -160,7 +160,7 @@ class BaseCoreplexConfig extends Config (
             else new MESICoherence(site(L2DirectoryRepresentation))),
           nManagers = site(NBanksPerMemoryChannel)*site(NMemoryChannels) + 1 /* MMIO */,
           nCachingClients = site(NCachedTileLinkPorts),
-          nCachelessClients = (if (site(ExportBusPort)) 1 else 0) + site(NUncachedTileLinkPorts),
+          nCachelessClients = site(NBusPorts) + site(NUncachedTileLinkPorts),
           maxClientXacts = max_int(
               // L1 cache
               site(NMSHRs) + 1 /* IOMSHR */,

--- a/coreplex/src/main/scala/Configs.scala
+++ b/coreplex/src/main/scala/Configs.scala
@@ -160,7 +160,7 @@ class BaseCoreplexConfig extends Config (
             else new MESICoherence(site(L2DirectoryRepresentation))),
           nManagers = site(NBanksPerMemoryChannel)*site(NMemoryChannels) + 1 /* MMIO */,
           nCachingClients = site(NCachedTileLinkPorts),
-          nCachelessClients = site(NBusPorts) + site(NUncachedTileLinkPorts),
+          nCachelessClients = site(NExternalClients) + site(NUncachedTileLinkPorts),
           maxClientXacts = max_int(
               // L1 cache
               site(NMSHRs) + 1 /* IOMSHR */,

--- a/coreplex/src/main/scala/DirectGroundTest.scala
+++ b/coreplex/src/main/scala/DirectGroundTest.scala
@@ -14,7 +14,7 @@ class DirectGroundTestCoreplex(topParams: Parameters) extends Coreplex()(topPara
   io.debug.resp.valid := Bool(false)
 
   require(!exportMMIO)
-  require(!exportBus)
+  require(nBusPorts == 0)
   require(nMemChannels == 1)
   require(nTiles == 1)
 

--- a/coreplex/src/main/scala/DirectGroundTest.scala
+++ b/coreplex/src/main/scala/DirectGroundTest.scala
@@ -14,7 +14,7 @@ class DirectGroundTestCoreplex(topParams: Parameters) extends Coreplex()(topPara
   io.debug.resp.valid := Bool(false)
 
   require(!exportMMIO)
-  require(nBusPorts == 0)
+  require(nExtClients == 0)
   require(nMemChannels == 1)
   require(nTiles == 1)
 

--- a/coreplex/src/main/scala/UnitTest.scala
+++ b/coreplex/src/main/scala/UnitTest.scala
@@ -8,7 +8,7 @@ import cde.Parameters
 
 class UnitTestCoreplex(topParams: Parameters) extends Coreplex()(topParams) {
   require(!exportMMIO)
-  require(!exportBus)
+  require(nBusPorts == 0)
   require(nMemChannels == 0)
 
   io.debug.req.ready := Bool(false)

--- a/coreplex/src/main/scala/UnitTest.scala
+++ b/coreplex/src/main/scala/UnitTest.scala
@@ -8,7 +8,7 @@ import cde.Parameters
 
 class UnitTestCoreplex(topParams: Parameters) extends Coreplex()(topParams) {
   require(!exportMMIO)
-  require(nBusPorts == 0)
+  require(nExtClients == 0)
   require(nMemChannels == 0)
 
   io.debug.req.ready := Bool(false)

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -132,7 +132,7 @@ class BasePlatformConfig extends Config (
       case ExportMMIOPort => (site(ExtraDevices).size + site(ExtMMIOPorts).size) > 0
       case AsyncBusChannels => false
       case NExtBusAXIChannels => 0
-      case NBusPorts => if (site(NExtBusAXIChannels) > 1) 1 else 0
+      case NExternalClients => if (site(NExtBusAXIChannels) > 1) 1 else 0
       case ConnectExtraPorts =>
         (out: Bundle, in: Bundle, p: Parameters) => out <> in
 

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -132,7 +132,7 @@ class BasePlatformConfig extends Config (
       case ExportMMIOPort => (site(ExtraDevices).size + site(ExtMMIOPorts).size) > 0
       case AsyncBusChannels => false
       case NExtBusAXIChannels => 0
-      case ExportBusPort => site(NExtBusAXIChannels) > 0
+      case NBusPorts => if (site(NExtBusAXIChannels) > 1) 1 else 0
       case ConnectExtraPorts =>
         (out: Bundle, in: Bundle, p: Parameters) => out <> in
 


### PR DESCRIPTION
In the coreplex refactoring, I only had one bus port (TileLink master) exported out of the coreplex. This was fine because we only had the AXI bus ports, and those could be collected with an AXI arbiter. But I now realize that we might want to add different kinds of bus masters. Instead of having to instantiate another TileLink arbiter in the top-level, it would be better just to extend the l1tol2 network.