### PR TITLE
Use CDEMatchError for improved performance

### DIFF
--- a/src/main/scala/coreplex/TestConfigs.scala
+++ b/src/main/scala/coreplex/TestConfigs.scala
@@ -146,6 +146,7 @@ class WithTraceGen extends Config(
   knobValues = {
     case "L1D_SETS" => 16
     case "L1D_WAYS" => 1
+    case _ => throw new CDEMatchError
   })
 
 class WithPCIeMockupTest extends Config(

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -152,6 +152,7 @@ class RoccExampleConfig extends Config(new WithRoccExample ++ new BaseConfig)
 class WithMIFDataBits(n: Int) extends Config(
   (pname, site, here) => pname match {
     case MIFDataBits => Dump("MIF_DATA_BITS", n)
+    case _ => throw new CDEMatchError
   })
 
 class MIF128BitConfig extends Config(
@@ -182,12 +183,14 @@ class TinyConfig extends Config(
 
 class WithAsyncDebug extends Config (
   (pname, site, here) => pname match {
-     case AsyncDebugBus => true
+    case AsyncDebugBus => true
+    case _ => throw new CDEMatchError
   }
 )
 
 class WithJtagDTM extends Config (
   (pname, site, here) => pname match {
-     case IncludeJtagDTM => true
+    case IncludeJtagDTM => true
+    case _ => throw new CDEMatchError
   }
 )

--- a/src/main/scala/uncore/Builder.scala
+++ b/src/main/scala/uncore/Builder.scala
@@ -1,7 +1,7 @@
 package uncore
 
 import Chisel._
-import cde.{Config, Parameters, ParameterDump, Knob, Dump}
+import cde.{Config, Parameters, ParameterDump, Knob, Dump, CDEMatchError}
 import junctions.PAddrBits
 import uncore.tilelink._
 import uncore.agents._
@@ -85,6 +85,7 @@ class DefaultL2Config extends Config (
       case ECCCode => None
       case AmoAluOperandBits => 64
       case SplitMetadata => false
+      case _ => throw new CDEMatchError
  //     case XLen => 128
   }},
   knobValues = {
@@ -93,22 +94,24 @@ class DefaultL2Config extends Config (
     case "NTILES" => 2
     case "N_CACHED_TILES" => 2
     case "L2_CAPACITY_IN_KB" => 256
+    case _ => throw new CDEMatchError
   }
 )
 
 class WithPLRU extends Config(
   (pname, site, here) => pname match {
     case L2Replacer => () => new SeqPLRU(site(NSets), site(NWays))
+    case _ => throw new CDEMatchError
   })
 
 class PLRUL2Config extends Config(new WithPLRU ++ new DefaultL2Config)
 
-class With1L2Ways extends Config(knobValues = { case "L2_WAYS" => 1 })
-class With2L2Ways extends Config(knobValues = { case "L2_WAYS" => 2 })
-class With4L2Ways extends Config(knobValues = { case "L2_WAYS" => 4 })
+class With1L2Ways extends Config(knobValues = { case "L2_WAYS" => 1; case _ => throw new CDEMatchError })
+class With2L2Ways extends Config(knobValues = { case "L2_WAYS" => 2; case _ => throw new CDEMatchError })
+class With4L2Ways extends Config(knobValues = { case "L2_WAYS" => 4; case _ => throw new CDEMatchError })
 
-class With1Cached extends Config(knobValues = { case "N_CACHED_TILES" => 1 })
-class With2Cached extends Config(knobValues = { case "N_CACHED_TILES" => 2 })
+class With1Cached extends Config(knobValues = { case "N_CACHED_TILES" => 1; case _ => throw new CDEMatchError })
+class With2Cached extends Config(knobValues = { case "N_CACHED_TILES" => 2; case _ => throw new CDEMatchError })
 
 
 class W1Cached1WaysConfig extends Config(new With1L2Ways ++ new With1Cached ++ new DefaultL2Config)


### PR DESCRIPTION
This combined with ucb-bar/context-dependent-environments#6 removes MatchErrors from the compilation of rocket-chip. Improves performance by ~30%