### PR TITLE
Add firrtl and verilog Makefile targets to vsim

### DIFF
--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -5,6 +5,11 @@
 # files.
 .SECONDARY: $(generated_dir)/$(MODEL).$(CONFIG).fir
 
+firrtl: $(generated_dir)/$(MODEL).$(CONFIG).fir
+verilog: $(generated_dir)/$(MODEL).$(CONFIG).v
+
+.PHONY: firrtl verilog
+
 $(generated_dir)/%.$(CONFIG).fir $(generated_dir)/%.$(CONFIG).d $(generated_dir)/%.prm: $(chisel_srcs) $(bootrom_img)
 	mkdir -p $(dir $@)
 	cd $(base_dir) && $(SBT) "run $(generated_dir) $(PROJECT) $(notdir $*) $(CFG_PROJECT) $(CONFIG)"

--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -6,9 +6,8 @@
 .SECONDARY: $(generated_dir)/$(MODEL).$(CONFIG).fir
 
 firrtl: $(generated_dir)/$(MODEL).$(CONFIG).fir
-verilog: $(generated_dir)/$(MODEL).$(CONFIG).v
 
-.PHONY: firrtl verilog
+.PHONY: firrtl
 
 $(generated_dir)/%.$(CONFIG).fir $(generated_dir)/%.$(CONFIG).d $(generated_dir)/%.prm: $(chisel_srcs) $(bootrom_img)
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Helps create just the Firrtl or Verilog target files. Not sure if these are really wanted but I find them useful.