### PR TITLE
Fix routing in non-contiguous MMIO regions

### DIFF
--- a/src/main/scala/junctions/addrmap.scala
+++ b/src/main/scala/junctions/addrmap.scala
@@ -153,4 +153,8 @@ class AddrMap(
     }
     new AddrMapProt().fromBits(protForRegion.reduce(_|_))
   }
+
+  override def containsAddress(x: UInt) = {
+    flatten.map(_.region.containsAddress(x)).reduce(_||_)
+  }
 }


### PR DESCRIPTION
This is a temporary fix, which can generate more hardware than necessary, but this is OK for now, since this code will soon be replaced with tilelink2 code.