### PR TITLE
Have Travis cache the entire verilator directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   directories:
     $HOME/.ivy2
     regression/install
-    emulator/verilator/install
+    emulator/verilator
 
 # packages needed to build riscv-tools
 addons:


### PR DESCRIPTION
It turns out the makefile will try to rebuild the installed verilator binary if the source is missing, so we should cache the entire verilator directory (both source and installation). Hopefully this will speed up future Travis runs.