### PR TITLE
Remove openocd from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "firrtl"]
 	path = firrtl
 	url = https://github.com/ucb-bar/firrtl.git
-[submodule "openocd"]
-	path = openocd
-	url = http://github.com/sifive/openocd.git


### PR DESCRIPTION
I don't believe we actually want to include openocd as a submodule. I had added commands to install it as part of the regression.

@aswaterman correct?