### PR TITLE
only use companion objects for types

### DIFF
--- a/src/main/scala/coreplex/Coreplex.scala
+++ b/src/main/scala/coreplex/Coreplex.scala
@@ -61,7 +61,7 @@ abstract class Coreplex(implicit val p: Parameters) extends Module
     val mmio = p(ExportMMIOPort).option(new ClientUncachedTileLinkIO()(outermostMMIOParams))
     val interrupts = Vec(p(NExtInterrupts), Bool()).asInput
     val debug = new DebugBusIO()(p).flip
-    val rtcTick = new Bool(INPUT)
+    val rtcTick = Bool(INPUT)
     val extra = p(ExtraCoreplexPorts)(p)
     val success: Option[Bool] = hasSuccessFlag.option(Bool(OUTPUT))
   }


### PR DESCRIPTION
This is the only case of creating IOs with the constructor rather than the companion object.

We don't want this to happen anymore as per email discussion.