### PR TITLE
Allow MODEL to be something other than TestHarness

### DIFF
--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
   srand48(random_seed);
 
   Verilated::randReset(2);
-  VTestHarness *tile = new VTestHarness;
+  MODEL *tile = new MODEL;
 
 #if VM_TRACE
   Verilated::traceEverOn(true); // Verilator must compute traced signals

--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -54,7 +54,7 @@ VERILATOR_FLAGS := --top-module $(MODEL) \
   +define+STOP_COND=\$$c\(\"done_reset\"\) --assert \
 	-Wno-STMTDLY --x-assign unique \
   -I$(base_dir)/vsrc \
-  -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -include $(base_dir)/csrc/verilator.h"
+  -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -include $(base_dir)/csrc/verilator.h -DMODEL=V$(MODEL)"
 cppfiles = $(addprefix $(base_dir)/csrc/, $(addsuffix .cc, $(CXXSRCS)))
 headers = $(wildcard $(base_dir)/csrc/*.h)
 

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -39,11 +39,13 @@ $(error Set SUITE to the regression suite you want to run)
 endif
 
 ifeq ($(SUITE),RocketSuite)
+MODEL=TestHarness
 PROJECT=rocketchip
 CONFIGS=DefaultConfig DefaultL2Config DefaultBufferlessConfig TinyConfig
 endif
 
 ifeq ($(SUITE),GroundtestSuite)
+MODEL=TestHarness
 PROJECT=rocketchip
 CONFIGS=MemtestConfig MemtestBufferlessConfig MemtestStatelessConfig FancyMemtestConfig \
 	BroadcastRegressionTestConfig BufferlessRegressionTestConfig CacheRegressionTestConfig \
@@ -51,7 +53,8 @@ CONFIGS=MemtestConfig MemtestBufferlessConfig MemtestStatelessConfig FancyMemtes
 endif
 
 ifeq ($(SUITE),UnittestSuite)
-PROJECT=rocketchip.utest
+MODEL=UnitTestHarness
+PROJECT=rocketchip
 CONFIGS=UnitTestConfig
 endif
 
@@ -123,65 +126,65 @@ $(RISCV)/install.stamp:
 # Builds the various simulators
 stamps/%/emulator-verilog.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) verilog
+	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) verilog
 	date > $@
 
 stamps/%/emulator-ndebug.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV))
+	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV))
 	date > $@
 
 stamps/%/emulator-debug.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) debug
+	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) debug
 	date > $@
 
 stamps/%/vsim-verilog.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) verilog
+	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) verilog
 	date > $@
 
 stamps/%/vsim-ndebug.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV))
+	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV))
 	date > $@
 
 stamps/%/vsim-debug.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) debug
+	+flock -x $(dir $@)/chisel-lock $(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) debug
 	date > $@
 
 # Runs tests on one of the simulators
 stamps/%/emulator-asm-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) run-asm-tests-fast
+	$(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) run-asm-tests-fast
 	date > $@
 
 stamps/%/emulator-bmark-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) run-bmark-tests-fast
+	$(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) run-bmark-tests-fast
 	date > $@
 
 stamps/%/emulator-regression-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) clean-run-output
-	$(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) run-regression-tests-fast
+	$(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) clean-run-output
+	$(MAKE) -C $(abspath $(TOP))/emulator PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) run-regression-tests-fast
 	date > $@
 
 stamps/%/vsim-asm-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) run-asm-tests-fast
+	$(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) run-asm-tests-fast
 	date > $@
 
 stamps/%/vsim-bmark-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) run-bmark-tests-fast
+	$(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) run-bmark-tests-fast
 	date > $@
 
 stamps/%/vsim-regression-tests.stamp: stamps/other-submodules.stamp $(RISCV)/install.stamp
 	mkdir -p $(dir $@)
-	$(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) clean-run-output
-	$(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) CONFIG=$* RISCV=$(abspath $(RISCV)) run-regression-tests-fast
+	$(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) clean-run-output
+	$(MAKE) -C $(abspath $(TOP))/vsim PROJECT=$(PROJECT) MODEL=$(MODEL) CONFIG=$* RISCV=$(abspath $(RISCV)) run-regression-tests-fast
 	date > $@
 
 # The torture tests run subtly differently on the different targets, so they

--- a/src/main/scala/rocketchip/UnitTest.scala
+++ b/src/main/scala/rocketchip/UnitTest.scala
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-package rocketchip.utest
+package rocketchip
 
 import scala.collection.mutable.LinkedHashSet
 
@@ -31,7 +31,7 @@ class WithUnitTest extends Config(
 
 class UnitTestConfig extends Config(new WithUnitTest ++ new BaseConfig)
 
-class TestHarness(implicit val p: Parameters) extends Module {
+class UnitTestHarness(implicit val p: Parameters) extends Module {
   val io = new Bundle {
     val success = Bool(OUTPUT)
   }

--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -51,6 +51,7 @@ VCS_OPTS = -notice -line +lint=all,noVCDE,noONGS,noUI -error=PCWM-L -timescale=1
 	$(RISCV)/lib/libfesvr.so \
 	-sverilog \
 	+incdir+$(generated_dir) \
+	+define+MODEL=$(MODEL) \
 	+define+CLOCK_PERIOD=1.0 $(sim_vsrcs) $(sim_csrcs) \
 	+define+PRINTF_COND=$(TB).printf_cond \
 	+define+STOP_COND=!$(TB).reset \

--- a/vsrc/TestDriver.v
+++ b/vsrc/TestDriver.v
@@ -87,7 +87,7 @@ module TestDriver;
     end
   end
 
-  TestHarness testHarness(
+  `MODEL testHarness(
     .clk(clk),
     .reset(reset),
     .io_success(success)


### PR DESCRIPTION
This uses C and Verilog pre-processor macros to set the name of the top-level module so that MODEL doesn't have to be TestHarness in order to simulate. This also moves the UnitTest stuff from rocketchip.utest back up to rocketchip and renames rocketchip.utest.TestHarness to rocketchip.UnitTestHarness.