### PR TITLE
fix clang support for emulator-debug

### DIFF
--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -98,14 +98,14 @@ int main(int argc, char** argv)
 #if VM_TRACE
     bool dump = tfp && trace_count >= start;
     if (dump)
-      tfp->dump(trace_count * 2);
+      tfp->dump(static_cast<vluint64_t>(trace_count * 2));
 #endif
 
     tile->clk = 1;
     tile->eval();
 #if VM_TRACE
     if (dump)
-      tfp->dump(trace_count * 2 + 1);
+      tfp->dump(static_cast<vluint64_t>(trace_count * 2 + 1));
 #endif
     trace_count++;
   }


### PR DESCRIPTION
Clang has difficulty resolving the overloaded function dump().

This fix allows clang to build emulator-debug.