### PR TITLE
Pass nMemChannels to coreplex through CoreplexConfig

### DIFF
--- a/src/main/scala/coreplex/UnitTest.scala
+++ b/src/main/scala/coreplex/UnitTest.scala
@@ -9,7 +9,7 @@ import cde.Parameters
 class UnitTestCoreplex(tp: Parameters, tc: CoreplexConfig) extends Coreplex()(tp, tc) {
   require(!tc.hasExtMMIOPort)
   require(tc.nSlaves == 0)
-  require(nMemChannels == 0)
+  require(tc.nMemChannels == 0)
 
   io.debug.req.ready := Bool(false)
   io.debug.resp.valid := Bool(false)

--- a/src/main/scala/rocketchip/Top.scala
+++ b/src/main/scala/rocketchip/Top.scala
@@ -16,6 +16,8 @@ import coreplex._
 case object GlobalAddrMap extends Field[GlobalVariable[AddrMap]]
 case object ConfigString extends Field[GlobalVariable[String]]
 case object NCoreplexExtClients extends Field[GlobalVariable[Int]]
+/** Function for building Coreplex */
+case object BuildCoreplex extends Field[(Parameters, CoreplexConfig) => Coreplex]
 
 /** Base Top with no Periphery */
 abstract class BaseTop(val p: Parameters) extends LazyModule {
@@ -36,6 +38,7 @@ class BaseTopModule[+L <: BaseTop, +B <: BaseTopBundle](val p: Parameters, l: L,
     nTiles = p(NTiles),
     nExtInterrupts = outer.pInterrupts.sum,
     nSlaves = outer.pBusMasters.sum,
+    nMemChannels = p(NMemoryChannels),
     hasSupervisor = p(UseVM),
     hasExtMMIOPort = !(outer.pDevices.get.isEmpty && p(ExtMMIOPorts).isEmpty)
   )


### PR DESCRIPTION
This is the comment I made on the Periphery refactor. To keep things consistent, we should pass nMemChannels to the Coreplex through the CoreplexConfig instead of the cde Parameters.