### PR TITLE
Allow configuration to be in separate project from test harness

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -5,6 +5,7 @@ endif
 
 MODEL ?= TestHarness
 PROJECT := rocketchip
+CFG_PROJECT := $(PROJECT)
 CXX ?= g++
 CXXFLAGS := -O1
 

--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -11,11 +11,11 @@ verilog_debug = $(generated_dir_debug)/$(MODEL).$(CONFIG).v
 
 $(generated_dir)/%.$(CONFIG).fir $(generated_dir)/%.$(CONFIG).prm $(generated_dir)/%.$(CONFIG).d: $(chisel_srcs) $(bootrom_img)
 	mkdir -p $(dir $@)
-	cd $(base_dir) && $(SBT) "run $(generated_dir) $(PROJECT) $(MODEL) $(PROJECT) $(CONFIG)"
+	cd $(base_dir) && $(SBT) "run $(generated_dir) $(PROJECT) $(MODEL) $(CFG_PROJECT) $(CONFIG)"
 
 $(generated_dir_debug)/%.$(CONFIG).fir $(generated_dir_debug)/%.$(CONFIG).prm $(generated_dir_debug)/%.$(CONFIG).d: $(chisel_srcs) $(bootrom_img)
 	mkdir -p $(dir $@)
-	cd $(base_dir) && $(SBT) "run $(generated_dir_debug) $(PROJECT) $(MODEL) $(PROJECT) $(CONFIG)"
+	cd $(base_dir) && $(SBT) "run $(generated_dir_debug) $(PROJECT) $(MODEL) $(CFG_PROJECT) $(CONFIG)"
 
 %.v: %.fir $(FIRRTL_JAR)
 	mkdir -p $(dir $@)

--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -7,7 +7,7 @@
 
 $(generated_dir)/%.$(CONFIG).fir $(generated_dir)/%.$(CONFIG).d $(generated_dir)/%.prm: $(chisel_srcs) $(bootrom_img)
 	mkdir -p $(dir $@)
-	cd $(base_dir) && $(SBT) "run $(generated_dir) $(PROJECT) $(notdir $*) $(PROJECT) $(CONFIG)"
+	cd $(base_dir) && $(SBT) "run $(generated_dir) $(PROJECT) $(notdir $*) $(CFG_PROJECT) $(CONFIG)"
 
 $(generated_dir)/%.v: $(generated_dir)/%.fir $(FIRRTL_JAR)
 	mkdir -p $(dir $@)


### PR DESCRIPTION
It may be the case that you want the configuration project to be different from the test harness project. This change allows that to happen by specifying a separate variable CFG_PROJECT, which is by default the same as PROJECT.