### PR TITLE
TL2Node: make it possible for {Identity,Output,Input}Node to pass a Vec

### DIFF
--- a/src/main/scala/uncore/tilelink2/Buffer.scala
+++ b/src/main/scala/uncore/tilelink2/Buffer.scala
@@ -39,10 +39,10 @@ class TLBuffer(entries: Int = 2, pipe: Boolean = false) extends LazyModule
 
 object TLBuffer
 {
-  // applied to the TL source node; connect (TLBuffer(x.node) -> y.node)
-  def apply(x: TLBaseNode, entries: Int = 2, pipe: Boolean = false)(implicit lazyModule: LazyModule, sourceInfo: SourceInfo): TLBaseNode = {
+  // applied to the TL source node; y.node := TLBuffer(x.node)
+  def apply(x: TLBaseNode, entries: Int = 2, pipe: Boolean = false)(implicit sourceInfo: SourceInfo): TLBaseNode = {
     val buffer = LazyModule(new TLBuffer(entries, pipe))
-    lazyModule.connect(x -> buffer.node)
+    buffer.node := x
     buffer.node
   }
 }

--- a/src/main/scala/uncore/tilelink2/Fragmenter.scala
+++ b/src/main/scala/uncore/tilelink2/Fragmenter.scala
@@ -240,10 +240,10 @@ class TLFragmenter(minSize: Int, maxSize: Int, alwaysMin: Boolean = false) exten
 
 object TLFragmenter
 {
-  // applied to the TL source node; connect (TLFragmenter(x.node, 256, 4) -> y.node)
-  def apply(x: TLBaseNode, minSize: Int, maxSize: Int, alwaysMin: Boolean = false)(implicit lazyModule: LazyModule, sourceInfo: SourceInfo): TLBaseNode = {
+  // applied to the TL source node; y.node := TLFragmenter(x.node, 256, 4)
+  def apply(x: TLBaseNode, minSize: Int, maxSize: Int, alwaysMin: Boolean = false)(implicit sourceInfo: SourceInfo): TLBaseNode = {
     val fragmenter = LazyModule(new TLFragmenter(minSize, maxSize, alwaysMin))
-    lazyModule.connect(x -> fragmenter.node)
+    fragmenter.node := x
     fragmenter.node
   }
 }

--- a/src/main/scala/uncore/tilelink2/HintHandler.scala
+++ b/src/main/scala/uncore/tilelink2/HintHandler.scala
@@ -90,10 +90,10 @@ class TLHintHandler(supportManagers: Boolean = true, supportClients: Boolean = f
 
 object TLHintHandler
 {
-  // applied to the TL source node; connect (TLHintHandler(x.node) -> y.node)
-  def apply(x: TLBaseNode, supportManagers: Boolean = true, supportClients: Boolean = false, passthrough: Boolean = true)(implicit lazyModule: LazyModule, sourceInfo: SourceInfo): TLBaseNode = {
+  // applied to the TL source node; y.node := TLHintHandler(x.node)
+  def apply(x: TLBaseNode, supportManagers: Boolean = true, supportClients: Boolean = false, passthrough: Boolean = true)(implicit sourceInfo: SourceInfo): TLBaseNode = {
     val hints = LazyModule(new TLHintHandler(supportManagers, supportClients, passthrough))
-    lazyModule.connect(x -> hints.node)
+    hints.node := x
     hints.node
   }
 }

--- a/src/main/scala/uncore/tilelink2/LazyModule.scala
+++ b/src/main/scala/uncore/tilelink2/LazyModule.scala
@@ -18,16 +18,13 @@ abstract class LazyModule
 
   // Use as: connect(source -> sink, source2 -> sink2, ...)
   def connect[PO, PI, EO, EI, B <: Data](edges: (BaseNode[PO, PI, EO, EI, B], BaseNode[PO, PI, EO, EI, B])*)(implicit sourceInfo: SourceInfo) = {
-    edges.foreach { case (source, sink) =>
-      bindings = (source edge sink) :: bindings
-    }
+    edges.foreach { case (source, sink) => sink := source }
   }
 
   def name = getClass.getName.split('.').last
   def line = sourceLine(info)
 
   def module: LazyModuleImp
-  implicit val lazyModule = this
 
   protected[tilelink2] def instantiate() = {
     children.reverse.foreach { c => 

--- a/src/main/scala/uncore/tilelink2/Nodes.scala
+++ b/src/main/scala/uncore/tilelink2/Nodes.scala
@@ -29,39 +29,46 @@ class RootNode
 }
 
 class BaseNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B])(
-  private val oFn: Option[Seq[PO] => PO],
-  private val iFn: Option[Seq[PI] => PI],
+  private val oFn: (Int, Seq[PO]) => Seq[PO],
+  private val iFn: (Int, Seq[PI]) => Seq[PI],
   private val numPO: Range.Inclusive,
   private val numPI: Range.Inclusive) extends RootNode
 {
   // At least 0 ports must be supported
-  require (!numPO.isEmpty)
-  require (!numPI.isEmpty)
-  require (numPO.start >= 0)
-  require (numPI.start >= 0)
+  def name = lazyModule.name + "." + getClass.getName.split('.').last
+  require (!numPO.isEmpty, s"No number of outputs would be acceptable to ${name}${lazyModule.line}")
+  require (!numPI.isEmpty, s"No number of inputs would be acceptable to ${name}${lazyModule.line}")
+  require (numPO.start >= 0, s"${name} accepts a negative number of outputs${lazyModule.line}")
+  require (numPI.start >= 0, s"${name} accepts a negative number of inputs${lazyModule.line}")
 
   val noOs = numPO.size == 1 && numPO.contains(0)
   val noIs = numPI.size == 1 && numPI.contains(0)
 
-  require (noOs || oFn.isDefined)
-  require (noIs || iFn.isDefined)
-
-  private val accPO = ListBuffer[BaseNode[PO, PI, EO, EI, B]]()
-  private val accPI = ListBuffer[BaseNode[PO, PI, EO, EI, B]]()
+  private val accPO = ListBuffer[(Int, BaseNode[PO, PI, EO, EI, B])]()
+  private val accPI = ListBuffer[(Int, BaseNode[PO, PI, EO, EI, B])]()
   private var oRealized  = false
   private var iRealized = false
 
-  def name = lazyModule.name + "." + getClass.getName.split('.').last
   private def reqO() = require(numPO.contains(accPO.size), s"${name} has ${accPO.size} outputs, expected ${numPO}${lazyModule.line}")
   private def reqI() = require(numPI.contains(accPI.size), s"${name} has ${accPI.size} inputs, expected ${numPI}${lazyModule.line}")
+  protected def reqE(o: Int, i: Int) = require(i == o, s"${name} has ${i} inputs and ${o} outputs; they must match${lazyModule.line}")
 
   private lazy val oPorts = { oRealized = true; reqO(); accPO.result() }
   private lazy val iPorts = { iRealized = true; reqI(); accPI.result() }
-  private lazy val oParams : Option[PO] = oFn.map(_(iPorts.map(_.oParams.get)))
-  private lazy val iParams : Option[PI] = iFn.map(_(oPorts.map(_.iParams.get)))
 
-  lazy val edgesOut = oPorts.map { n => imp.edgeO(oParams.get, n.iParams.get) }
-  lazy val edgesIn  = iPorts.map { n => imp.edgeI(n.oParams.get, iParams.get) }
+  private lazy val oParams : Seq[PO] = {
+    val o = oFn(oPorts.size, iPorts.map{ case (i, n) => n.oParams(i) })
+    reqE(oPorts.size, o.size)
+    o
+  }
+  private lazy val iParams : Seq[PI] = {
+    val i = iFn(iPorts.size, oPorts.map{ case (o, n) => n.iParams(o) })
+    reqE(i.size, iPorts.size)
+    i
+  }
+
+  lazy val edgesOut = (oPorts zip oParams).map { case ((i, n), o) => imp.edgeO(o, n.iParams(i)) }
+  lazy val edgesIn  = (iPorts zip iParams).map { case ((o, n), i) => imp.edgeI(n.oParams(o), i) }
 
   lazy val bundleOut = imp.bundleO(edgesOut)
   lazy val bundleIn  = imp.bundleI(edgesIn)
@@ -71,14 +78,15 @@ class BaseNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B])(
 
   // source.edge(sink)
   protected[tilelink2] def edge(x: BaseNode[PO, PI, EO, EI, B])(implicit sourceInfo: SourceInfo) = {
-    require (!noOs)
-    require (!oRealized)
-    require (!x.noIs)
-    require (!x.iRealized)
+    val info = sourceLine(sourceInfo, " at ", "")
+    require (!noOs, s"${name}${lazyModule.line} was incorrectly connected as a source" + info)
+    require (!oRealized, s"${name}${lazyModule.line} was incorrectly connected as a source after it's .module was used" + info)
+    require (!x.noIs, s"${x.name}${x.lazyModule.line} was incorrectly connected as a sink" + info)
+    require (!x.iRealized, s"${x.name}${x.lazyModule.line} was incorrectly connected as a sink after it's .module was used" + info)
     val i = x.accPI.size
     val o = accPO.size
-    accPO += x
-    x.accPI += this
+    accPO += ((i, x))
+    x.accPI += ((o, this))
     () => {
       imp.connect(connectOut(o), edgesOut(o), x.connectIn(i), x.edgesIn(i))
     }
@@ -86,7 +94,7 @@ class BaseNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B])(
 }
 
 class IdentityNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B])
