### PR TITLE
Rename Coreplex/Peripheral bus, some Coreplex bundle names

### DIFF
--- a/src/main/scala/coreplex/Coreplex.scala
+++ b/src/main/scala/coreplex/Coreplex.scala
@@ -40,7 +40,7 @@ class DefaultCoreplexModule[+L <: DefaultCoreplex, +B <: DefaultCoreplexBundle](
 
 trait TileClockResetBundle {
   val c: CoreplexConfig
-  val trcs = Vec(c.nTiles, new Bundle {
+  val tcrs = Vec(c.nTiles, new Bundle {
     val clock = Clock(INPUT)
     val reset = Bool(INPUT)
   })
@@ -51,21 +51,21 @@ trait AsyncConnection {
   val tiles: Seq[Tile]
   val uncoreTileIOs: Seq[TileIO]
 
-  (tiles, uncoreTileIOs, io.trcs).zipped foreach { case (tile, uncore, trc) =>
-    tile.clock := trc.clock
-    tile.reset := trc.reset
+  (tiles, uncoreTileIOs, io.tcrs).zipped foreach { case (tile, uncore, tcr) =>
+    tile.clock := tcr.clock
+    tile.reset := tcr.reset
 
-    (uncore.cached zip tile.io.cached) foreach { case (u, t) => u <> AsyncTileLinkFrom(trc.clock, trc.reset, t) }
-    (uncore.uncached zip tile.io.uncached) foreach { case (u, t) => u <> AsyncUTileLinkFrom(trc.clock, trc.reset, t) }
-    tile.io.slave.foreach { _ <> AsyncUTileLinkTo(trc.clock, trc.reset, uncore.slave.get)}
+    (uncore.cached zip tile.io.cached) foreach { case (u, t) => u <> AsyncTileLinkFrom(tcr.clock, tcr.reset, t) }
+    (uncore.uncached zip tile.io.uncached) foreach { case (u, t) => u <> AsyncUTileLinkFrom(tcr.clock, tcr.reset, t) }
+    tile.io.slave.foreach { _ <> AsyncUTileLinkTo(tcr.clock, tcr.reset, uncore.slave.get)}
 
     val ti = tile.io.interrupts
     val ui = uncore.interrupts
-    ti.debug := LevelSyncTo(trc.clock, ui.debug)
-    ti.mtip := LevelSyncTo(trc.clock, ui.mtip)
-    ti.msip := LevelSyncTo(trc.clock, ui.msip)
-    ti.meip := LevelSyncTo(trc.clock, ui.meip)
-    ti.seip.foreach { _ := LevelSyncTo(trc.clock, ui.seip.get) }
+    ti.debug := LevelSyncTo(tcr.clock, ui.debug)
+    ti.mtip := LevelSyncTo(tcr.clock, ui.mtip)
+    ti.msip := LevelSyncTo(tcr.clock, ui.msip)
+    ti.meip := LevelSyncTo(tcr.clock, ui.meip)
+    ti.seip.foreach { _ := LevelSyncTo(tcr.clock, ui.seip.get) }
 
     tile.io.hartid := uncore.hartid
     tile.io.resetVector := uncore.resetVector

--- a/src/main/scala/groundtest/BusMasterTest.scala
+++ b/src/main/scala/groundtest/BusMasterTest.scala
@@ -69,7 +69,7 @@ class BusMasterTest(implicit p: Parameters) extends GroundTest()(p)
        s_req_check :: s_resp_check :: s_done :: Nil) = Enum(Bits(), 8)
   val state = Reg(init = s_idle)
 
-  val busMasterBlock = addrMap("io:ext:busmaster").start >> p(CacheBlockOffsetBits)
+  val busMasterBlock = addrMap("io:pbus:busmaster").start >> p(CacheBlockOffsetBits)
   val start_acq = Put(
     client_xact_id = UInt(0),
     addr_block = UInt(busMasterBlock),

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -137,7 +137,7 @@ class WithComparator extends Config(
     case BuildGroundTest =>
       (p: Parameters) => Module(new ComparatorCore()(p))
     case ComparatorKey => ComparatorParameters(
-      targets    = Seq("mem", "io:ext:TL2:testram").map(name =>
+      targets    = Seq("mem", "io:pbus:TL2:testram").map(name =>
                     site(GlobalAddrMap)(name).start.longValue),
       width      = 8,
       operations = 1000,

--- a/src/main/scala/groundtest/Regression.scala
+++ b/src/main/scala/groundtest/Regression.scala
@@ -72,7 +72,7 @@ class IOGetAfterPutBlockRegression(implicit p: Parameters) extends Regression()(
   io.mem.grant.ready := Bool(true)
 
   io.cache.req.valid := !get_sent && started
-  io.cache.req.bits.addr := UInt(addrMap("io:ext:TL2:bootrom").start)
+  io.cache.req.bits.addr := UInt(addrMap("io:pbus:TL2:bootrom").start)
   io.cache.req.bits.typ := UInt(log2Ceil(32 / 8))
   io.cache.req.bits.cmd := M_XRD
   io.cache.req.bits.tag := UInt(0)

--- a/src/main/scala/rocket/dcache.scala
+++ b/src/main/scala/rocket/dcache.scala
@@ -119,7 +119,7 @@ class DCache(implicit p: Parameters) extends L1HellaCacheModule()(p) {
       require(nWays == 1)
       metaWriteArb.io.out.ready := true
       metaReadArb.io.out.ready := !metaWriteArb.io.out.valid
-      val inScratchpad = addrMap(s"io:int:dmem${tileId}").containsAddress(s1_paddr)
+      val inScratchpad = addrMap(s"io:cbus:dmem${tileId}").containsAddress(s1_paddr)
       val hitState = Mux(inScratchpad, ClientMetadata.onReset.onHit(M_XWR), ClientMetadata.onReset)
       (inScratchpad, hitState, L1Metadata(UInt(0), ClientMetadata.onReset))
     } else {

--- a/src/main/scala/rocketchip/BaseTop.scala
+++ b/src/main/scala/rocketchip/BaseTop.scala
@@ -65,11 +65,11 @@ abstract class BaseTopModule[+L <: BaseTop, +B <: BaseTopBundle](
   val coreplex = p(BuildCoreplex)(outer.c, p)
   val coreplexIO = coreplex.io
 
-  val mmioNetwork =
-    Module(new TileLinkRecursiveInterconnect(1, p(GlobalAddrMap).subMap("io:ext"))(
+  val pBus =
+    Module(new TileLinkRecursiveInterconnect(1, p(GlobalAddrMap).subMap("io:pbus"))(
       p.alterPartial({ case TLId => "L2toMMIO" })))
-  mmioNetwork.io.in.head <> coreplexIO.master.mmio.get
-  outer.legacy.module.io.legacy <> mmioNetwork.port("TL2")
+  pBus.io.in.head <> coreplexIO.master.mmio.get
+  outer.legacy.module.io.legacy <> pBus.port("TL2")
 
   println("Generated Address Map")
   for (entry <- p(GlobalAddrMap).flatten) {

--- a/src/main/scala/rocketchip/BaseTop.scala
+++ b/src/main/scala/rocketchip/BaseTop.scala
@@ -36,8 +36,7 @@ abstract class BaseTop(q: Parameters) extends LazyModule {
     nExtInterrupts = pInterrupts.sum,
     nSlaves = pBusMasters.sum,
     nMemChannels = q(NMemoryChannels),
-    hasSupervisor = q(UseVM),
-    hasExtMMIOPort = true
+    hasSupervisor = q(UseVM)
   )
 
   lazy val genGlobalAddrMap = GenerateGlobalAddrMap(q, pDevices.get, peripheryManagers)
@@ -68,7 +67,7 @@ abstract class BaseTopModule[+L <: BaseTop, +B <: BaseTopBundle](
   val pBus =
     Module(new TileLinkRecursiveInterconnect(1, p(GlobalAddrMap).subMap("io:pbus"))(
       p.alterPartial({ case TLId => "L2toMMIO" })))
-  pBus.io.in.head <> coreplexIO.master.mmio.get
+  pBus.io.in.head <> coreplexIO.master.mmio
   outer.legacy.module.io.legacy <> pBus.port("TL2")
 
   println("Generated Address Map")

--- a/src/main/scala/rocketchip/ExampleTop.scala
+++ b/src/main/scala/rocketchip/ExampleTop.scala
@@ -62,8 +62,8 @@ class ExampleMultiClockTopBundle(p: Parameters) extends ExampleTopBundle(p)
 class ExampleMultiClockTopModule[+L <: ExampleMultiClockTop, +B <: ExampleMultiClockTopBundle](p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b) {
   val multiClockCoreplexIO = coreplexIO.asInstanceOf[MultiClockCoreplexBundle]
 
-  multiClockCoreplexIO.trcs foreach { trc =>
-    trc.clock := clock
-    trc.reset := reset
+  multiClockCoreplexIO.tcrs foreach { tcr =>
+    tcr.clock := clock
+    tcr.reset := reset
   }
 }

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -204,10 +204,10 @@ trait PeripheryMasterMMIOModule extends HasPeripheryParameters {
   implicit val p: Parameters
   val outer: PeripheryMasterMMIO
   val io: PeripheryMasterMMIOBundle
-  val mmioNetwork: TileLinkRecursiveInterconnect
+  val pBus: TileLinkRecursiveInterconnect
 
   val mmio_ports = p(ExtMMIOPorts) map { port =>
-    TileLinkWidthAdapter(mmioNetwork.port(port.name), "MMIO_Outermost")
+    TileLinkWidthAdapter(pBus.port(port.name), "MMIO_Outermost")
   }
 
   val mmio_axi_start = 0


### PR DESCRIPTION
These were bothering me while I was adding multiclock support to the Coreplex, but split into a separate PR.  This commit renames the coreplex/peripheral bus to cbus and pbus, and changes the Coreplex bundle names.