### PR TITLE
Allow ExtraDevices to have client ports as well as MMIO ports

### DIFF
--- a/groundtest/src/main/scala/BusMasterTest.scala
+++ b/groundtest/src/main/scala/BusMasterTest.scala
@@ -1,0 +1,108 @@
+package groundtest
+
+import Chisel._
+import uncore.tilelink._
+import uncore.agents._
+import uncore.coherence.{InnerTLId, OuterTLId}
+import uncore.Util._
+import junctions.HasAddrMapParameters
+import cde.Parameters
+
+class ExampleBusMaster(implicit val p: Parameters) extends Module
+    with HasAddrMapParameters
+    with HasTileLinkParameters {
+  val mmioParams = p.alterPartial({ case TLId => p(InnerTLId) })
+  val memParams = p.alterPartial({ case TLId => p(OuterTLId) })
+  val memStart = addrMap("mem").start
+  val memStartBlock = memStart >> p(CacheBlockOffsetBits)
+
+  val io = new Bundle {
+    val mmio = new ClientUncachedTileLinkIO()(mmioParams).flip
+    val mem = new ClientUncachedTileLinkIO()(memParams)
+  }
+
+  val s_idle :: s_put :: s_resp :: Nil = Enum(Bits(), 3)
+  val state = Reg(init = s_idle)
+  val send_resp = Reg(init = Bool(false))
+  val r_acq = Reg(new AcquireMetadata)
+
+  io.mmio.acquire.ready := !send_resp
+  io.mmio.grant.valid := send_resp
+  io.mmio.grant.bits := Grant(
+    is_builtin_type = Bool(true),
+    g_type = r_acq.getBuiltInGrantType(),
+    client_xact_id = r_acq.client_xact_id,
+    manager_xact_id = UInt(0),
+    addr_beat = r_acq.addr_beat,
+    data = Mux(state === s_idle, UInt(0), UInt(1)))
+
+  when (io.mmio.acquire.fire()) {
+    send_resp := Bool(true)
+    r_acq := io.mmio.acquire.bits
+    when (state === s_idle && io.mmio.acquire.bits.hasData()) { state := s_put }
+  }
+  when (io.mmio.grant.fire()) { send_resp := Bool(false) }
+
+  val (put_beat, put_done) = Counter(io.mem.acquire.fire(), tlDataBeats)
+  when (put_done) { state := s_resp }
+  when (io.mem.grant.fire()) { state := s_idle }
+
+  io.mem.acquire.valid := state === s_put
+  io.mem.acquire.bits := PutBlock(
+    client_xact_id = UInt(0),
+    addr_block = UInt(memStartBlock),
+    addr_beat = put_beat,
+    data = put_beat)
+  io.mem.grant.ready := state === s_resp
+}
+
+class BusMasterTest(implicit p: Parameters) extends GroundTest()(p)
+    with HasTileLinkParameters {
+  val (s_idle :: s_req_start :: s_resp_start :: s_req_poll :: s_resp_poll ::
+       s_req_check :: s_resp_check :: s_done :: Nil) = Enum(Bits(), 8)
+  val state = Reg(init = s_idle)
+
+  val busMasterBlock = addrMap("io:ext:busmaster").start >> p(CacheBlockOffsetBits)
+  val start_acq = Put(
+    client_xact_id = UInt(0),
+    addr_block = UInt(busMasterBlock),
+    addr_beat = UInt(0),
+    data = UInt(1))
+  val poll_acq = Get(
+    client_xact_id = UInt(0),
+    addr_block = UInt(busMasterBlock),
+    addr_beat = UInt(0))
+  val check_acq = GetBlock(
+    client_xact_id = UInt(0),
+    addr_block = UInt(memStartBlock))
+
+  val acq = io.mem.head.acquire
+  val gnt = io.mem.head.grant
+
+  acq.valid := state.isOneOf(s_req_start, s_req_poll, s_req_check)
+  acq.bits := MuxLookup(state, check_acq, Seq(
+    s_req_start -> start_acq,
+    s_req_poll -> poll_acq))
+  gnt.ready := state.isOneOf(s_resp_start, s_resp_poll, s_resp_check)
+
+  val (get_beat, get_done) = Counter(
+    state === s_resp_check && gnt.valid, tlDataBeats)
+
+  when (state === s_idle) { state := s_req_start }
+  when (state === s_req_start && acq.ready) { state := s_resp_start }
+  when (state === s_resp_start && gnt.valid) { state := s_req_poll }
+  when (state === s_req_poll && acq.ready) { state := s_resp_poll }
+  when (state === s_resp_poll && gnt.valid) {
+    when (gnt.bits.data === UInt(0)) {
+      state := s_req_check
+    } .otherwise { state := s_req_poll }
+  }
+  when (state === s_req_check && acq.ready) { state := s_resp_check }
+  when (get_done) { state := s_done }
+
+  io.status.finished := state === s_done
+
+  assert(state =/= s_resp_check || !gnt.valid ||
+         gnt.bits.data === get_beat,
+         "BusMasterTest: data does not match")
+}

--- a/groundtest/src/main/scala/BusMasterTest.scala
+++ b/groundtest/src/main/scala/BusMasterTest.scala
@@ -8,6 +8,13 @@ import uncore.Util._
 import junctions.HasAddrMapParameters
 import cde.Parameters
 
