### PR TITLE
Make BootROM & PRCI Optional in Coreplex

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -188,6 +188,8 @@ class BaseCoreplexConfig extends Config (
       case TLKey("MMIO_Outermost") => site(TLKey("L2toMMIO")).copy(dataBeats = site(MIFDataBeats))
 
       case BootROMFile => "./bootrom/bootrom.img"
+      case CoreplexBootROM => true
+      case CoreplexPRCI => true
       case NTiles => Knob("NTILES")
       case NBanksPerMemoryChannel => Knob("NBANKS_PER_MEM_CHANNEL")
       case BankIdLSB => 0

--- a/src/main/scala/rocketchip/Utils.scala
+++ b/src/main/scala/rocketchip/Utils.scala
@@ -52,9 +52,13 @@ object GenerateGlobalAddrMap {
     lazy val intIOAddrMap: AddrMap = {
       val entries = collection.mutable.ArrayBuffer[AddrMapEntry]()
       entries += AddrMapEntry("debug", MemSize(4096, MemAttr(AddrMapProt.RWX)))
-      entries += AddrMapEntry("bootrom", MemSize(4096, MemAttr(AddrMapProt.RX)))
+      if (p(CoreplexBootROM)) {
+        entries += AddrMapEntry("bootrom", MemSize(4096, MemAttr(AddrMapProt.RX)))
+      }
       entries += AddrMapEntry("plic", MemRange(0x40000000, 0x4000000, MemAttr(AddrMapProt.RW)))
-      entries += AddrMapEntry("prci", MemSize(0x4000000, MemAttr(AddrMapProt.RW)))
+      if (p(CoreplexPRCI)) {
+        entries += AddrMapEntry("prci", MemSize(0x4000000, MemAttr(AddrMapProt.RW)))
+      }
       if (p(DataScratchpadSize) > 0) { // TODO heterogeneous tiles
         require(p(NTiles) == 1) // TODO relax this
         require(p(NMemoryChannels) == 0) // TODO allow both scratchpad & DRAM


### PR DESCRIPTION
This is an intermediate parameterization to disable the BootROM and/or PRCI instantiation within the Coreplex, since it's now possible to easily instantiate different versions of them in the Periphery instead. 
