### PR TITLE
fix some incorrect behavior on enabling external mmio port.

### DIFF
--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -31,8 +31,8 @@ trait HasCoreplexParameters {
   lazy val nBanksPerMemChannel = p(NBanksPerMemoryChannel)
   lazy val lsb = p(BankIdLSB)
   lazy val innerParams = p.alterPartial({ case TLId => "L1toL2" })
+  lazy val innerMMIOParams = p.alterPartial({ case TLId => "L2toMMIO" })
   lazy val outermostParams = p.alterPartial({ case TLId => "Outermost" })
-  lazy val outermostMMIOParams = p.alterPartial({ case TLId => "MMIO_Outermost" })
   lazy val globalAddrMap = p(rocketchip.GlobalAddrMap)
 }
 
@@ -51,7 +51,7 @@ abstract class BaseCoreplex(c: CoreplexConfig)(implicit p: Parameters) extends L
 abstract class BaseCoreplexBundle(val c: CoreplexConfig)(implicit val p: Parameters) extends Bundle with HasCoreplexParameters {
   val master = new Bundle {
     val mem = Vec(c.nMemChannels, new ClientUncachedTileLinkIO()(outermostParams))
-    val mmio = new ClientUncachedTileLinkIO()(outermostMMIOParams)
+    val mmio = new ClientUncachedTileLinkIO()(innerMMIOParams)
   }
   val slave = Vec(c.nSlaves, new ClientUncachedTileLinkIO()(innerParams)).flip
   val interrupts = Vec(c.nExtInterrupts, Bool()).asInput

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -207,7 +207,7 @@ trait PeripheryMasterMMIOModule extends HasPeripheryParameters {
   val pBus: TileLinkRecursiveInterconnect
 
   val mmio_ports = p(ExtMMIOPorts) map { port =>
-    TileLinkWidthAdapter(pBus.port(port.name), "MMIO_Outermost")
+    TileLinkWidthAdapter(pBus.port(port.name), "MMIO_Outermost")(outermostMMIOParams)
   }
 
   val mmio_axi_start = 0


### PR DESCRIPTION
When I config ExtMMIOPorts with MIFDataBits == 128, there two issue.
1. undefined TLId error
2. MSB of DataBeats TL signal is unconnected.

This commit fix them.