-  extends BaseNode(imp)(Some{case Seq(x) => x}, Some{case Seq(x) => x}, 1 to 1, 1 to 1)
+  extends BaseNode(imp)({case (_, s) => s}, {case (_, s) => s}, 0 to 999, 0 to 999)
 
 class OutputNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B]) extends IdentityNode(imp)
 {
@@ -101,21 +109,21 @@ class InputNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B]) exte
 }
 
 class SourceNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B])(po: PO, num: Range.Inclusive = 1 to 1)
-  extends BaseNode(imp)(Some{case Seq() => po}, None, num, 0 to 0)
+  extends BaseNode(imp)({case (n, Seq()) => Seq.fill(n)(po)}, {case (0, _) => Seq()}, num, 0 to 0)
 {
-  require (num.end >= 1)
+  require (num.end >= 1, s"${name} is a source which does not accept outputs${lazyModule.line}")
 }
 
 class SinkNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B])(pi: PI, num: Range.Inclusive = 1 to 1)
-  extends BaseNode(imp)(None, Some{case Seq() => pi}, 0 to 0, num)
+  extends BaseNode(imp)({case (0, _) => Seq()}, {case (n, Seq()) => Seq.fill(n)(pi)}, 0 to 0, num)
 {
-  require (num.end >= 1)
+  require (num.end >= 1, s"${name} is a sink which does not accept inputs${lazyModule.line}")
 }
 
 class InteriorNode[PO, PI, EO, EI, B <: Data](imp: NodeImp[PO, PI, EO, EI, B])
   (oFn: Seq[PO] => PO, iFn: Seq[PI] => PI, numPO: Range.Inclusive, numPI: Range.Inclusive)
