### PR TITLE
Multi-Clock Changes Redux

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -109,6 +109,7 @@ class BaseCoreplexConfig extends Config (
         }
       }
       case BuildRoCC => Nil
+      case CoreplexMultiClock => CoreplexClockConfig(false, false)
       case RoccNMemChannels => site(BuildRoCC).map(_.nMemChannels).foldLeft(0)(_ + _)
       case RoccNPTWPorts => site(BuildRoCC).map(_.nPTWPorts).foldLeft(0)(_ + _)
       //Rocket Core Constants

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -41,8 +41,7 @@ class BasePlatformConfig extends Config(
         }
         case BuildCoreplex =>
           (p: Parameters, c: CoreplexConfig) => Module(new DefaultCoreplex(p, c))
-        case NExtTopInterrupts => 2
-        // Note that PLIC asserts that this is > 0.
+        case NExtTopInterrupts => 0
         case AsyncDebugBus => false
         case IncludeJtagDTM => false
         case AsyncMMIOChannels => false

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -383,3 +383,22 @@ trait PeripheryTestBusMasterModule {
   implicit val p: Parameters
   val outer: PeripheryTestBusMaster
 }
+
+trait PeripheryExtraClocks extends LazyModule {
+  implicit val p: Parameters
+}
+
+trait PeripheryExtraClocksBundle {
+  implicit val p: Parameters
+  val c: Coreplex
+
+  val clocks = c.io.clocks.asInput
+}
+
+trait PeripheryExtraClocksModule {
+  implicit val p: Parameters
+  val coreplex: Coreplex
+  val io: PeripheryExtraClocksBundle
+
+  coreplex.io.clocks := io.clocks
+}

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -166,7 +166,7 @@ trait PeripheryMasterMemModule extends HasPeripheryParameters {
   val coreplex: Coreplex
 
   // Abuse the fact that zip takes the shorter of the two lists
-  ((io.mem_axi zip coreplex.io.master.mem) zipWithIndex) foreach { case ((axi, mem), idx) =>
+  (io.mem_axi zip coreplex.io.master.mem).zipWithIndex.foreach { case ((axi, mem), idx) =>
     val axi_sync = PeripheryUtils.convertTLtoAXI(mem)(outermostParams)
     axi_sync.ar.bits.cache := CACHE_NORMAL_NOCACHE_BUF
     axi_sync.aw.bits.cache := CACHE_NORMAL_NOCACHE_BUF
@@ -180,8 +180,11 @@ trait PeripheryMasterMemModule extends HasPeripheryParameters {
     ahb <> PeripheryUtils.convertTLtoAHB(mem, atomics = false)(outermostParams)
   }
 
-  (io.mem_tl zip coreplex.io.master.mem) foreach { case (tl, mem) =>
-    tl <> TileLinkEnqueuer(mem, 2)(outermostParams)
+  (io.mem_tl zip coreplex.io.master.mem).zipWithIndex.foreach { case ((tl, mem), idx) =>
+    val tl_sync = TileLinkEnqueuer(mem, 2)(outermostParams)
+    tl <> (
+      if (!p(AsyncMemChannels)) tl_sync
+      else AsyncClientUncachedTileLinkTo(io.mem_clk.get(idx), io.mem_rst.get(idx), tl_sync))
   }
 }
 
@@ -231,7 +234,10 @@ trait PeripheryMasterMMIOModule extends HasPeripheryParameters {
       io.mmio_ahb(idx) <> PeripheryUtils.convertTLtoAHB(mmio_ports(i), atomics = true)(outermostMMIOParams)
     } else if (mmio_tl_start <= i && i < mmio_tl_end) {
       val idx = i-mmio_tl_start
-      io.mmio_tl(idx) <> TileLinkEnqueuer(mmio_ports(i), 2)(outermostMMIOParams)
+      val tl_sync = TileLinkEnqueuer(mmio_ports(i), 2)(outermostMMIOParams)
+      io.mmio_tl(idx) <> (
+        if (!p(AsyncMMIOChannels)) tl_sync
+        else AsyncClientUncachedTileLinkTo(io.mmio_clk.get(idx), io.mmio_rst.get(idx), tl_sync))
     } else {
       require(false, "Unconnected external MMIO port")
     }

--- a/src/main/scala/rocketchip/TestHarness.scala
+++ b/src/main/scala/rocketchip/TestHarness.scala
@@ -72,6 +72,9 @@ class TestHarness(q: Parameters) extends Module {
     slave.io <> mmio_axi
   }
 
+  dut.io.clocks.l2Clock.foreach { _ := clock }
+  dut.io.clocks.l2Reset.foreach { _ := reset }
+  dut.io.clocks.tileClocks.toSeq.flatten.foreach { _ := clock }
 }
 
 class SimAXIMem(size: BigInt)(implicit p: Parameters) extends NastiModule()(p) {

--- a/src/main/scala/rocketchip/Top.scala
+++ b/src/main/scala/rocketchip/Top.scala
@@ -84,17 +84,20 @@ class BaseTopModule[+L <: BaseTop, +B <: BaseTopBundle](val p: Parameters, l: L,
 
 /** Example Top with Periphery */
 class ExampleTop(q: Parameters) extends BaseTop(q)
-    with PeripheryBootROM with PeripheryDebug with PeripheryExtInterrupts with PeripheryAON
+    with PeripheryBootROM with PeripheryDebug with PeripheryAON
+    with PeripheryExtInterrupts with PeripheryExtraClocks
     with PeripheryMasterMem with PeripheryMasterMMIO with PeripherySlave {
   override lazy val module = Module(new ExampleTopModule(p, this, new ExampleTopBundle(p, _)))
 }
 
 class ExampleTopBundle(p: Parameters, c: Coreplex) extends BaseTopBundle(p, c)
-    with PeripheryBootROMBundle with PeripheryDebugBundle with PeripheryExtInterruptsBundle with PeripheryAONBundle
+    with PeripheryBootROMBundle with PeripheryDebugBundle with PeripheryAONBundle
+    with PeripheryExtInterruptsBundle with PeripheryExtraClocksBundle
     with PeripheryMasterMemBundle with PeripheryMasterMMIOBundle with PeripherySlaveBundle
 
 class ExampleTopModule[+L <: ExampleTop, +B <: ExampleTopBundle](p: Parameters, l: L, b: Coreplex => B) extends BaseTopModule(p, l, b)
-    with PeripheryBootROMModule with PeripheryDebugModule with PeripheryExtInterruptsModule with PeripheryAONModule
+    with PeripheryBootROMModule with PeripheryDebugModule with PeripheryAONModule
+    with PeripheryExtInterruptsModule with PeripheryExtraClocksModule
     with PeripheryMasterMemModule with PeripheryMasterMMIOModule with PeripherySlaveModule
 
 /** Example Top with TestRAM */

--- a/src/main/scala/uncore/tilelink/Crossings.scala
+++ b/src/main/scala/uncore/tilelink/Crossings.scala
@@ -1,0 +1,122 @@
+package uncore.tilelink
+
+import Chisel._
+import junctions._
+
+object AsyncClientUncachedTileLinkCrossing {
+  def apply(from_clock: Clock, from_reset: Bool, from_source: ClientUncachedTileLinkIO,
+            to_clock: Clock, to_reset: Bool,
+            depth: Int = 8, sync: Int = 3): ClientUncachedTileLinkIO = {
+    val to_sink = Wire(new ClientUncachedTileLinkIO()(from_source.p))
+
+    to_sink.acquire <> AsyncDecoupledCrossing(
+      from_clock, from_reset, from_source.acquire,
+      to_clock, to_reset, depth, sync)
+    from_source.grant <> AsyncDecoupledCrossing(
+      to_clock, to_reset, to_sink.grant,
+      from_clock, from_reset, depth, sync)
+
+    to_sink
+  }
+}
+
+object AsyncClientTileLinkCrossing {
+  def apply(from_clock: Clock, from_reset: Bool, from_source: ClientTileLinkIO,
+            to_clock: Clock, to_reset: Bool,
+            depth: Int = 8, sync: Int = 3): ClientTileLinkIO = {
+    val to_sink = Wire(new ClientTileLinkIO()(from_source.p))
+
+    to_sink.acquire <> AsyncDecoupledCrossing(
+      from_clock, from_reset, from_source.acquire,
+      to_clock, to_reset, depth, sync)
+    to_sink.release <> AsyncDecoupledCrossing(
+      from_clock, from_reset, from_source.release,
+      to_clock, to_reset, depth, sync)
+    to_sink.finish <> AsyncDecoupledCrossing(
+      from_clock, from_reset, from_source.finish,
+      to_clock, to_reset, depth, sync)
+    from_source.grant <> AsyncDecoupledCrossing(
+      to_clock, to_reset, to_sink.grant,
+      from_clock, from_reset, depth, sync)
+    from_source.probe <> AsyncDecoupledCrossing(
+      to_clock, to_reset, to_sink.probe,
+      from_clock, from_reset, depth, sync)
+
+    to_sink
+  }
+
+}
+
+object AsyncManagerTileLinkCrossing {
+  def apply(from_clock: Clock, from_reset: Bool, from_source: ManagerTileLinkIO,
+            to_clock: Clock, to_reset: Bool,
+            depth: Int = 8, sync: Int = 3): ManagerTileLinkIO = {
+    val to_sink = Wire(new ManagerTileLinkIO()(from_source.p))
+
+    from_source.acquire <> AsyncDecoupledCrossing(
+      to_clock, to_reset, to_sink.acquire,
+      from_clock, from_reset, depth, sync)
+    from_source.release <> AsyncDecoupledCrossing(
+      to_clock, to_reset, to_sink.release,
+      from_clock, from_reset, depth, sync)
+    from_source.finish <> AsyncDecoupledCrossing(
+      to_clock, to_reset, to_sink.finish,
+      from_clock, from_reset, depth, sync)
+    to_sink.grant <> AsyncDecoupledCrossing(
+      from_clock, from_reset, from_source.grant,
+      to_clock, to_reset, depth, sync)
+    to_sink.probe <> AsyncDecoupledCrossing(
+      from_clock, from_reset, from_source.probe,
+      to_clock, to_reset, depth, sync)
+
+    to_sink
+  }
+}
+
+object AsyncClientUncachedTileLinkTo {
+  def apply(to_clock: Clock, to_reset: Bool, source: ClientUncachedTileLinkIO,
+            depth: Int = 8, sync: Int = 3): ClientUncachedTileLinkIO = {
+    val scope = AsyncScope()
+    AsyncClientUncachedTileLinkCrossing(scope.clock, scope.reset, source, to_clock, to_reset, depth, sync)
+  }
+}
+
+object AsyncClientTileLinkTo {
+  def apply(to_clock: Clock, to_reset: Bool, source: ClientTileLinkIO,
+            depth: Int = 8, sync: Int = 3): ClientTileLinkIO = {
+    val scope = AsyncScope()
+    AsyncClientTileLinkCrossing(scope.clock, scope.reset, source, to_clock, to_reset, depth, sync)
+  }
+}
+
+object AsyncManagerTileLinkTo {
+  def apply(to_clock: Clock, to_reset: Bool, source: ManagerTileLinkIO,
+            depth: Int = 8, sync: Int = 3): ManagerTileLinkIO = {
+    val scope = AsyncScope()
+    AsyncManagerTileLinkCrossing(scope.clock, scope.reset, source, to_clock, to_reset, depth, sync)
+  }
+}
+
+object AsyncClientUncachedTileLinkFrom {
+  def apply(from_clock: Clock, from_reset: Bool, from_source: ClientUncachedTileLinkIO,
+            depth: Int = 8, sync: Int = 3): ClientUncachedTileLinkIO = {
+    val scope = AsyncScope()
+    AsyncClientUncachedTileLinkCrossing(from_clock, from_reset, from_source, scope.clock, scope.reset, depth, sync)
+  }
+}
+
+object AsyncClientTileLinkFrom {
+  def apply(from_clock: Clock, from_reset: Bool, from_source: ClientTileLinkIO,
+            depth: Int = 8, sync: Int = 3): ClientTileLinkIO = {
+    val scope = AsyncScope()
+    AsyncClientTileLinkCrossing(from_clock, from_reset, from_source, scope.clock, scope.reset, depth, sync)
+  }
+}
+
+object AsyncManagerTileLinkFrom {
+  def apply(from_clock: Clock, from_reset: Bool, from_source: ManagerTileLinkIO,
+            depth: Int = 8, sync: Int = 3): ManagerTileLinkIO = {
+    val scope = AsyncScope()
+    AsyncManagerTileLinkCrossing(from_clock, from_reset, from_source, scope.clock, scope.reset, depth, sync)
+  }
+}


### PR DESCRIPTION
This provides the ability to put the Tiles and L2 on separate clock domains from the rest of the core. Instead of passing things through the builder functions to the Module constructor, I just wrap BuildTiles and BuildL2CoherenceManager in a wrapper that changes the clocks and instantiates the clock crossers.

@yunsup Does this look satisfactory?

@terpstra I added level synchronizers junctions/crossings.scala to synchronize the reset and interrupt signals. Is this the proper way to do it? It's just a register in the `from` domain connected to two or more registers in the `to` domain. Is it safe to do this for multi-bit signals? There might be glitching, but eventually they'll settle to the final value, right? 