### PR TITLE
Fix a bunch of small annoyances

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -189,7 +189,7 @@ class BaseCoreplexConfig extends Config (
       case TLKey("MMIO_Outermost") => site(TLKey("L2toMMIO")).copy(dataBeats = site(MIFDataBeats))
 
       case BootROMFile => "./bootrom/bootrom.img"
-      case NTiles => Knob("NTILES")
+      case NTiles => 1
       case NBanksPerMemoryChannel => Knob("NBANKS_PER_MEM_CHANNEL")
       case BankIdLSB => 0
       case CacheBlockBytes => Dump("CACHE_BLOCK_BYTES", 64)
@@ -224,7 +224,6 @@ class BaseCoreplexConfig extends Config (
       case _ => throw new CDEMatchError
   }},
   knobValues = {
-    case "NTILES" => 1
     case "NBANKS_PER_MEM_CHANNEL" => 1
     case "L1D_MSHRS" => 2
     case "L1D_SETS" => 64
@@ -236,7 +235,9 @@ class BaseCoreplexConfig extends Config (
 )
 
 class WithNCores(n: Int) extends Config(
-  knobValues = { case"NTILES" => n; case _ => throw new CDEMatchError })
+  (pname,site,here) => pname match {
+    case NTiles => n
+  })
 
 class WithNBanksPerMemChannel(n: Int) extends Config(
   knobValues = {

--- a/src/main/scala/junctions/stream.scala
+++ b/src/main/scala/junctions/stream.scala
@@ -45,7 +45,7 @@ class NastiIOStreamIOConverter(w: Int)(implicit p: Parameters) extends Module {
   io.nasti.ar.ready := !reading
   io.nasti.r.valid := reading && io.stream.in.valid
   io.nasti.r.bits := io.stream.in.bits
-  io.nasti.r.bits.resp := UInt(0)
+  io.nasti.r.bits.resp := RESP_OKAY
   io.nasti.r.bits.id := read_id
   io.stream.in.ready := reading && io.nasti.r.ready
 
@@ -72,7 +72,7 @@ class NastiIOStreamIOConverter(w: Int)(implicit p: Parameters) extends Module {
   io.stream.out.valid := writing && io.nasti.w.valid
   io.stream.out.bits := io.nasti.w.bits
   io.nasti.b.valid := write_resp
-  io.nasti.b.bits.resp := UInt(0)
+  io.nasti.b.bits.resp := RESP_OKAY
   io.nasti.b.bits.id := write_id
 
   when (io.nasti.aw.fire()) {

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -5,6 +5,7 @@ package rocketchip
 import Chisel._
 import cde.{Parameters, Field}
 import junctions._
+import junctions.NastiConstants._
 import uncore.tilelink._
 import uncore.tilelink2.{LazyModule, LazyModuleImp}
 import uncore.converters._
@@ -165,8 +166,8 @@ trait PeripheryMasterMemModule extends HasPeripheryParameters {
   // Abuse the fact that zip takes the shorter of the two lists
   ((io.mem_axi zip coreplex.io.master.mem) zipWithIndex) foreach { case ((axi, mem), idx) =>
     val axi_sync = PeripheryUtils.convertTLtoAXI(mem)(outermostParams)
-    axi_sync.ar.bits.cache := UInt("b0011")
-    axi_sync.aw.bits.cache := UInt("b0011")
+    axi_sync.ar.bits.cache := CACHE_NORMAL_NOCACHE_BUF
+    axi_sync.aw.bits.cache := CACHE_NORMAL_NOCACHE_BUF
     axi <> (
       if (!p(AsyncMemChannels)) axi_sync
       else AsyncNastiTo(io.mem_clk.get(idx), io.mem_rst.get(idx), axi_sync)

--- a/src/main/scala/rocketchip/TestHarness.scala
+++ b/src/main/scala/rocketchip/TestHarness.scala
@@ -6,6 +6,7 @@ import Chisel._
 import cde.{Parameters, Field}
 import rocket.Util._
 import junctions._
+import junctions.NastiConstants._
 
 case object BuildExampleTop extends Field[Parameters => ExampleTop]
 case object SimMemLatency extends Field[Int]
@@ -117,12 +118,12 @@ class SimAXIMem(size: BigInt)(implicit p: Parameters) extends NastiModule()(p) {
 
   io.axi.b.valid := bValid
   io.axi.b.bits.id := aw.id
-  io.axi.b.bits.resp := UInt(0)
+  io.axi.b.bits.resp := RESP_OKAY
 
   io.axi.r.valid := rValid
   io.axi.r.bits.id := ar.id
   io.axi.r.bits.data := mem((ar.addr >> log2Ceil(nastiXDataBits/8))(log2Ceil(depth)-1, 0))
-  io.axi.r.bits.resp := UInt(0)
+  io.axi.r.bits.resp := RESP_OKAY
   io.axi.r.bits.last := ar.len === UInt(0)
 }
 

--- a/src/main/scala/uncore/converters/Nasti.scala
+++ b/src/main/scala/uncore/converters/Nasti.scala
@@ -3,6 +3,7 @@ package uncore.converters
 import Chisel._
 import junctions._
 import util.{ReorderQueue, DecoupledHelper}
+import junctions.NastiConstants._
 import uncore.tilelink._
 import uncore.constants._
 import cde.Parameters
@@ -234,8 +235,8 @@ class NastiIOTileLinkIOConverter(implicit p: Parameters) extends TLModule()(p)
     data = Bits(0))
   assert(!gnt_arb.io.in(1).valid || put_id_mapper.io.resp.matches, "NASTI tag error")
 
-  assert(!io.nasti.r.valid || io.nasti.r.bits.resp === UInt(0), "NASTI read error")
-  assert(!io.nasti.b.valid || io.nasti.b.bits.resp === UInt(0), "NASTI write error")
+  assert(!io.nasti.r.valid || io.nasti.r.bits.resp === RESP_OKAY, "NASTI read error")
+  assert(!io.nasti.b.valid || io.nasti.b.bits.resp === RESP_OKAY, "NASTI write error")
 }
 
 class TileLinkIONastiIOConverter(implicit p: Parameters) extends TLModule()(p)


### PR DESCRIPTION
Trying to save on Travis latency a bit. This fixes a few minor things.

1. As mentioned in issue #272, we should be consistent about using named constants for the AXI resp, cache, and prot fields. 
2. There's no reason that NTiles should be a Knob instead of a config. Knobs should only be used for things that can be tuned to get performance but don't affect the architectural view of the processor.
3. When I added the latency pipe, I didn't realize how annoying it would be to see a bunch of single-entry queues under the dut module in dve. This collects them into a module so that they don't blow up the module list in the waveform viewer.