### PR TITLE
Merge ClientTileLinkEnqueuer and ClientUncachedTileLinkEnqueuer into TileLinkEnqueuer

### DIFF
--- a/src/main/scala/coreplex/Coreplex.scala
+++ b/src/main/scala/coreplex/Coreplex.scala
@@ -117,13 +117,13 @@ class DefaultCoreplex(tp: Parameters, tc: CoreplexConfig) extends Coreplex()(tp,
     val backendBuffering = TileLinkDepths(0,0,0,0,0)
     for ((bank, icPort) <- managerEndpoints zip mem_ic.io.in) {
       val unwrap = Module(new ClientTileLinkIOUnwrapper()(outerTLParams))
-      unwrap.io.in <> ClientTileLinkEnqueuer(bank.outerTL, backendBuffering)(outerTLParams)
+      unwrap.io.in <> TileLinkEnqueuer(bank.outerTL, backendBuffering)(outerTLParams)
       TileLinkWidthAdapter(icPort, unwrap.io.out)
     }
 
     io.master.mem <> mem_ic.io.out
 
-    buildMMIONetwork(ClientUncachedTileLinkEnqueuer(mmioManager.io.outer, 1))(
+    buildMMIONetwork(TileLinkEnqueuer(mmioManager.io.outer, 1))(
         p.alterPartial({case TLId => "L2toMMIO"}))
   }
 
@@ -157,7 +157,7 @@ class DefaultCoreplex(tp: Parameters, tc: CoreplexConfig) extends Coreplex()(tp,
 
     val tileSlavePorts = (0 until tc.nTiles) map (i => s"int:dmem$i") filter (ioAddrMap contains _)
     for ((t, m) <- (tileList.map(_.io.slave).flatten) zip (tileSlavePorts map (mmioNetwork port _)))
-      t <> ClientUncachedTileLinkEnqueuer(m, 1)
+      t <> TileLinkEnqueuer(m, 1)
 
     io.master.mmio.foreach { _ <> mmioNetwork.port("ext") }
   }

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -179,7 +179,7 @@ trait PeripheryMasterMemModule extends HasPeripheryParameters {
   }
 
   (io.mem_tl zip coreplex.io.master.mem) foreach { case (tl, mem) =>
-    tl <> ClientUncachedTileLinkEnqueuer(mem, 2)(outermostParams)
+    tl <> TileLinkEnqueuer(mem, 2)(outermostParams)
   }
 }
 
@@ -229,7 +229,7 @@ trait PeripheryMasterMMIOModule extends HasPeripheryParameters {
       io.mmio_ahb(idx) <> PeripheryUtils.convertTLtoAHB(mmio_ports(i), atomics = true)(outermostMMIOParams)
     } else if (mmio_tl_start <= i && i < mmio_tl_end) {
       val idx = i-mmio_tl_start
-      io.mmio_tl(idx) <> ClientUncachedTileLinkEnqueuer(mmio_ports(i), 2)(outermostMMIOParams)
+      io.mmio_tl(idx) <> TileLinkEnqueuer(mmio_ports(i), 2)(outermostMMIOParams)
     } else {
       require(false, "Unconnected external MMIO port")
     }

--- a/src/main/scala/uncore/util/Enqueuer.scala
+++ b/src/main/scala/uncore/util/Enqueuer.scala
@@ -30,6 +30,23 @@ object TileLinkEnqueuer {
   def apply(in: TileLinkIO, depth: Int)(implicit p: Parameters): TileLinkIO = {
     apply(in, TileLinkDepths(depth, depth, depth, depth, depth))
   }
+
+  def apply(in: ClientTileLinkIO, depths: TileLinkDepths)(implicit p: Parameters): ClientTileLinkIO = {
+    val t = Module(new ClientTileLinkEnqueuer(depths))
+    t.io.inner <> in
+    t.io.outer
+  }
+  def apply(in: ClientTileLinkIO, depth: Int)(implicit p: Parameters): ClientTileLinkIO = {
+    apply(in, TileLinkDepths(depth, depth, depth, depth, depth))
+  }
+  def apply(in: ClientUncachedTileLinkIO, depths: UncachedTileLinkDepths)(implicit p: Parameters): ClientUncachedTileLinkIO = {
+    val t = Module(new ClientUncachedTileLinkEnqueuer(depths))
+    t.io.inner <> in
+    t.io.outer
+  }
+  def apply(in: ClientUncachedTileLinkIO, depth: Int)(implicit p: Parameters): ClientUncachedTileLinkIO = {
+    apply(in, UncachedTileLinkDepths(depth, depth))
+  }
 }
 
 class ClientTileLinkEnqueuer(depths: TileLinkDepths)(implicit p: Parameters) extends Module {
@@ -45,17 +62,6 @@ class ClientTileLinkEnqueuer(depths: TileLinkDepths)(implicit p: Parameters) ext
   io.outer.finish  <> (if(depths.fin > 0) Queue(io.inner.finish,  depths.fin) else io.inner.finish)
 }
 
-object ClientTileLinkEnqueuer {
-  def apply(in: ClientTileLinkIO, depths: TileLinkDepths)(implicit p: Parameters): ClientTileLinkIO = {
-    val t = Module(new ClientTileLinkEnqueuer(depths))
-    t.io.inner <> in
-    t.io.outer
-  }
-  def apply(in: ClientTileLinkIO, depth: Int)(implicit p: Parameters): ClientTileLinkIO = {
-    apply(in, TileLinkDepths(depth, depth, depth, depth, depth))
-  }
-}
-
 class ClientUncachedTileLinkEnqueuer(depths: UncachedTileLinkDepths)(implicit p: Parameters) extends Module {
   val io = new Bundle {
     val inner = new ClientUncachedTileLinkIO().flip
@@ -64,15 +70,4 @@ class ClientUncachedTileLinkEnqueuer(depths: UncachedTileLinkDepths)(implicit p:
 
   io.outer.acquire <> (if(depths.acq > 0) Queue(io.inner.acquire, depths.acq) else io.inner.acquire)
   io.inner.grant   <> (if(depths.gnt > 0) Queue(io.outer.grant,   depths.gnt) else io.outer.grant)
-}
-
-object ClientUncachedTileLinkEnqueuer {
-  def apply(in: ClientUncachedTileLinkIO, depths: UncachedTileLinkDepths)(implicit p: Parameters): ClientUncachedTileLinkIO = {
-    val t = Module(new ClientUncachedTileLinkEnqueuer(depths))
-    t.io.inner <> in
-    t.io.outer
-  }
-  def apply(in: ClientUncachedTileLinkIO, depth: Int)(implicit p: Parameters): ClientUncachedTileLinkIO = {
-    apply(in, UncachedTileLinkDepths(depth, depth))
-  }
 }


### PR DESCRIPTION
There's no reason to have objects with such long names when we could just overload the TileLinkEnqueuer object. This is the same approach taken by TileLinkIOWrapper.