### PR TITLE
tilelink2 Fragmenter: Mask low bits of D channel addr_lo

### DIFF
--- a/src/main/scala/uncore/tilelink2/Fragmenter.scala
+++ b/src/main/scala/uncore/tilelink2/Fragmenter.scala
@@ -168,6 +168,7 @@ class TLFragmenter(minSize: Int, maxSize: Int, alwaysMin: Boolean = false) exten
     out.d.ready := in.d.ready || drop
     in.d.valid  := out.d.valid && !drop
     in.d.bits   := out.d.bits // pass most stuff unchanged
+    in.d.bits.addr_lo := out.d.bits.addr_lo & ~dsizeOH1
     in.d.bits.source := out.d.bits.source >> fragmentBits
     in.d.bits.size   := Mux(dFirst, dFirst_size, dOrig)
 


### PR DESCRIPTION
This fixes an issue where `addr_lo` was being passed through unchanged, which triggered unaligned address assertions in the Monitor.