### PR TITLE
Tl2 cheap address decode

### DIFF
--- a/src/main/scala/rocketchip/Utils.scala
+++ b/src/main/scala/rocketchip/Utils.scala
@@ -77,7 +77,7 @@ object GenerateGlobalAddrMap {
         (if (manager.executable)      AddrMapProt.X else 0), cacheable)
       val multi = manager.address.size > 1
       manager.address.zipWithIndex.map { case (address, i) =>
-        require (!address.strided) // TL1 can't do this
+        require (address.contiguous) // TL1 needs this
         val name = manager.name + (if (multi) ".%d".format(i) else "")
         AddrMapEntry(name, MemRange(address.base, address.mask+1, attr))
       }

--- a/src/main/scala/uncore/tilelink2/Edges.scala
+++ b/src/main/scala/uncore/tilelink2/Edges.scala
@@ -231,7 +231,7 @@ class TLEdgeOut(
   // Transfers
   def Acquire(fromSource: UInt, toAddress: UInt, lgSize: UInt, growPermissions: UInt) = {
     require (manager.anySupportAcquire)
-    val legal = manager.supportsAcquire(toAddress, lgSize)
+    val legal = manager.supportsAcquireFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.Acquire
     a.param   := growPermissions
@@ -245,7 +245,7 @@ class TLEdgeOut(
 
   def Release(fromSource: UInt, toAddress: UInt, lgSize: UInt, shrinkPermissions: UInt) = {
     require (manager.anySupportAcquire)
-    val legal = manager.supportsAcquire(toAddress, lgSize)
+    val legal = manager.supportsAcquireFast(toAddress, lgSize)
     val c = Wire(new TLBundleC(bundle))
     c.opcode  := TLMessages.Release
     c.param   := shrinkPermissions
@@ -260,7 +260,7 @@ class TLEdgeOut(
 
   def Release(fromSource: UInt, toAddress: UInt, lgSize: UInt, shrinkPermissions: UInt, data: UInt) = {
     require (manager.anySupportAcquire)
-    val legal = manager.supportsAcquire(toAddress, lgSize)
+    val legal = manager.supportsAcquireFast(toAddress, lgSize)
     val c = Wire(new TLBundleC(bundle))
     c.opcode  := TLMessages.ReleaseData
     c.param   := shrinkPermissions
@@ -308,7 +308,7 @@ class TLEdgeOut(
   // Accesses
   def Get(fromSource: UInt, toAddress: UInt, lgSize: UInt) = {
     require (manager.anySupportGet)
-    val legal = manager.supportsGet(toAddress, lgSize)
+    val legal = manager.supportsGetFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.Get
     a.param   := UInt(0)
@@ -322,7 +322,7 @@ class TLEdgeOut(
 
   def Put(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt) = {
     require (manager.anySupportPutFull)
-    val legal = manager.supportsPutFull(toAddress, lgSize)
+    val legal = manager.supportsPutFullFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.PutFullData
     a.param   := UInt(0)
@@ -336,7 +336,7 @@ class TLEdgeOut(
 
   def Put(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, mask : UInt) = {
     require (manager.anySupportPutPartial)
-    val legal = manager.supportsPutPartial(toAddress, lgSize)
+    val legal = manager.supportsPutPartialFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.PutPartialData
     a.param   := UInt(0)
@@ -350,7 +350,7 @@ class TLEdgeOut(
 
   def Arithmetic(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, atomic: UInt) = {
     require (manager.anySupportArithmetic)
-    val legal = manager.supportsArithmetic(toAddress, lgSize)
+    val legal = manager.supportsArithmeticFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.ArithmeticData
     a.param   := atomic
@@ -364,7 +364,7 @@ class TLEdgeOut(
 
   def Logical(fromSource: UInt, toAddress: UInt, lgSize: UInt, data: UInt, atomic: UInt) = {
     require (manager.anySupportLogical)
-    val legal = manager.supportsLogical(toAddress, lgSize)
+    val legal = manager.supportsLogicalFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.LogicalData
     a.param   := atomic
@@ -378,7 +378,7 @@ class TLEdgeOut(
 
   def Hint(fromSource: UInt, toAddress: UInt, lgSize: UInt, param: UInt) = {
     require (manager.anySupportHint)
-    val legal = manager.supportsHint(toAddress, lgSize)
+    val legal = manager.supportsHintFast(toAddress, lgSize)
     val a = Wire(new TLBundleA(bundle))
     a.opcode  := TLMessages.Hint
     a.param   := param
@@ -445,7 +445,7 @@ class TLEdgeIn(
   // Transfers
   def Probe(fromAddress: UInt, toSource: UInt, lgSize: UInt, capPermissions: UInt) = {
     require (client.anySupportProbe)
-    val legal = client.supportsProbe(fromAddress, lgSize)
+    val legal = client.supportsProbe(toSource, lgSize)
     val b = Wire(new TLBundleB(bundle))
     b.opcode  := TLMessages.Probe
     b.param   := capPermissions

--- a/src/main/scala/uncore/tilelink2/Fragmenter.scala
+++ b/src/main/scala/uncore/tilelink2/Fragmenter.scala
@@ -189,7 +189,7 @@ class TLFragmenter(minSize: Int, maxSize: Int, alwaysMin: Boolean = false) exten
     val maxLgHints       = maxHints      .map(m => if (m == 0) lgMinSize else UInt(log2Ceil(m)))
 
     // If this is infront of a single manager, these become constants
-    val find = manager.find(edgeIn.address(in.a.bits))
+    val find = manager.findFast(edgeIn.address(in.a.bits))
     val maxLgArithmetic  = Mux1H(find, maxLgArithmetics)
     val maxLgLogical     = Mux1H(find, maxLgLogicals)
     val maxLgGet         = Mux1H(find, maxLgGets)

--- a/src/main/scala/uncore/tilelink2/Fuzzer.scala
+++ b/src/main/scala/uncore/tilelink2/Fuzzer.scala
@@ -163,10 +163,12 @@ class TLFuzzer(
                               edge.Hint(src, addr, size, UInt(0))
                             } else { (glegal, gbits) }
 
+    val legal_dest = edge.manager.containsSafe(addr)
+
     // Pick a specific message to try to send
     val a_type_sel  = noiseMaker(3, inc)
 
-    val legal = MuxLookup(a_type_sel, glegal, Seq(
+    val legal = legal_dest && MuxLookup(a_type_sel, glegal, Seq(
       UInt("b000") -> glegal,
       UInt("b001") -> pflegal,
       UInt("b010") -> pplegal,

--- a/src/main/scala/uncore/tilelink2/Fuzzer.scala
+++ b/src/main/scala/uncore/tilelink2/Fuzzer.scala
@@ -218,14 +218,18 @@ class ClockDivider extends BlackBox {
 class TLFuzzRAM extends LazyModule
 {
   val model = LazyModule(new TLRAMModel)
-  val ram  = LazyModule(new TLRAM(AddressSet(0, 0x3ff)))
+  val ram  = LazyModule(new TLRAM(AddressSet(0x800, 0x7ff)))
+  val ram2 = LazyModule(new TLRAM(AddressSet(0, 0x3ff), beatBytes = 16))
   val gpio = LazyModule(new RRTest1(0x400))
   val xbar = LazyModule(new TLXbar)
+  val xbar2= LazyModule(new TLXbar)
   val fuzz = LazyModule(new TLFuzzer(5000))
   val cross = LazyModule(new TLAsyncCrossing)
 
   model.node := fuzz.node
-  xbar.node := TLWidthWidget(TLHintHandler(model.node), 16)
+  xbar2.node := model.node
+  ram2.node := TLFragmenter(xbar2.node, 16, 256)
+  xbar.node := TLWidthWidget(TLHintHandler(xbar2.node), 16)
   cross.node := TLFragmenter(TLBuffer(xbar.node), 4, 256)
   ram.node := cross.node
   gpio.node := TLFragmenter(TLBuffer(xbar.node), 4, 32)

--- a/src/main/scala/uncore/tilelink2/HintHandler.scala
+++ b/src/main/scala/uncore/tilelink2/HintHandler.scala
@@ -45,7 +45,7 @@ class TLHintHandler(supportManagers: Boolean = true, supportClients: Boolean = f
 
       // Who wants what?
       val address = edgeIn.address(in.a.bits)
-      val handleA = if (passthrough) !edgeOut.manager.supportsHint(address, edgeIn.size(in.a.bits)) else Bool(true)
+      val handleA = if (passthrough) !edgeOut.manager.supportsHintFast(address, edgeIn.size(in.a.bits)) else Bool(true)
       val hintBitsAtA = handleA && in.a.bits.opcode === TLMessages.Hint
       val hintWantsD = in.a.valid && hintBitsAtA
       val outerWantsD = out.d.valid
@@ -57,7 +57,7 @@ class TLHintHandler(supportManagers: Boolean = true, supportClients: Boolean = f
       assert (!hintHoldsD || hintWantsD)
 
       in.d.valid  := Mux(hintWinsD, hintWantsD, outerWantsD)
-      in.d.bits   := Mux(hintWinsD, edgeIn.HintAck(in.a.bits, edgeOut.manager.findId(address)), out.d.bits)
+      in.d.bits   := Mux(hintWinsD, edgeIn.HintAck(in.a.bits, edgeOut.manager.findIdStartFast(address)), out.d.bits)
       out.d.ready := in.d.ready && !hintHoldsD
 
       in.a.ready  := Mux(hintBitsAtA, hintWinsD && in.d.ready, out.a.ready)

--- a/src/main/scala/uncore/tilelink2/Monitor.scala
+++ b/src/main/scala/uncore/tilelink2/Monitor.scala
@@ -24,7 +24,7 @@ object TLMonitor
     val mask = edge.full_mask(bundle)
 
     when (bundle.opcode === TLMessages.Acquire) {
-      assert (edge.manager.supportsAcquire(edge.address(bundle), bundle.size), "'A' channel carries Acquire type unsupported by manager" + extra)
+      assert (edge.manager.supportsAcquireSafe(edge.address(bundle), bundle.size), "'A' channel carries Acquire type unsupported by manager" + extra)
       assert (source_ok, "'A' channel Acquire carries invalid source ID" + extra)
       assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'A' channel Acquire smaller than a beat" + extra)
       assert (is_aligned, "'A' channel Acquire address not aligned to size" + extra)
@@ -33,7 +33,7 @@ object TLMonitor
     }
 
     when (bundle.opcode === TLMessages.Get) {
-      assert (edge.manager.supportsGet(edge.address(bundle), bundle.size), "'A' channel carries Get type unsupported by manager" + extra)
+      assert (edge.manager.supportsGetSafe(edge.address(bundle), bundle.size), "'A' channel carries Get type unsupported by manager" + extra)
       assert (source_ok, "'A' channel Get carries invalid source ID" + extra)
       assert (is_aligned, "'A' channel Get address not aligned to size" + extra)
       assert (bundle.param === UInt(0), "'A' channel Get carries invalid param" + extra)
@@ -41,7 +41,7 @@ object TLMonitor
     }
 
     when (bundle.opcode === TLMessages.PutFullData) {
-      assert (edge.manager.supportsPutFull(edge.address(bundle), bundle.size), "'A' channel carries PutFull type unsupported by manager" + extra)
+      assert (edge.manager.supportsPutFullSafe(edge.address(bundle), bundle.size), "'A' channel carries PutFull type unsupported by manager" + extra)
       assert (source_ok, "'A' channel PutFull carries invalid source ID" + extra)
       assert (is_aligned, "'A' channel PutFull address not aligned to size" + extra)
       assert (bundle.param === UInt(0), "'A' channel PutFull carries invalid param" + extra)
@@ -49,7 +49,7 @@ object TLMonitor
     }
 
     when (bundle.opcode === TLMessages.PutPartialData) {
-      assert (edge.manager.supportsPutPartial(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type unsupported by manager" + extra)
+      assert (edge.manager.supportsPutPartialSafe(edge.address(bundle), bundle.size), "'A' channel carries PutPartial type unsupported by manager" + extra)
       assert (source_ok, "'A' channel PutPartial carries invalid source ID" + extra)
       assert (is_aligned, "'A' channel PutPartial address not aligned to size" + extra)
       assert (bundle.param === UInt(0), "'A' channel PutPartial carries invalid param" + extra)
@@ -57,7 +57,7 @@ object TLMonitor
     }
 
     when (bundle.opcode === TLMessages.ArithmeticData) {
-      assert (edge.manager.supportsArithmetic(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type unsupported by manager" + extra)
+      assert (edge.manager.supportsArithmeticSafe(edge.address(bundle), bundle.size), "'A' channel carries Arithmetic type unsupported by manager" + extra)
       assert (source_ok, "'A' channel Arithmetic carries invalid source ID" + extra)
       assert (is_aligned, "'A' channel Arithmetic address not aligned to size" + extra)
       assert (TLAtomics.isArithmetic(bundle.param), "'A' channel Arithmetic carries invalid opcode param" + extra)
@@ -65,7 +65,7 @@ object TLMonitor
     }
 
     when (bundle.opcode === TLMessages.LogicalData) {
-      assert (edge.manager.supportsLogical(edge.address(bundle), bundle.size), "'A' channel carries Logical type unsupported by manager" + extra)
+      assert (edge.manager.supportsLogicalSafe(edge.address(bundle), bundle.size), "'A' channel carries Logical type unsupported by manager" + extra)
       assert (source_ok, "'A' channel Logical carries invalid source ID" + extra)
       assert (is_aligned, "'A' channel Logical address not aligned to size" + extra)
       assert (TLAtomics.isLogical(bundle.param), "'A' channel Logical carries invalid opcode param" + extra)
@@ -73,7 +73,7 @@ object TLMonitor
     }
 
     when (bundle.opcode === TLMessages.Hint) {
-      assert (edge.manager.supportsHint(edge.address(bundle), bundle.size), "'A' channel carries Hint type unsupported by manager" + extra)
+      assert (edge.manager.supportsHintSafe(edge.address(bundle), bundle.size), "'A' channel carries Hint type unsupported by manager" + extra)
       assert (source_ok, "'A' channel Hint carries invalid source ID" + extra)
       assert (is_aligned, "'A' channel Hint address not aligned to size" + extra)
       assert (bundle.mask === mask, "'A' channel Hint contains invalid mask" + extra)
@@ -84,7 +84,7 @@ object TLMonitor
     assert (TLMessages.isB(bundle.opcode), "'B' channel has invalid opcode" + extra)
 
     // Reuse these subexpressions to save some firrtl lines
-    val address_ok = edge.manager.contains(bundle.source)
+    val address_ok = edge.manager.containsSafe(edge.address(bundle))
     val is_aligned = edge.isHiAligned(bundle.addr_hi, bundle.size)
     val mask = edge.full_mask(bundle)
 
@@ -150,7 +150,7 @@ object TLMonitor
 
     val source_ok = edge.client.contains(bundle.source)
     val is_aligned = edge.isHiAligned(bundle.addr_hi, bundle.size) && edge.isLoAligned(bundle.addr_lo, bundle.size)
-    val address_ok = edge.manager.contains(bundle.source)
+    val address_ok = edge.manager.containsSafe(edge.address(bundle))
 
     when (bundle.opcode === TLMessages.ProbeAck) {
       assert (address_ok, "'C' channel ProbeAck carries unmanaged address" + extra)
@@ -171,7 +171,7 @@ object TLMonitor
     }
 
     when (bundle.opcode === TLMessages.Release) {
-      assert (edge.manager.supportsAcquire(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
+      assert (edge.manager.supportsAcquireSafe(edge.address(bundle), bundle.size), "'C' channel carries Release type unsupported by manager" + extra)
       assert (source_ok, "'C' channel Release carries invalid source ID" + extra)
       assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'C' channel Release smaller than a beat" + extra)
       assert (is_aligned, "'C' channel Release address not aligned to size" + extra)
@@ -180,7 +180,7 @@ object TLMonitor
     }
 
     when (bundle.opcode === TLMessages.ReleaseData) {
-      assert (edge.manager.supportsAcquire(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
+      assert (edge.manager.supportsAcquireSafe(edge.address(bundle), bundle.size), "'C' channel carries ReleaseData type unsupported by manager" + extra)
       assert (source_ok, "'C' channel ReleaseData carries invalid source ID" + extra)
       assert (bundle.size >= UInt(log2Ceil(edge.manager.beatBytes)), "'C' channel ReleaseData smaller than a beat" + extra)
       assert (is_aligned, "'C' channel ReleaseData address not aligned to size" + extra)

--- a/src/main/scala/uncore/tilelink2/Parameters.scala
+++ b/src/main/scala/uncore/tilelink2/Parameters.scala
@@ -95,10 +95,8 @@ case class AddressSet(base: BigInt, mask: BigInt) extends Ordered[AddressSet]
 
   // The number of bytes to which the manager must be aligned
   def alignment = ((mask + 1) & ~mask)
-
   // Is this a contiguous memory range
   def contiguous = alignment == mask+1
-  def strided = alignment != mask+1
 
   def finite = mask >= 0
   def max = { require (finite); base | mask }
@@ -162,7 +160,7 @@ case class TLManagerParameters(
   lazy val dts = customDTS.getOrElse {
     val header = s"${name} {\n"
     val middle = address.map { a =>
-      require (!a.strided) // Config String does not support this
+      require (a.contiguous) // Config String is not so flexible
       "  addr 0x%x;\n  size 0x%x;\n".format(a.base, a.mask+1)
     }
     val footer = "}\n"

--- a/src/main/scala/uncore/tilelink2/RAMModel.scala
+++ b/src/main/scala/uncore/tilelink2/RAMModel.scala
@@ -119,7 +119,7 @@ class TLRAMModel extends LazyModule
     val a_addr_hi = a.addr_hi | (a_beats1 & ~a_counter1)
     val a_base = edge.address(a)
     val a_mask = edge.mask(a_base, a_size)
-    val a_fifo = edge.manager.hasFifoId(a_base)
+    val a_fifo = edge.manager.hasFifoIdFast(a_base)
 
     // Grab the concurrency state we need
     val a_inc_bytes = inc_bytes.map(_.read(a_addr_hi))
@@ -203,7 +203,7 @@ class TLRAMModel extends LazyModule
     val d_base = d_flight.base
     val d_addr_hi = d_base >> shift | (d_beats1 & ~d_counter1)
     val d_mask = edge.mask(d_base, d_size)
-    val d_fifo = edge.manager.hasFifoId(d_flight.base)
+    val d_fifo = edge.manager.hasFifoIdFast(d_flight.base)
 
     // Grab the concurrency state we need
     val d_inc_bytes = inc_bytes.map(_.read(d_addr_hi))
@@ -222,7 +222,8 @@ class TLRAMModel extends LazyModule
 
       // Check the response is correct
       assert (d_size === d_flight.size)
-      assert (edge.manager.findId(d_flight.base) === d.sink)
+      assert (edge.manager.findIdStartFast(d_flight.base) <= d.sink)
+      assert (edge.manager.findIdEndFast  (d_flight.base) > d.sink)
       // addr_lo is allowed to differ
 
       when (d_flight.opcode === TLMessages.Hint) {

--- a/src/main/scala/uncore/tilelink2/RegisterRouter.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterRouter.scala
@@ -75,7 +75,7 @@ object TLRegisterNode
 abstract class TLRegisterRouterBase(address: AddressSet, interrupts: Int, concurrency: Option[Int], beatBytes: Int, undefZero: Boolean) extends LazyModule
 {
   val node = TLRegisterNode(address, concurrency, beatBytes, undefZero)
-  val intnode = IntSourceNode(name + s" @ ${address.base}", interrupts)
+  val intnode = IntSourceNode(interrupts)
 }
 
 case class TLRegBundleArg(interrupts: Vec[Vec[Bool]], in: Vec[TLBundle])

--- a/src/main/scala/uncore/tilelink2/RegisterRouter.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterRouter.scala
@@ -12,7 +12,7 @@ class TLRegisterNode(address: AddressSet, concurrency: Option[Int] = None, beatB
     supportsPutFull    = TransferSizes(1, beatBytes),
     fifoId             = Some(0))) // requests are handled in order
 {
-  require (!address.strided)
+  require (address.contiguous)
 
   // Calling this method causes the matching TL2 bundle to be
   // configured to route all requests to the listed RegFields.


### PR DESCRIPTION
This reduces the circuit complexity for all TL2 components which must inspect the address.