### PR TITLE
connect top level interrupts to coreplex

### DIFF
--- a/src/main/scala/RocketChip.scala
+++ b/src/main/scala/RocketChip.scala
@@ -171,6 +171,8 @@ class Top(topParams: Parameters) extends Module with HasTopLevelParameters {
       asyncAxiFrom(io.bus_clk.get, io.bus_rst.get, io.bus_axi)
     else io.bus_axi)
 
+  coreplex.io.interrupts <> io.interrupts
+
   io.extra <> periphery.io.extra
   p(ConnectExtraPorts)(io.extra, coreplex.io.extra, p)
 }


### PR DESCRIPTION
seems like a simple omission as it is connected to by both the test harness and the coreplex itself