### PR TITLE
Move Coreplex to separate clock in ExampleMultiClockTop

### DIFF
--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -74,6 +74,11 @@ abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](
   val nUncachedPorts = tiles.map(tile => tile.io.uncached.size).reduce(_ + _)
   val nBanks = c.nMemChannels * nBanksPerMemChannel
 
+  val uncoreExtMem = Wire(Vec(c.nMemChannels, new ClientUncachedTileLinkIO()(outermostParams)))
+  val uncoreExtMMIO = Wire(new ClientUncachedTileLinkIO()(outermostMMIOParams))
+  val uncoreExtSlave = Wire(Vec(c.nSlaves, new ClientUncachedTileLinkIO()(innerParams)))
+  val uncoreExtDebug = Wire(new DebugBusIO)
+
   // Build an uncore backing the Tiles
   buildUncore(p.alterPartial({
     case HastiId => "TL"
@@ -106,7 +111,7 @@ abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](
     // Wire the tiles to the TileLink client ports of the L1toL2 network,
     // and coherence manager(s) to the other side
     l1tol2net.io.clients_cached <> uncoreTileIOs.map(_.cached).flatten
-    l1tol2net.io.clients_uncached <> uncoreTileIOs.map(_.uncached).flatten ++ io.slave
+    l1tol2net.io.clients_uncached <> uncoreTileIOs.map(_.uncached).flatten ++ uncoreExtSlave
     l1tol2net.io.managers <> managerEndpoints.map(_.innerTL) :+ mmioManager.io.inner
 
     // Create a converter between TileLinkIO and MemIO for each channel
@@ -120,7 +125,7 @@ abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](
       TileLinkWidthAdapter(icPort, unwrap.io.out)
     }
 
-    io.master.mem <> mem_ic.io.out
+    uncoreExtMem <> mem_ic.io.out
 
     buildMMIONetwork(TileLinkEnqueuer(mmioManager.io.outer, 1))(
         p.alterPartial({case TLId => "L2toMMIO"}))
@@ -142,7 +147,7 @@ abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](
 
     val debugModule = Module(new DebugModule)
     debugModule.io.tl <> cBus.port("cbus:debug")
-    debugModule.io.db <> io.debug
+    debugModule.io.db <> uncoreExtDebug
 
     // connect coreplex-internal interrupts to tiles
     for ((tile, i) <- (uncoreTileIOs zipWithIndex)) {
@@ -158,7 +163,7 @@ abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](
     for ((t, m) <- (uncoreTileIOs.map(_.slave).flatten) zip (tileSlavePorts map (cBus port _)))
       t <> m
 
-    io.master.mmio <> cBus.port("pbus")
+    uncoreExtMMIO <> cBus.port("pbus")
   }
 
   // Coreplex doesn't know when to stop running

--- a/src/main/scala/coreplex/Coreplex.scala
+++ b/src/main/scala/coreplex/Coreplex.scala
@@ -5,11 +5,18 @@ import cde.{Parameters, Field}
 import junctions._
 import uncore.tilelink._
 import uncore.util._
+import uncore.devices.{DebugBusIO, AsyncDebugBusFrom}
 import rocket._
 
 trait DirectConnection {
   val tiles: Seq[Tile]
   val uncoreTileIOs: Seq[TileIO]
+
+  val io: BaseCoreplexBundle
+  val uncoreExtMem: Vec[ClientUncachedTileLinkIO]
+  val uncoreExtMMIO: ClientUncachedTileLinkIO
+  val uncoreExtSlave: Vec[ClientUncachedTileLinkIO]
+  val uncoreExtDebug: DebugBusIO
 
   val tlBuffering = TileLinkDepths(1,1,2,2,0)
   val ultBuffering = UncachedTileLinkDepths(1,2)
@@ -24,6 +31,11 @@ trait DirectConnection {
     tile.io.hartid := uncore.hartid
     tile.io.resetVector := uncore.resetVector
   }
+
+  io.master.mem <> uncoreExtMem
+  io.master.mmio <> uncoreExtMMIO
+  uncoreExtSlave <> io.slave
+  uncoreExtDebug <> io.debug
 }
 
 class DefaultCoreplex(c: CoreplexConfig)(implicit p: Parameters) extends BaseCoreplex(c)(p) {
@@ -32,26 +44,36 @@ class DefaultCoreplex(c: CoreplexConfig)(implicit p: Parameters) extends BaseCor
 
 class DefaultCoreplexBundle(c: CoreplexConfig)(implicit p: Parameters) extends BaseCoreplexBundle(c)(p)
 
-class DefaultCoreplexModule[+L <: DefaultCoreplex, +B <: DefaultCoreplexBundle](
-    c: CoreplexConfig, l: L, b: => B)(implicit p: Parameters) extends BaseCoreplexModule(c, l, b)(p)
-    with DirectConnection
+class DefaultCoreplexModule[+L <: DefaultCoreplex, +B <: DefaultCoreplexBundle]
+  (c: CoreplexConfig, l: L, b: => B)(implicit p: Parameters)
+  extends BaseCoreplexModule(c, l, b)(p) with DirectConnection
 
 /////
 
-trait TileClockResetBundle {
+trait HasExtraClockResets {
   val c: CoreplexConfig
   val tcrs = Vec(c.nTiles, new Bundle {
     val clock = Clock(INPUT)
     val reset = Bool(INPUT)
   })
+  val extcr = new Bundle {
+    val clock = Clock(INPUT)
+    val reset = Bool(INPUT)
+  }
 }
 
 trait AsyncConnection {
-  val io: TileClockResetBundle
+  val io: BaseCoreplexBundle
+  val cio = io.asInstanceOf[HasExtraClockResets]
+
   val tiles: Seq[Tile]
   val uncoreTileIOs: Seq[TileIO]
+  val uncoreExtMem: Vec[ClientUncachedTileLinkIO]
+  val uncoreExtMMIO: ClientUncachedTileLinkIO
+  val uncoreExtSlave: Vec[ClientUncachedTileLinkIO]
+  val uncoreExtDebug: DebugBusIO
 
-  (tiles, uncoreTileIOs, io.tcrs).zipped foreach { case (tile, uncore, tcr) =>
+  (tiles, uncoreTileIOs, cio.tcrs).zipped foreach { case (tile, uncore, tcr) =>
     tile.clock := tcr.clock
     tile.reset := tcr.reset
 
@@ -61,24 +83,36 @@ trait AsyncConnection {
 
     val ti = tile.io.interrupts
     val ui = uncore.interrupts
-    ti.debug := LevelSyncTo(tcr.clock, ui.debug)
-    ti.mtip := LevelSyncTo(tcr.clock, ui.mtip)
-    ti.msip := LevelSyncTo(tcr.clock, ui.msip)
+    // These two come from outside the coreplex
+    ti.mtip := LevelSyncCrossing(cio.extcr.clock, tcr.clock, ui.mtip)
+    ti.msip := LevelSyncCrossing(cio.extcr.clock, tcr.clock, ui.msip)
+    // These come from inside the coreplex
     ti.meip := LevelSyncTo(tcr.clock, ui.meip)
+    ti.debug := LevelSyncTo(tcr.clock, ui.debug)
     ti.seip.foreach { _ := LevelSyncTo(tcr.clock, ui.seip.get) }
 
     tile.io.hartid := uncore.hartid
     tile.io.resetVector := uncore.resetVector
   }
+
+
+  io.master.mem.zip(uncoreExtMem).foreach { case (ext, uncore) =>
+    ext <> AsyncUTileLinkTo(cio.extcr.clock, cio.extcr.reset, uncore)
+  }
+  io.master.mmio <> AsyncUTileLinkTo(cio.extcr.clock, cio.extcr.reset, uncoreExtMMIO)
+  uncoreExtSlave.zip(io.slave).foreach { case (uncore, ext) =>
+    uncore <> AsyncUTileLinkFrom(cio.extcr.clock, cio.extcr.reset, ext)
+  }
+  uncoreExtDebug <> AsyncDebugBusFrom(cio.extcr.clock, cio.extcr.reset, io.debug)
 }
 
 class MultiClockCoreplex(c: CoreplexConfig)(implicit p: Parameters) extends BaseCoreplex(c)(p) {
   override lazy val module = Module(new MultiClockCoreplexModule(c, this, new MultiClockCoreplexBundle(c)(p))(p))
 }
 
-class MultiClockCoreplexBundle(c: CoreplexConfig)(implicit p: Parameters) extends BaseCoreplexBundle(c)(p)
-    with TileClockResetBundle
+class MultiClockCoreplexBundle(c: CoreplexConfig)(implicit p: Parameters)
+  extends BaseCoreplexBundle(c)(p) with HasExtraClockResets
 
-class MultiClockCoreplexModule[+L <: MultiClockCoreplex, +B <: MultiClockCoreplexBundle](
-    c: CoreplexConfig, l: L, b: => B)(implicit p: Parameters) extends BaseCoreplexModule(c, l, b)(p)
-    with AsyncConnection
+class MultiClockCoreplexModule[+L <: MultiClockCoreplex, +B <: MultiClockCoreplexBundle]
+  (c: CoreplexConfig, l: L, b: => B)(implicit p: Parameters)
+  extends BaseCoreplexModule(c, l, b)(p) with AsyncConnection

--- a/src/main/scala/groundtest/Coreplex.scala
+++ b/src/main/scala/groundtest/Coreplex.scala
@@ -10,7 +10,8 @@ class GroundTestCoreplex(c: CoreplexConfig)(implicit p: Parameters) extends Base
 
 class GroundTestCoreplexBundle(c: CoreplexConfig)(implicit p: Parameters) extends BaseCoreplexBundle(c)(p)
 
-class GroundTestCoreplexModule[+L <: GroundTestCoreplex, +B <: GroundTestCoreplexBundle](
-    c: CoreplexConfig, l: L, b: => B)(implicit p: Parameters) extends BaseCoreplexModule(c, l, b)(p) with DirectConnection {
+class GroundTestCoreplexModule[+L <: GroundTestCoreplex, +B <: GroundTestCoreplexBundle]
+    (c: CoreplexConfig, l: L, b: => B)(implicit p: Parameters)
+    extends BaseCoreplexModule(c, l, b)(p) with DirectConnection {
   io.success := tiles.flatMap(_.io.elements get "success").map(_.asInstanceOf[Bool]).reduce(_&&_)
 }

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -188,3 +188,16 @@ class WithJtagDTM extends Config (
     case _ => throw new CDEMatchError
   }
 )
+
+class WithMultiClock extends Config(
+  (pname, site, here) => pname match {
+    case BuildCoreplex => (c: CoreplexConfig, p: Parameters) =>
+      LazyModule(new MultiClockCoreplex(c)(p)).module
+    case BuildExampleTop => (p: Parameters) =>
+      LazyModule(new ExampleMultiClockTop(p))
+    case _ => throw new CDEMatchError
+  }
+)
+
+class MultiClockConfig extends Config(
+  new WithMultiClock ++ new BaseConfig)

--- a/src/main/scala/rocketchip/ExampleTop.scala
+++ b/src/main/scala/rocketchip/ExampleTop.scala
@@ -7,6 +7,7 @@ import cde.{Parameters, Field}
 import junctions._
 import coreplex._
 import rocketchip._
+import util.Pow2ClockDivider
 
 /** Example Top with Periphery */
 class ExampleTop(q: Parameters) extends BaseTop(q)
@@ -59,11 +60,18 @@ class ExampleMultiClockTop(q: Parameters) extends ExampleTop(q)
 
 class ExampleMultiClockTopBundle(p: Parameters) extends ExampleTopBundle(p)
 
-class ExampleMultiClockTopModule[+L <: ExampleMultiClockTop, +B <: ExampleMultiClockTopBundle](p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b) {
+class ExampleMultiClockTopModule[+L <: ExampleMultiClockTop, +B <: ExampleMultiClockTopBundle]
+    (p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b) {
   val multiClockCoreplexIO = coreplexIO.asInstanceOf[MultiClockCoreplexBundle]
 
+  val coreplexDivider = Module(new Pow2ClockDivider(2))
+  coreplex.clock := coreplexDivider.io.clock_out
+
   multiClockCoreplexIO.tcrs foreach { tcr =>
-    tcr.clock := clock
+    val tileDivider = Module(new Pow2ClockDivider(1))
+    tcr.clock := tileDivider.io.clock_out
     tcr.reset := reset
   }
+  multiClockCoreplexIO.extcr.clock := clock
+  multiClockCoreplexIO.extcr.reset := reset
 }


### PR DESCRIPTION
This moves the coreplex as a whole to a separate clock and adds synchronizers from the coreplex to the periphery.

It also uses clock dividers to simulate that things work even if coreplex clock, tile clock and main clock are all different.

The one unsettled question is whether we need synchronizers for the interrupts and coreplex-local interrupts. Currently, the coreplex-local interrupts remain high until the tile intervenes to set them low, so perhaps it's okay? There might still be metastability events though.