### PR TITLE
Allow some External Interrupts to come from Periphery

### DIFF
--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -115,7 +115,10 @@ class BasePlatformConfig extends Config (
           idBits = Dump("MEM_ID_BITS", site(MIFTagBits)))
       }
       case BuildCoreplex => (p: Parameters) => Module(new DefaultCoreplex(p))
-      case NExtInterrupts => 2
+      case NExtTopInterrupts => 2
+      case NExtPeripheryInterrupts => 0
+      // Note that PLIC asserts that this is > 0.
+      case NExtInterrupts => site(NExtTopInterrupts) + site(NExtPeripheryInterrupts)
       case AsyncDebugBus => false
       case IncludeJtagDTM => false
       case AsyncMMIOChannels => false
@@ -260,11 +263,13 @@ class WithTestRAM extends Config(
         def addrMapEntries = Seq(
           AddrMapEntry("testram", MemSize(ramSize, MemAttr(AddrMapProt.RW))))
         def builder(
-            mmioPorts: HashMap[String, ClientUncachedTileLinkIO],
-            clientPorts: Seq[ClientUncachedTileLinkIO],
-            extra: Bundle, p: Parameters) {
+          mmioPorts: HashMap[String, ClientUncachedTileLinkIO],
+          clientPorts: Seq[ClientUncachedTileLinkIO],
+          interrupts: Seq[Bool],
+          extra: Bundle, p: Parameters) {
           val testram = Module(new TileLinkTestRAM(ramSize)(p))
           testram.io <> mmioPorts("testram")
+          interrupts.foreach(x => x := Bool(false))
         }
       }
       new TestRAMDevice

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -116,7 +116,7 @@ class BasePlatformConfig extends Config (
       }
       case BuildCoreplex => (p: Parameters) => Module(new DefaultCoreplex(p))
       case NExtTopInterrupts => 2
-      case NExtPeripheryInterrupts => 0
+      case NExtPeripheryInterrupts => site(ExtraDevices).nInterrupts
       // Note that PLIC asserts that this is > 0.
       case NExtInterrupts => site(NExtTopInterrupts) + site(NExtPeripheryInterrupts)
       case AsyncDebugBus => false
@@ -269,7 +269,6 @@ class WithTestRAM extends Config(
           extra: Bundle, p: Parameters) {
           val testram = Module(new TileLinkTestRAM(ramSize)(p))
           testram.io <> mmioPorts("testram")
-          interrupts.foreach(x => x := Bool(false))
         }
       }
       new TestRAMDevice

--- a/src/main/scala/rocketchip/Devices.scala
+++ b/src/main/scala/rocketchip/Devices.scala
@@ -14,6 +14,10 @@ abstract class DeviceBlock {
   def nClientPorts: Int
   /** Address map entries for all of the devices */
   def addrMapEntries: Seq[AddrMapEntry]
+  /**
+   * The total number of interrupt signals coming 
+   *  from all the devices                       */
+  def nInterrupts : Int = 0
 
   /**
    * The function that elaborates all the extra devices and connects them
@@ -48,6 +52,8 @@ abstract class DeviceBlock {
        "}\n"
     }.mkString
   }
+
+
 }
 
 class EmptyDeviceBlock extends DeviceBlock {

--- a/src/main/scala/rocketchip/Devices.scala
+++ b/src/main/scala/rocketchip/Devices.scala
@@ -23,12 +23,14 @@ abstract class DeviceBlock {
    *    Use the names specified in addrMapEntries to get
    *    the mmio port for each device.
    * @param clientPorts All the client ports available for the devices
+   * @param interrupts External interrupts from Periphery to Coreplex 
    * @param extra The extra top-level IO bundle
    * @param p The CDE parameters for the devices
    */
   def builder(
     mmioPorts: HashMap[String, ClientUncachedTileLinkIO],
     clientPorts: Seq[ClientUncachedTileLinkIO],
+    interrupts : Seq[Bool],
     extra: Bundle, p: Parameters): Unit
 
   /**
@@ -53,7 +55,8 @@ class EmptyDeviceBlock extends DeviceBlock {
   def addrMapEntries = Seq.empty
 
   def builder(
-      mmioPorts: HashMap[String, ClientUncachedTileLinkIO],
-      clientPorts: Seq[ClientUncachedTileLinkIO],
-      extra: Bundle, p: Parameters) {}
+    mmioPorts: HashMap[String, ClientUncachedTileLinkIO],
+    clientPorts: Seq[ClientUncachedTileLinkIO],
+    interrupts : Seq[Bool], 
+    extra: Bundle, p: Parameters) {}
 }

--- a/src/main/scala/rocketchip/TestConfigs.scala
+++ b/src/main/scala/rocketchip/TestConfigs.scala
@@ -196,7 +196,6 @@ class WithBusMasterTest extends Config(
           val busmaster = Module(new ExampleBusMaster()(p))
           busmaster.io.mmio <> mmioPorts("busmaster")
           clientPorts.head <> busmaster.io.mem
-          interrupts.foreach(x => x := Bool(false))
         }
       }
       new BusMasterDevice

--- a/src/main/scala/rocketchip/TestConfigs.scala
+++ b/src/main/scala/rocketchip/TestConfigs.scala
@@ -189,12 +189,14 @@ class WithBusMasterTest extends Config(
         def addrMapEntries = Seq(
           AddrMapEntry("busmaster", MemSize(4096, MemAttr(AddrMapProt.RW))))
         def builder(
-            mmioPorts: HashMap[String, ClientUncachedTileLinkIO],
-            clientPorts: Seq[ClientUncachedTileLinkIO],
-            extra: Bundle, p: Parameters) {
+          mmioPorts: HashMap[String, ClientUncachedTileLinkIO],
+          clientPorts: Seq[ClientUncachedTileLinkIO],
+          interrupts : Seq[Bool], 
+          extra: Bundle, p: Parameters) {
           val busmaster = Module(new ExampleBusMaster()(p))
           busmaster.io.mmio <> mmioPorts("busmaster")
           clientPorts.head <> busmaster.io.mem
+          interrupts.foreach(x => x := Bool(false))
         }
       }
       new BusMasterDevice


### PR DESCRIPTION
This addresses Issue #219  -- the NExtInterrupts parameter is now divided into NExtTopInterrupts (which actually come out of Top) and NExtPeripheryInterrupts (which actually come out of Periphery). The Periphery interrupts are at the lower bits (which may have some ramifications for priority)