### PR TITLE
More accurate conditional include of generated .d make fragment

### DIFF
--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -35,7 +35,7 @@ test:
 # Run assembly tests and benchmarks
 #--------------------------------------------------------------------
 
-ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(filter run% %.run %.out %.vpd %.vcd,$(MAKECMDGOALS)),)
 -include $(generated_dir)/$(MODEL).$(CONFIG).d
 endif
 

--- a/vsim/Makefile
+++ b/vsim/Makefile
@@ -21,7 +21,7 @@ TB ?= TestDriver
 
 include $(base_dir)/Makefrag
 include $(sim_dir)/Makefrag
-ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(filter run% %.run %.out %.vpd %.vcd,$(MAKECMDGOALS)),)
 -include $(generated_dir)/$(MODEL).$(CONFIG).d
 endif
 include $(base_dir)/vsim/Makefrag-verilog


### PR DESCRIPTION
The make infrastructure has historically been rather trigger-happy because it nearly always attempted to include the generated .d file, making just about everything effectively depend on Chisel execution.  This led to some unwanted behavior, e.g., Chisel would run even when you used `make -n`.

This fixes the problem by included the .d file only when it's actually needed to define the simulation targets.