### PR TITLE
Clean up our use of UIntIsOneOf

### DIFF
--- a/groundtest/src/main/scala/BusMasterTest.scala
+++ b/groundtest/src/main/scala/BusMasterTest.scala
@@ -4,7 +4,7 @@ import Chisel._
 import uncore.tilelink._
 import uncore.agents._
 import uncore.coherence.{InnerTLId, OuterTLId}
-import uncore.Util._
+import uncore.util._
 import junctions.HasAddrMapParameters
 import cde.Parameters
 

--- a/groundtest/src/main/scala/CacheFillTest.scala
+++ b/groundtest/src/main/scala/CacheFillTest.scala
@@ -4,6 +4,7 @@ import Chisel._
 import uncore.tilelink._
 import uncore.constants._
 import uncore.agents._
+import uncore.util._
 import cde.{Parameters, Field}
 
 class CacheFillTest(implicit p: Parameters) extends GroundTest()(p)
@@ -13,7 +14,7 @@ class CacheFillTest(implicit p: Parameters) extends GroundTest()(p)
   val s_start :: s_prefetch :: s_retrieve :: s_finished :: Nil = Enum(Bits(), 4)
   val state = Reg(init = s_start)
 
-  val active = state === s_prefetch || state === s_retrieve
+  val active = state.isOneOf(s_prefetch, s_retrieve)
 
   val xact_pending = Reg(init = UInt(0, tlMaxClientXacts))
   val xact_id = PriorityEncoder(~xact_pending)

--- a/rocket/src/main/scala/btb.scala
+++ b/rocket/src/main/scala/btb.scala
@@ -6,6 +6,7 @@ import Chisel._
 import junctions._
 import cde.{Parameters, Field}
 import Util._
+import uncore.util._
 
 case object BtbKey extends Field[BtbParameters]
 

--- a/rocket/src/main/scala/csr.scala
+++ b/rocket/src/main/scala/csr.scala
@@ -349,7 +349,7 @@ class CSRFile(implicit p: Parameters) extends CoreModule()(p)
   val cpu_wen = cpu_ren && io.rw.cmd =/= CSR.R && priv_sufficient
   val wen = cpu_wen && !read_only
 
