### PR TITLE
Move RTC

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -128,7 +128,6 @@ class BaseCoreplexConfig extends Config (
       case MtvecInit => BigInt(0x1010)
       case MtvecWritable => true
       //Uncore Paramters
-      case RTCPeriod => 100 // gives 10 MHz RTC assuming 1 GHz uncore clock
       case LNEndpoints => site(TLKey(site(TLId))).nManagers + site(TLKey(site(TLId))).nClients
       case LNHeaderBits => log2Ceil(site(TLKey(site(TLId))).nManagers) +
                              log2Up(site(TLKey(site(TLId))).nClients)

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -154,7 +154,7 @@ class BasePlatformConfig extends Config (
       case ConfigString => makeConfigString()
       case GlobalAddrMap => globalAddrMap
       case RTCPeriod => 100 // gives 10 MHz RTC assuming 1 GHz uncore clock
-      case RTC => (p: Parameters, t_io: Bundle, p_io:Bundle) => Counter(p(RTCPeriod)).inc() 
+      case RTCTick => (p: Parameters, t_io: Bundle, p_io:Bundle) => Counter(p(RTCPeriod)).inc() 
       case _ => throw new CDEMatchError
   }})
 

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -153,6 +153,8 @@ class BasePlatformConfig extends Config (
       case ExtMemSize => Dump("MEM_SIZE", 0x10000000L)
       case ConfigString => makeConfigString()
       case GlobalAddrMap => globalAddrMap
+      case RTCPeriod => 100 // gives 10 MHz RTC assuming 1 GHz uncore clock
+      case RTC => (p: Parameters, t_io: Bundle, p_io:Bundle) => Counter(p(RTCPeriod)).inc() 
       case _ => throw new CDEMatchError
   }})
 

--- a/src/main/scala/rocketchip/RocketChip.scala
+++ b/src/main/scala/rocketchip/RocketChip.scala
@@ -53,6 +53,10 @@ case object ExtMemSize extends Field[Long]
   **/
 case object NExtTopInterrupts extends Field[Int]
 case object NExtPeripheryInterrupts extends Field[Int]
+/** Source of  RTC. First bundle is TopIO.extra, Second bundle is periphery.io.extra  **/
+case object RTC extends Field[(Parameters, Bundle, Bundle) => Bool]
+case object RTCPeriod extends Field[Int]
+
 
 /** Utility trait for quick access to some relevant parameters */
 trait HasTopLevelParameters {
@@ -194,7 +198,11 @@ class Top(topParams: Parameters) extends Module with HasTopLevelParameters {
   coreplex.io.interrupts <> (periphery.io.interrupts ++ io.interrupts)
 
   io.extra <> periphery.io.extra
+
+  coreplex.io.rtcTick := p(RTC)(p, io.extra, periphery.io.extra)
+
   p(ConnectExtraPorts)(io.extra, coreplex.io.extra, p)
+
 }
 
 class Periphery(implicit val p: Parameters) extends Module

--- a/src/main/scala/rocketchip/RocketChip.scala
+++ b/src/main/scala/rocketchip/RocketChip.scala
@@ -54,7 +54,7 @@ case object ExtMemSize extends Field[Long]
 case object NExtTopInterrupts extends Field[Int]
 case object NExtPeripheryInterrupts extends Field[Int]
 /** Source of  RTC. First bundle is TopIO.extra, Second bundle is periphery.io.extra  **/
-case object RTC extends Field[(Parameters, Bundle, Bundle) => Bool]
+case object RTCTick extends Field[(Parameters, Bundle, Bundle) => Bool]
 case object RTCPeriod extends Field[Int]
 
 
@@ -199,11 +199,12 @@ class Top(topParams: Parameters) extends Module with HasTopLevelParameters {
 
   io.extra <> periphery.io.extra
 
-  coreplex.io.rtcTick := p(RTC)(p, io.extra, periphery.io.extra)
+  coreplex.io.rtcTick := p(RTCTick)(p, io.extra, periphery.io.extra)
 
   p(ConnectExtraPorts)(io.extra, coreplex.io.extra, p)
 
 }
+
 
 class Periphery(implicit val p: Parameters) extends Module
     with HasTopLevelParameters {


### PR DESCRIPTION
This moves the Real Time Clock tick to be a parameter function, and moves it into RocketChipTop. The idea is from there the actual tick signal could come from either the Top IO or Periphery IO. 