### PR TITLE
util: Do BlackBox Async Set/Reset Registers more properly

### DIFF
--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -8,6 +8,7 @@ bb_vsrcs = $(base_dir)/vsrc/DebugTransportModuleJtag.v \
 	$(base_dir)/vsrc/jtag_vpi.v \
 	$(base_dir)/vsrc/AsyncMailbox.v \
 	$(base_dir)/vsrc/AsyncResetReg.v \
+        $(base_dir)/vsrc/AsyncSetReg.v \
 	$(base_dir)/vsrc/ClockDivider.v \
         $(base_dir)/vsrc/ClockToSignal.v \
         $(base_dir)/vsrc/SignalToClock.v \

--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -8,11 +8,11 @@ bb_vsrcs = $(base_dir)/vsrc/DebugTransportModuleJtag.v \
 	$(base_dir)/vsrc/jtag_vpi.v \
 	$(base_dir)/vsrc/AsyncMailbox.v \
 	$(base_dir)/vsrc/AsyncResetReg.v \
-        $(base_dir)/vsrc/AsyncSetReg.v \
+	$(base_dir)/vsrc/AsyncSetReg.v \
 	$(base_dir)/vsrc/ClockDivider.v \
-        $(base_dir)/vsrc/ClockToSignal.v \
-        $(base_dir)/vsrc/SignalToClock.v \
-        
+	$(base_dir)/vsrc/ClockToSignal.v \
+	$(base_dir)/vsrc/SignalToClock.v \
+
 
 sim_vsrcs = \
 	$(generated_dir)/$(MODEL).$(CONFIG).v \

--- a/vsrc/AsyncResetReg.v
+++ b/vsrc/AsyncResetReg.v
@@ -1,6 +1,6 @@
 
 
-/** This black-boxes an Async Set
+/** This black-boxes an Async Reset
   * Reg.
   *  
   * Because Chisel doesn't support
@@ -20,13 +20,8 @@
   *  @param q Data Output
   *  @param clk Clock Input
   *  @param rst Reset Input
+  *  @param en Write Enable Input
   *  
-  *  @param init Value to write at Reset. 
-  *  This is a constant, 
-  *  but this construction
-  *  will likely make backend flows
-  *  and lint tools unhappy.
-  * 
   */
 
 module AsyncResetReg (

--- a/vsrc/AsyncSetReg.v
+++ b/vsrc/AsyncSetReg.v
@@ -43,5 +43,5 @@ module AsyncSetReg (
    end
    
 
-endmodule // AsyncResetReg
+endmodule // AsyncSetReg
 

--- a/vsrc/AsyncSetReg.v
+++ b/vsrc/AsyncSetReg.v
@@ -20,30 +20,26 @@
   *  @param q Data Output
   *  @param clk Clock Input
   *  @param rst Reset Input
-  *  
-  *  @param init Value to write at Reset. 
-  *  This is a constant, 
-  *  but this construction
-  *  will likely make backend flows
-  *  and lint tools unhappy.
+  *  @param en Write Enable Input
   * 
   */
 
-module AsyncResetReg (
+module AsyncSetReg (
                       input      d,
                       output reg q,
-                      input      en,
-
+                      input en,
+                    
                       input      clk,
                       input      rst);
    
    always @(posedge clk or posedge rst) begin
 
       if (rst) begin
-         q <= 1'b0;
+         q <= 1'b1;
       end else if (en) begin
          q <= d;
       end
+   
    end
    
 


### PR DESCRIPTION
The way BlackBox "init" registers were coded before was
not really kosher verilog for most synthesis tools.
Also, the enable logic wasn't really pushed down into the flop.

This change is more explicit about set/reset flops.

Again this is only a temporary fix that would go away
with parametrizable blackboxes (or general async reset support).