### PR TITLE
Turn on the inferRW Firrtl pass

### DIFF
--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -11,7 +11,7 @@ $(generated_dir)/%.$(CONFIG).fir $(generated_dir)/%.$(CONFIG).d $(generated_dir)
 
 $(generated_dir)/%.v $(generated_dir)/%.conf : $(generated_dir)/%.fir $(FIRRTL_JAR)
 	mkdir -p $(dir $@)
-	$(FIRRTL) -i $< -o $@ -X verilog --replSeqMem -c:$(MODEL):-o:$(generated_dir)/$(MODEL).$(CONFIG).conf
+	$(FIRRTL) -i $< -o $@ -X verilog --inferRW $(MODEL) --replSeqMem -c:$(MODEL):-o:$(generated_dir)/$(MODEL).$(CONFIG).conf
 
 $(generated_dir)/$(MODEL).$(CONFIG).behav_srams.v : $(generated_dir)/$(MODEL).$(CONFIG).conf $(mem_gen)
 	cd $(generated_dir) && \


### PR DESCRIPTION
Without this, all of the memories wind up as two-ported.