-  extends BaseNode(imp)(Some(oFn), Some(iFn), numPO, numPI)
+  extends BaseNode(imp)({case (n,s) => Seq.fill(n)(oFn(s))}, {case (n,s) => Seq.fill(n)(iFn(s))}, numPO, numPI)
 {
-  require (numPO.end >= 1)
-  require (numPI.end >= 1)
+  require (numPO.end >= 1, s"${name} is an adapter which does not accept outputs${lazyModule.line}")
+  require (numPI.end >= 1, s"${name} is an adapter which does not accept inputs${lazyModule.line}")
 }

--- a/src/main/scala/uncore/tilelink2/WidthWidget.scala
+++ b/src/main/scala/uncore/tilelink2/WidthWidget.scala
@@ -171,10 +171,10 @@ class TLWidthWidget(innerBeatBytes: Int) extends LazyModule
 
 object TLWidthWidget
 {
-  // applied to the TL source node; connect (WidthWidget(x.node, 16) -> y.node)
-  def apply(x: TLBaseNode, innerBeatBytes: Int)(implicit lazyModule: LazyModule, sourceInfo: SourceInfo): TLBaseNode = {
+  // applied to the TL source node; y.node := WidthWidget(x.node, 16)
+  def apply(x: TLBaseNode, innerBeatBytes: Int)(implicit sourceInfo: SourceInfo): TLBaseNode = {
     val widget = LazyModule(new TLWidthWidget(innerBeatBytes))
-    lazyModule.connect(x -> widget.node)
+    widget.node := x
     widget.node
   }
 }

--- a/src/main/scala/uncore/tilelink2/package.scala
+++ b/src/main/scala/uncore/tilelink2/package.scala
@@ -1,6 +1,7 @@
 package uncore
 
 import Chisel._
+import chisel3.internal.sourceinfo.{SourceInfo, SourceLine, UnlocatableSourceInfo}
 
 package object tilelink2
 {
@@ -9,4 +10,9 @@ package object tilelink2
   def OH1ToUInt(x: UInt) = OHToUInt((x << 1 | UInt(1)) ^ x)
   def UIntToOH1(x: UInt, width: Int) = ~(SInt(-1, width=width).asUInt << x)(width-1, 0)
   def trailingZeros(x: Int) = if (x > 0) Some(log2Ceil(x & -x)) else None
+
+  def sourceLine(sourceInfo: SourceInfo, prefix: String = " (", suffix: String = ")") = sourceInfo match {
+    case SourceLine(filename, line, col) => s"$prefix$filename:$line:$col$suffix"
+    case _ => ""
+  }
 }


### PR DESCRIPTION
In order to implement a pass-through RAM Monitor model, we will want to support
a variable number of inputs and outputs with BOTH different manager and client
parameters on each bundle.