### PR TITLE
Get in line with FIRRTL randomization flag changes

### DIFF
--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -48,7 +48,10 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	+define+CLOCK_PERIOD=1.0 $(sim_vsrcs) $(sim_csrcs) \
 	+define+PRINTF_COND=$(TB).printf_cond \
 	+define+STOP_COND=!$(TB).reset \
-	+define+RANDOMIZE \
+	+define+RANDOMIZE_MEM_INIT \
+	+define+RANDOMIZE_REG_INIT \
+	+define+RANDOMIZE_GARBAGE_ASSIGN \
+	+define+RANDOMIZE_INVALID_ASSIGN \
 	+libext+.v \
 
 VCS_OPTS += +vpi


### PR DESCRIPTION
Basically the same as the previous PR that got dropped, except this turns on all the randomization options by default. Necessary to get up to date with the latest FIRRTL changes.