+/**
+ * An example bus mastering devices that writes some preset data to memory.
+ * When it receives an MMIO put request, it starts writing out the data.
+ * When it receives an MMIO get request, it responds with the progress of
+ * the write. A grant data of 1 means it is still writing, grant data 0 
+ * means it has finished.
+ */
 class ExampleBusMaster(implicit val p: Parameters) extends Module
     with HasAddrMapParameters
     with HasTileLinkParameters {

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -263,16 +263,17 @@ class WithTestRAM extends Config(
     case ExtraDevices => {
       class TestRAMDevice extends Device {
         val ramSize = 0x1000
-        def builder(
-            sPort: Option[ClientUncachedTileLinkIO],
-            mPort: Option[ClientUncachedTileLinkIO],
-            extra: Bundle, p: Parameters) {
-          val testram = Module(new TileLinkTestRAM(ramSize)(p))
-          testram.io <> sPort.get
-        }
-        def addrMapEntry = AddrMapEntry("testram", MemSize(ramSize, MemAttr(AddrMapProt.RW)))
         def hasClientPort = false
         def hasMMIOPort = true
+        def builder(
+            mmioPort: Option[ClientUncachedTileLinkIO],
+            clientPort: Option[ClientUncachedTileLinkIO],
+            extra: Bundle, p: Parameters) {
+          val testram = Module(new TileLinkTestRAM(ramSize)(p))
+          testram.io <> mmioPort.get
+        }
+        override def addrMapEntry =
+          AddrMapEntry("testram", MemSize(ramSize, MemAttr(AddrMapProt.RW)))
       }
       Seq(new TestRAMDevice)
     }

--- a/src/main/scala/Devices.scala
+++ b/src/main/scala/Devices.scala
@@ -15,7 +15,8 @@ abstract class Device {
     mmioPort: Option[ClientUncachedTileLinkIO],
     clientPort: Option[ClientUncachedTileLinkIO],
     extra: Bundle, p: Parameters): Unit
-  def addrMapEntry: AddrMapEntry
+  def addrMapEntry: AddrMapEntry =
+    throw new UnsupportedOperationException("no addrMapEntry defined")
   def makeConfigString(region: MemRegion): String = {
     s"${addrMapEntry.name} {\n" +
     s"  addr 0x${region.start.toString(16)};\n" +

--- a/src/main/scala/Devices.scala
+++ b/src/main/scala/Devices.scala
@@ -9,7 +9,12 @@ case object ExtraTopPorts extends Field[Parameters => Bundle]
 case object ExtraDevices extends Field[Seq[Device]]
 
 abstract class Device {
-  def builder(port: ClientUncachedTileLinkIO, extra: Bundle, p: Parameters): Unit
+  def hasMMIOPort: Boolean
+  def hasClientPort: Boolean
+  def builder(
+    mmioPort: Option[ClientUncachedTileLinkIO],
+    clientPort: Option[ClientUncachedTileLinkIO],
+    extra: Bundle, p: Parameters): Unit
   def addrMapEntry: AddrMapEntry
   def makeConfigString(region: MemRegion): String = {
     s"${addrMapEntry.name} {\n" +

--- a/src/main/scala/Devices.scala
+++ b/src/main/scala/Devices.scala
@@ -9,14 +9,35 @@ case object ExtraTopPorts extends Field[Parameters => Bundle]
 case object ExtraDevices extends Field[Seq[Device]]
 
 abstract class Device {
+  /** Does this device have an MMIO port? */
   def hasMMIOPort: Boolean
+  /** Does this device have a client port? */
   def hasClientPort: Boolean
+  /**
+   * This function elaborates the hardware for the device and connects
+   * it to the mmio port, client port, and extra top-level ports.
+   *
+   * @param mmioPort The port from the MMIO network that goes to this device.
+   *  If hasMMIOPort is false, this will be None
+   *
+   * @param clientPort The client port provided for this device to make
+   *  requests to the memory system. If hasClientPort is false, this will be None
+   */
   def builder(
     mmioPort: Option[ClientUncachedTileLinkIO],
     clientPort: Option[ClientUncachedTileLinkIO],
     extra: Bundle, p: Parameters): Unit
+  /**
+   * The entry that will be placed into the address map for this device.
+   * If hasMMIOPort is false, you do not need to override this
+   */
   def addrMapEntry: AddrMapEntry =
     throw new UnsupportedOperationException("no addrMapEntry defined")
+
+  /**
+   * Create the config string entry for this device that goes into the
+   * Boot ROM. You generally won't need to override this
+   */
   def makeConfigString(region: MemRegion): String = {
     s"${addrMapEntry.name} {\n" +
     s"  addr 0x${region.start.toString(16)};\n" +

--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -242,8 +242,8 @@ class Periphery(implicit val p: Parameters) extends Module
       } else None
 
       val buildParams = p.alterPartial({
-        case InnerTLId => "L2toMMIO"
-        case OuterTLId => "L1toL2"
+        case InnerTLId => "L2toMMIO" // Device MMIO port
+        case OuterTLId => "L1toL2"   // Device client port
       })
 
       device.builder(mmioPort, clientPort, io.extra, buildParams)

--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -9,6 +9,7 @@ import uncore.tilelink._
 import uncore.devices._
 import uncore.util._
 import uncore.converters._
+import uncore.coherence.{InnerTLId, OuterTLId}
 import rocket._
 import coreplex._
 
@@ -240,7 +241,12 @@ class Periphery(implicit val p: Parameters) extends Module
         Some(io.clients_out(client_ind - 1))
       } else None
 
-      device.builder(mmioPort, clientPort, io.extra, p)
+      val buildParams = p.alterPartial({
+        case InnerTLId => "L2toMMIO"
+        case OuterTLId => "L1toL2"
+      })
+
+      device.builder(mmioPort, clientPort, io.extra, buildParams)
     }
 
     val ext = p(ExtMMIOPorts).map(


### PR DESCRIPTION
Before, we assumed that extra devices in the periphery would only need MMIO ports (i.e. acting as a slave talking to extra IO). But now I realize they might also need to have client ports in order to do any kind of DMA. This gives the devices an optional client port (the MMIO port is also made optional) to give the implementation more flexibility.