### PR TITLE
Correct Merge Conflict -- clock, not clk

### DIFF
--- a/vsrc/TestDriver.v
+++ b/vsrc/TestDriver.v
@@ -9,7 +9,7 @@ module TestDriver;
   reg clock = 1'b0;
   reg reset = 1'b1;
 
-  always #(`CLOCK_PERIOD/2.0) clk = ~clk;
+  always #(`CLOCK_PERIOD/2.0) clock = ~clock;
   initial #(`RESET_DELAY) reset = 0;
 
   // Read input arguments and initialize


### PR DESCRIPTION
I think there was a merge conflict somewhere. This should be 'clock', not 'clk'