### PR TITLE
Backport some changes from DMA branch

### DIFF
--- a/src/main/scala/groundtest/Tile.scala
+++ b/src/main/scala/groundtest/Tile.scala
@@ -69,6 +69,11 @@ class DummyPTW(n: Int)(implicit p: Parameters) extends CoreModule()(p) {
     requestor.resp.bits := s2_resp
     requestor.status.vm := UInt("b01000")
     requestor.status.prv := UInt(PRV.S)
+    requestor.status.debug := Bool(false)
+    requestor.status.mprv  := Bool(true)
+    requestor.status.mpp := UInt(0)
+    requestor.ptbr.asid := UInt(0)
+    requestor.ptbr.ppn := UInt(0)
     requestor.invalidate := Bool(false)
   }
 }

--- a/src/main/scala/rocket/nbdcache.scala
+++ b/src/main/scala/rocket/nbdcache.scala
@@ -1221,7 +1221,6 @@ class SimpleHellaCacheIF(implicit p: Parameters) extends Module
 
   io.cache.invalidate_lr := io.requestor.invalidate_lr
   io.cache.req <> req_arb.io.out
-  io.cache.req.bits.phys := Bool(true)
   io.cache.s1_kill := io.cache.s2_nack
   io.cache.s1_data := RegEnable(req_arb.io.out.bits.data, s0_req_fire)
 

--- a/src/main/scala/rocket/rocc.scala
+++ b/src/main/scala/rocket/rocc.scala
@@ -121,7 +121,6 @@ class AccumulatorExample(n: Int = 4)(implicit p: Parameters) extends RoCC()(p) {
   io.mem.req.bits.cmd := M_XRD // perform a load (M_XWR for stores)
   io.mem.req.bits.typ := MT_D // D = 8 bytes, W = 4, H = 2, B = 1
   io.mem.req.bits.data := Bits(0) // we're not performing any stores...
-  io.mem.invalidate_lr := false
 
   io.autl.acquire.valid := false
   io.autl.grant.ready := false
@@ -168,7 +167,6 @@ class TranslatorExample(implicit p: Parameters) extends RoCC()(p) {
   io.busy := (state =/= s_idle)
   io.interrupt := Bool(false)
   io.mem.req.valid := Bool(false)
-  io.mem.invalidate_lr := Bool(false)
   io.autl.acquire.valid := Bool(false)
   io.autl.grant.ready := Bool(false)
 }
@@ -250,7 +248,6 @@ class CharacterCountExample(implicit p: Parameters) extends RoCC()(p)
   io.busy := (state =/= s_idle)
   io.interrupt := Bool(false)
   io.mem.req.valid := Bool(false)
-  io.mem.invalidate_lr := Bool(false)
 }
 
 class OpcodeSet(val opcodes: Seq[UInt]) {

--- a/src/main/scala/rocket/rocc.scala
+++ b/src/main/scala/rocket/rocc.scala
@@ -58,6 +58,7 @@ class RoCCInterface(implicit p: Parameters) extends CoreBundle()(p) {
 abstract class RoCC(implicit p: Parameters) extends CoreModule()(p) {
   val io = new RoCCInterface
   io.mem.req.bits.phys := Bool(true) // don't perform address translation
+  io.mem.invalidate_lr := Bool(false) // don't mess with LR/SC
 }
 
 class AccumulatorExample(n: Int = 4)(implicit p: Parameters) extends RoCC()(p) {


### PR DESCRIPTION
This cherry-picks some bugfix commits from my new dma branch. The main changes are

* Fix the DecoupledTLB so that it actually handles misses correctly
* Fix DummyPTW to set the new status and ptbr fields that the TLB depends on
* Don't override the setting of req.bits.phys in the SimpleHellaCacheIF
* Tie invalidate_lr to false by default in RoCC accelerator