### PR TITLE
Do not randomize disconnected outputs

### DIFF
--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -48,7 +48,10 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	+define+CLOCK_PERIOD=1.0 $(sim_vsrcs) $(sim_csrcs) \
 	+define+PRINTF_COND=$(TB).printf_cond \
 	+define+STOP_COND=!$(TB).reset \
-	+define+RANDOMIZE \
+	+define+RANDOMIZE_MEM_INIT \
+	+define+RANDOMIZE_REG_INIT \
+	+define+RANDOMIZE_GARBAGE_ASSIGN \
+	#+define+RANDOMIZE_INVALID_ASSIGN \
 	+libext+.v \
 
 VCS_OPTS += +vpi


### PR DESCRIPTION
Following FIRRTL PR [252](https://github.com/ucb-bar/firrtl/pull/252), we should turn off randomization of disconnected wires in the simulator.

For one thing, this makes it difficult to find accidentally disconnected wires in RTL simulation. For another, it is not always safe to assume that an undriven net will have a sensible value in actual hardware.

Registers and memories are still given random initialization, since they will get some initial value on power on in the actual circuit.

There's an additional commit to make sure the rocket pipeline stages are clean on reset. Currently there is a remote possibility that an erroneous dcache write will be sent out and committed to memory.