### PR TITLE
RR: undefined regs return zeros

### DIFF
--- a/src/main/scala/uncore/tilelink2/Parameters.scala
+++ b/src/main/scala/uncore/tilelink2/Parameters.scala
@@ -98,6 +98,9 @@ case class AddressSet(base: BigInt, mask: BigInt) extends Ordered[AddressSet]
   // A strided slave serves discontiguous ranges
   def strided = alignment1 != mask
 
+  // Widen the match function to ignore all bits in imask
+  def widen(imask: BigInt) = AddressSet(base & ~imask, mask | imask)
+
   // AddressSets have one natural Ordering (the containment order)
   def compare(x: AddressSet) = {
     val primary   = (this.base - x.base).signum // smallest address first

--- a/src/main/scala/uncore/tilelink2/RegisterRouter.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterRouter.scala
@@ -27,7 +27,7 @@ class TLRegisterNode(address: AddressSet, concurrency: Option[Int] = None, beatB
     val (sourceEnd, sourceOff) = (edge.bundle.sourceBits + sizeEnd, sizeEnd)
     val (addrLoEnd, addrLoOff) = (log2Up(beatBytes)      + sourceEnd, sourceEnd)
 
-    val params = RegMapperParams(log2Up(address.mask+1), beatBytes, addrLoEnd)
+    val params = RegMapperParams(log2Up((address.mask+1)/beatBytes), beatBytes, addrLoEnd)
     val in = Wire(Decoupled(new RegMapperInput(params)))
     in.bits.read  := a.bits.opcode === TLMessages.Get
     in.bits.index := a.bits.addr_hi
@@ -36,10 +36,7 @@ class TLRegisterNode(address: AddressSet, concurrency: Option[Int] = None, beatB
     in.bits.extra := Cat(edge.addr_lo(a.bits), a.bits.source, a.bits.size)
 
     // Invoke the register map builder
-    val (endIndex, out) = RegMapper(beatBytes, concurrency, undefZero, in, mapping:_*)
-
-    // All registers must fit inside the device address space
-    require (address.mask >= (endIndex-1)*beatBytes)
+    val out = RegMapper(beatBytes, concurrency, undefZero, in, mapping:_*)
 
     // No flow control needed
     in.valid  := a.valid

--- a/src/main/scala/uncore/tilelink2/RegisterRouterTest.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterRouterTest.scala
@@ -28,11 +28,13 @@ class RRTestCombinational(val bits: Int, rvalid: Bool => Bool, wready: Bool => B
 
   val reg = Reg(UInt(width = bits))
 
-  io.rvalid := rvalid(io.rready)
-  io.wready := wready(io.wvalid)
+  val rvalid_s = rvalid(io.rready)
+  val wready_s = wready(io.wvalid)
+  io.rvalid := rvalid_s
+  io.wready := wready_s
 
   io.rdata := reg
-  when (io.wvalid && io.wready) { reg := io.wdata }
+  when (io.wvalid && wready_s) { reg := io.wdata }
 }
 
 object RRTestCombinational


### PR DESCRIPTION
Restore the default behaviour of the RegisterRouter: undefined registers return zeros and ignore writes.