-  val wdata = (Mux((io.rw.cmd === CSR.S || io.rw.cmd === CSR.C), io.rw.rdata, UInt(0)) |
+  val wdata = (Mux(io.rw.cmd.isOneOf(CSR.S, CSR.C), io.rw.rdata, UInt(0)) |
                Mux(io.rw.cmd =/= CSR.C, io.rw.wdata, UInt(0))) &
               ~Mux(io.rw.cmd === CSR.C, io.rw.wdata, UInt(0))
 

--- a/rocket/src/main/scala/csr.scala
+++ b/rocket/src/main/scala/csr.scala
@@ -7,6 +7,7 @@ import Util._
 import Instructions._
 import cde.{Parameters, Field}
 import uncore.devices._
+import uncore.util._
 import junctions.AddrMap
 
 class MStatus extends Bundle {

--- a/rocket/src/main/scala/fpu.scala
+++ b/rocket/src/main/scala/fpu.scala
@@ -7,6 +7,7 @@ import Instructions._
 import Util._
 import FPConstants._
 import uncore.constants.MemoryOpConstants._
+import uncore.util._
 import cde.{Parameters, Field}
 
 case object SFMALatency extends Field[Int]

--- a/rocket/src/main/scala/ptw.scala
+++ b/rocket/src/main/scala/ptw.scala
@@ -130,7 +130,7 @@ class PTW(n: Int)(implicit p: Parameters) extends CoreModule()(p) {
   pte_wdata.a := true
   pte_wdata.d := r_req.store
   
-  io.mem.req.valid     := state === s_req || state === s_set_dirty
+  io.mem.req.valid     := state.isOneOf(s_req, s_set_dirty)
   io.mem.req.bits.phys := Bool(true)
   io.mem.req.bits.cmd  := Mux(state === s_set_dirty, M_XA_OR, M_XRD)
   io.mem.req.bits.typ  := log2Ceil(xLen/8)

--- a/rocket/src/main/scala/ptw.scala
+++ b/rocket/src/main/scala/ptw.scala
@@ -6,6 +6,7 @@ import Chisel._
 import uncore.agents._
 import uncore.constants._
 import Util._
+import uncore.util._
 import cde.{Parameters, Field}
 
 class PTWReq(implicit p: Parameters) extends CoreBundle()(p) {

--- a/rocket/src/main/scala/rvc.scala
+++ b/rocket/src/main/scala/rvc.scala
@@ -4,6 +4,7 @@ import Chisel._
 import Chisel.ImplicitConversions._
 import Util._
 import cde.Parameters
+import uncore.util._
 
 class ExpandedInstruction extends Bundle {
   val bits = UInt(width = 32)

--- a/rocket/src/main/scala/tlb.scala
+++ b/rocket/src/main/scala/tlb.scala
@@ -9,6 +9,7 @@ import scala.math._
 import cde.{Parameters, Field}
 import uncore.agents.PseudoLRU
 import uncore.coherence._
+import uncore.util._
 
 case object NTLBEntries extends Field[Int]
 

--- a/rocket/src/main/scala/util.scala
+++ b/rocket/src/main/scala/util.scala
@@ -3,7 +3,7 @@
 package rocket
 
 import Chisel._
-import uncore._
+import uncore.util._
 import scala.math._
 import cde.{Parameters, Field}
 
@@ -28,26 +28,6 @@ object Util {
 
   implicit def booleanToIntConv(x: Boolean) = new AnyRef {
     def toInt: Int = if (x) 1 else 0
-  }
-
-  implicit class SeqToAugmentedSeq[T <: Data](val x: Seq[T]) extends AnyVal {
-    def apply(idx: UInt): T = {
-      if (x.size == 1) {
-        x.head
-      } else {
-        val half = 1 << (log2Ceil(x.size) - 1)
-        val newIdx = idx & (half - 1)
-        Mux(idx >= UInt(half), x.drop(half)(newIdx), x.take(half)(newIdx))
-      }
-    }
-
-    def asUInt(): UInt = Cat(x.map(_.asUInt).reverse)
-  }
-
-  implicit class UIntIsOneOf(val x: UInt) extends AnyVal {
-    def isOneOf(s: Seq[UInt]): Bool = s.map(x === _).reduce(_||_)
-
-    def isOneOf(u1: UInt, u2: UInt*): Bool = isOneOf(u1 +: u2.toSeq)
   }
 }
 

--- a/uncore/src/main/scala/agents/Agents.scala
+++ b/uncore/src/main/scala/agents/Agents.scala
@@ -8,7 +8,7 @@ import junctions._
 import uncore.tilelink._
 import uncore.converters._
 import uncore.coherence._
-import uncore.Util._
+import uncore.util._
 
 case object NReleaseTransactors extends Field[Int]
 case object NProbeTransactors extends Field[Int]

--- a/uncore/src/main/scala/agents/Broadcast.scala
+++ b/uncore/src/main/scala/agents/Broadcast.scala
@@ -6,7 +6,7 @@ import Chisel._
 import uncore.coherence._
 import uncore.tilelink._
 import uncore.constants._
-import uncore.Util._
+import uncore.util._
 import cde.Parameters
 
 class L2BroadcastHub(implicit p: Parameters) extends HierarchicalCoherenceAgent()(p) {

--- a/uncore/src/main/scala/agents/Cache.scala
+++ b/uncore/src/main/scala/agents/Cache.scala
@@ -9,7 +9,7 @@ import uncore.util.AMOALU
 import uncore.coherence._
 import uncore.tilelink._
 import uncore.constants._
-import uncore.Util._
+import uncore.util._
 import cde.{Parameters, Field}
 
 case object CacheName extends Field[String]

--- a/uncore/src/main/scala/agents/Ecc.scala
+++ b/uncore/src/main/scala/agents/Ecc.scala
@@ -3,7 +3,7 @@
 package uncore.agents
 
 import Chisel._
-import uncore.Util._
+import uncore.util._
 
 abstract class Decoding
 {

--- a/uncore/src/main/scala/agents/Trackers.scala
+++ b/uncore/src/main/scala/agents/Trackers.scala
@@ -6,7 +6,7 @@ import Chisel._
 import uncore.coherence._
 import uncore.tilelink._
 import uncore.util._
-import uncore.Util._
+import uncore.util._
 import junctions._
 import cde.{Field, Parameters}
 import scala.math.max

--- a/uncore/src/main/scala/coherence/Policies.scala
+++ b/uncore/src/main/scala/coherence/Policies.scala
@@ -5,7 +5,7 @@ package uncore.coherence
 import Chisel._
 import uncore.tilelink._
 import uncore.constants._
-import uncore.Util._
+import uncore.util._
 
 /** The entire CoherencePolicy API consists of the following three traits:
   * HasCustomTileLinkMessageTypes, used to define custom messages

--- a/uncore/src/main/scala/devices/Bram.scala
+++ b/uncore/src/main/scala/devices/Bram.scala
@@ -74,7 +74,7 @@ class HastiRAM(depth: Int)(implicit p: Parameters) extends HastiModule()(p) {
     (0 until max_size).map(sz => (UInt(sz) -> UInt((1 << (1 << sz)) - 1))))
   val wmask = (wmask_lut << waddr(max_size - 1, 0))(hastiDataBytes - 1, 0)
 
-  val is_trans = io.hsel && (io.htrans === HTRANS_NONSEQ || io.htrans === HTRANS_SEQ)
+  val is_trans = io.hsel && io.htrans.isOneOf(HTRANS_NONSEQ, HTRANS_SEQ)
   val raddr = io.haddr >> UInt(max_size)
   val ren = is_trans && !io.hwrite
   val bypass = Reg(init = Bool(false))

--- a/uncore/src/main/scala/devices/Debug.scala
+++ b/uncore/src/main/scala/devices/Debug.scala
@@ -4,6 +4,7 @@ package uncore.devices
 
 import Chisel._
 import uncore.tilelink._
+import uncore.util._
 import junctions._
 import cde.{Parameters, Config, Field}
 
@@ -901,7 +902,7 @@ class DebugModule ()(implicit val p:cde.Parameters)
   when (sbAddr(11, 8) === UInt(4)) {                                 //0x400-0x4FF Debug RAM
     sbRdData  := sbRamRdData
     sbRamRdEn := sbRdEn
-  }.elsewhen (sbAddr(11,8) === UInt(8) || sbAddr(11,8) === UInt(9)){ //0x800-0x9FF Debug ROM
+  }.elsewhen (sbAddr(11,8).isOneOf(UInt(8), UInt(9))){ //0x800-0x9FF Debug ROM
     if (cfg.hasDebugRom) {
       sbRdData := sbRomRdData
     } else {

--- a/uncore/src/main/scala/tilelink/Definitions.scala
+++ b/uncore/src/main/scala/tilelink/Definitions.scala
@@ -4,7 +4,7 @@ package uncore.tilelink
 import Chisel._
 import junctions._
 import uncore.coherence.CoherencePolicy
-import uncore.Util._
+import uncore.util._
 import scala.math.max
 import uncore.constants._
 import cde.{Parameters, Field}

--- a/uncore/src/main/scala/util/Package.scala
+++ b/uncore/src/main/scala/util/Package.scala
@@ -2,7 +2,7 @@ package uncore
 
 import Chisel._
 
-package object Util {
+package object util {
   implicit class UIntIsOneOf(val x: UInt) extends AnyVal {
     def isOneOf(s: Seq[UInt]): Bool = s.map(x === _).reduce(_||_)
   


### PR DESCRIPTION
I got a bit annoyed at how the UIntIsOneOf and AugmentedSeq implicits were duplicated in rocket and uncore. Also how there was both a uncore.Util and uncore.util package.

This merges the two packages together and gets rid of the repeated definition in rocket.

I also replaced everywhere we use (state === for) || (state === bar) ... This touches a lot of files, so the diff is a bit large.