### PR TITLE
Fixup Tracegen

### DIFF
--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -12,8 +12,8 @@ CXXSRCS := emulator SimDTM
 CXXFLAGS := $(CXXFLAGS) -std=c++11 -I$(RISCV)/include -I$(base_dir)/csrc
 LDFLAGS := $(LDFLAGS) -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib -L$(abspath $(sim_dir)) -lfesvr -lpthread
 
-emu = emulator-$(MODEL)-$(CONFIG)
-emu_debug = emulator-$(MODEL)-$(CONFIG)-debug
+emu = emulator-$(PROJECT)-$(CONFIG)
+emu_debug = emulator-$(PROJECT)-$(CONFIG)-debug
 
 include $(sim_dir)/Makefrag-verilator
 

--- a/scripts/tracegen+check.sh
+++ b/scripts/tracegen+check.sh
@@ -30,7 +30,7 @@
 
 START_SEED=${START_SEED-0}
 NUM_TESTS=${NUM_TESTS-100}
-EMU=${EMU-emulator-Top-TraceGenConfig}
+EMU=${EMU-emulator-groundtest-TraceGenConfig}
 TRACE_GEN=${TRACE_GEN-tracegen.py}
 TO_AXE=${TO_AXE-toaxe.py}
 AXE=${AXE-axe}

--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -115,9 +115,9 @@ abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](
     val outerTLParams = p.alterPartial({ case TLId => "L2toMC" })
     val backendBuffering = TileLinkDepths(0,0,0,0,0)
     for ((bank, icPort) <- managerEndpoints zip mem_ic.io.in) {
-      val unwrap = Module(new ClientTileLinkIOUnwrapper()(outerTLParams))
-      unwrap.io.in <> TileLinkEnqueuer(bank.outerTL, backendBuffering)(outerTLParams)
-      TileLinkWidthAdapter(icPort, unwrap.io.out)
+      val enqueued = TileLinkEnqueuer(bank.outerTL, backendBuffering)
+      val unwrapped = TileLinkIOUnwrapper(enqueued)
+      TileLinkWidthAdapter(icPort, unwrapped)
     }
 
     io.master.mem <> mem_ic.io.out

--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -32,7 +32,7 @@ trait HasCoreplexParameters {
   lazy val lsb = p(BankIdLSB)
   lazy val innerParams = p.alterPartial({ case TLId => "L1toL2" })
   lazy val outermostParams = p.alterPartial({ case TLId => "Outermost" })
-  lazy val outermostMMIOParams = p.alterPartial({ case TLId => "MMIO_Outermost" })
+  lazy val outerMMIOParams = p.alterPartial({ case TLId => "L2toMMIO" })
   lazy val globalAddrMap = p(rocketchip.GlobalAddrMap)
 }
 
@@ -51,7 +51,7 @@ abstract class BaseCoreplex(c: CoreplexConfig)(implicit p: Parameters) extends L
 abstract class BaseCoreplexBundle(val c: CoreplexConfig)(implicit val p: Parameters) extends Bundle with HasCoreplexParameters {
   val master = new Bundle {
     val mem = Vec(c.nMemChannels, new ClientUncachedTileLinkIO()(outermostParams))
-    val mmio = new ClientUncachedTileLinkIO()(outermostMMIOParams)
+    val mmio = new ClientUncachedTileLinkIO()(outerMMIOParams)
   }
   val slave = Vec(c.nSlaves, new ClientUncachedTileLinkIO()(innerParams)).flip
   val interrupts = Vec(c.nExtInterrupts, Bool()).asInput
@@ -122,8 +122,7 @@ abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](
 
     io.master.mem <> mem_ic.io.out
 
-    buildMMIONetwork(TileLinkEnqueuer(mmioManager.io.outer, 1))(
-        p.alterPartial({case TLId => "L2toMMIO"}))
+    buildMMIONetwork(TileLinkEnqueuer(mmioManager.io.outer, 1))(outerMMIOParams)
   }
 
   def buildMMIONetwork(mmio: ClientUncachedTileLinkIO)(implicit p: Parameters) = {

--- a/src/main/scala/coreplex/Coreplex.scala
+++ b/src/main/scala/coreplex/Coreplex.scala
@@ -15,9 +15,9 @@ trait DirectConnection {
   val ultBuffering = UncachedTileLinkDepths(1,2)
 
   (tiles zip uncoreTileIOs) foreach { case (tile, uncore) =>
-    (uncore.cached zip tile.io.cached) foreach { case (u, t) => u <> TileLinkEnqueuer(t, tlBuffering)(t.p) }
-    (uncore.uncached zip tile.io.uncached) foreach { case (u, t) => u <> TileLinkEnqueuer(t, ultBuffering)(t.p) }
-    tile.io.slave.foreach { _ <> TileLinkEnqueuer(uncore.slave.get, 1)(uncore.slave.get.p) }
+    (uncore.cached zip tile.io.cached) foreach { case (u, t) => u <> TileLinkEnqueuer(t, tlBuffering) }
+    (uncore.uncached zip tile.io.uncached) foreach { case (u, t) => u <> TileLinkEnqueuer(t, ultBuffering) }
+    tile.io.slave.foreach { _ <> TileLinkEnqueuer(uncore.slave.get, 1) }
 
     tile.io.interrupts <> uncore.interrupts
 

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -239,11 +239,10 @@ class WithTraceGen extends Config(
       val nSets = 32 // L2 NSets
       val nWays = 1
       val blockOffset = site(CacheBlockOffsetBits)
-      val baseAddr = site(GlobalAddrMap)("mem").start
       val nBeats = site(MIFDataBeats)
       List.tabulate(4 * nWays) { i =>
-        Seq.tabulate(nBeats) { j => (j * 8) + ((i * nSets) << blockOffset) }
-      }.flatten.map(addr => baseAddr + BigInt(addr))
+        Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
+      }.flatten
     }
     case UseAtomics => true
     case _ => throw new CDEMatchError

--- a/src/main/scala/groundtest/TraceGen.scala
+++ b/src/main/scala/groundtest/TraceGen.scala
@@ -60,6 +60,7 @@ case object AddressBag extends Field[List[BigInt]]
 
 trait HasTraceGenParams {
   implicit val p: Parameters
+  val pAddrBits           = p(PAddrBits)
   val numGens             = p(NTiles)
   val numBitsInId         = log2Up(numGens)
   val numReqsPerGen       = p(GeneratorKey).maxRequests
@@ -178,12 +179,17 @@ class TagMan(val logNumTags : Int) extends Module {
 class TraceGenerator(id: Int)
     (implicit p: Parameters) extends L1HellaCacheModule()(p)
                                 with HasAddrMapParameters
-                                with HasTraceGenParams {
+                                with HasTraceGenParams
+                                with HasGroundTestParameters {
   val io = new Bundle {
     val finished = Bool(OUTPUT)
     val timeout = Bool(OUTPUT)
     val mem = new HellaCacheIO
   }
+
+  val totalNumAddrs = addressBag.size + numExtraAddrs
+  val initCount = Reg(init = UInt(0, log2Up(totalNumAddrs)))
+  val initDone = Reg(init = Bool(false))
 
   val reqTimer = Module(new Timer(8192, maxTags))
   reqTimer.io.start.valid := io.mem.req.fire()
@@ -199,12 +205,11 @@ class TraceGenerator(id: Int)
   // Address bag, shared by all cores, taken from module parameters.
   // In addition, there is a per-core random selection of extra addresses.
 
-  val baseAddr = addrMap("mem").start + 0x01000000
+  val bagOfAddrs = addressBag.map(x => UInt(memStart + x, pAddrBits))
 
-  val bagOfAddrs = addressBag.map(x => UInt(x, numBitsInWord))
-
-  val extraAddrs = (0 to numExtraAddrs-1).
-                   map(i => Reg(UInt(width = 16)))
+  val extraAddrs = Seq.fill(numExtraAddrs) {
+    UInt(memStart + Random.nextInt(1 << 16) * numBytesInWord, pAddrBits)
+  }
 
   // A random index into the address bag.
 
@@ -220,6 +225,9 @@ class TraceGenerator(id: Int)
 
   // Random address from the address bag or the extra addresses.
 
+  val extraAddrIndices = (0 to numExtraAddrs-1)
+                          .map(i => UInt(i, logNumExtraAddrs))
+
   val randAddr =
         if (! genExtraAddrs) {
           randAddrFromBag
@@ -230,10 +238,6 @@ class TraceGenerator(id: Int)
           val randExtraAddrIndex = LCG(logNumExtraAddrs)
 
           // A random address from the extra addresses.
-
-          val extraAddrIndices = (0 to numExtraAddrs-1).
-                                 map(i => UInt(i, logNumExtraAddrs))
-  
           val randAddrFromExtra = Cat(UInt(0),
                 MuxLookup(randExtraAddrIndex, UInt(0),
                   extraAddrIndices.zip(extraAddrs)), UInt(0, 3))
@@ -242,6 +246,12 @@ class TraceGenerator(id: Int)
             (1, randAddrFromBag),
             (1, randAddrFromExtra)))
         }
+
+  val allAddrs = extraAddrs ++ bagOfAddrs
+  val allAddrIndices = (0 until totalNumAddrs)
+    .map(i => UInt(i, log2Ceil(totalNumAddrs)))
+  val initAddr = MuxLookup(initCount, UInt(0),
+    allAddrIndices.zip(allAddrs))
 
   // Random opcodes
   // --------------
@@ -352,7 +362,7 @@ class TraceGenerator(id: Int)
     // No-op
     when (currentOp === opNop) {
       // Move on to a new operation
-      currentOp := randOp
+      currentOp := Mux(initDone, randOp, opStore)
     }
 
     // Fence
@@ -396,7 +406,7 @@ class TraceGenerator(id: Int)
           currentOp === opSwap) {
       when (canSendFreshReq) {
         // Set address
-        reqAddr := randAddr
+        reqAddr := Mux(initDone, randAddr, initAddr)
         // Set command
         when (currentOp === opLoad) {
           reqCmd := M_XRD
@@ -408,7 +418,13 @@ class TraceGenerator(id: Int)
         // Send request
         sendFreshReq := Bool(true)
         // Move on to a new operation
-        currentOp := randOp
+        when (!initDone && initCount =/= UInt(totalNumAddrs - 1)) {
+          initCount := initCount + UInt(1)
+          currentOp := opStore
+        } .otherwise {
+          currentOp := randOp
+          initDone := Bool(true)
+        }
       }
     }
   
@@ -548,7 +564,8 @@ class TraceGenerator(id: Int)
 
 class NoiseGenerator(implicit val p: Parameters) extends Module
     with HasTraceGenParams
-    with HasTileLinkParameters {
+    with HasTileLinkParameters
+    with HasGroundTestParameters {
   val io = new Bundle {
     val mem = new ClientUncachedTileLinkIO
     val finished = Bool(INPUT)
@@ -583,7 +600,7 @@ class NoiseGenerator(implicit val p: Parameters) extends Module
   val tlBlockOffset = tlBeatAddrBits + tlByteAddrBits
   val addr_idx = LCG(logAddressBagLen, io.mem.acquire.fire())
   val addr_bag = Vec(addressBag.map(
-    addr => UInt(addr >> tlBlockOffset, tlBlockAddrBits)))
+    addr => UInt(memStartBlock + (addr >> tlBlockOffset), tlBlockAddrBits)))
   val addr_block = addr_bag(addr_idx)
   val addr_beat = LCG(tlBeatAddrBits, io.mem.acquire.fire())
   val acq_select = LCG(1, io.mem.acquire.fire())

--- a/src/main/scala/uncore/agents/Agents.scala
+++ b/src/main/scala/uncore/agents/Agents.scala
@@ -139,7 +139,7 @@ abstract class ManagerCoherenceAgent(implicit p: Parameters) extends CoherenceAg
     with HasCoherenceAgentWiringHelpers {
   val io = new ManagerTLIO
   def innerTL = io.inner
-  def outerTL = TileLinkIOWrapper(io.outer)(p.alterPartial({case TLId => p(OuterTLId)}))
+  def outerTL = TileLinkIOWrapper(io.outer)
   def incoherent = io.incoherent
 }
 

--- a/src/main/scala/uncore/util/Enqueuer.scala
+++ b/src/main/scala/uncore/util/Enqueuer.scala
@@ -22,29 +22,29 @@ class TileLinkEnqueuer(depths: TileLinkDepths)(implicit p: Parameters) extends M
 }
 
 object TileLinkEnqueuer {
-  def apply(in: TileLinkIO, depths: TileLinkDepths)(implicit p: Parameters): TileLinkIO = {
-    val t = Module(new TileLinkEnqueuer(depths))
+  def apply(in: TileLinkIO, depths: TileLinkDepths): TileLinkIO = {
+    val t = Module(new TileLinkEnqueuer(depths)(in.p))
     t.io.client <> in
     t.io.manager
   }
-  def apply(in: TileLinkIO, depth: Int)(implicit p: Parameters): TileLinkIO = {
+  def apply(in: TileLinkIO, depth: Int): TileLinkIO = {
     apply(in, TileLinkDepths(depth, depth, depth, depth, depth))
   }
 
-  def apply(in: ClientTileLinkIO, depths: TileLinkDepths)(implicit p: Parameters): ClientTileLinkIO = {
-    val t = Module(new ClientTileLinkEnqueuer(depths))
+  def apply(in: ClientTileLinkIO, depths: TileLinkDepths): ClientTileLinkIO = {
+    val t = Module(new ClientTileLinkEnqueuer(depths)(in.p))
     t.io.inner <> in
     t.io.outer
   }
-  def apply(in: ClientTileLinkIO, depth: Int)(implicit p: Parameters): ClientTileLinkIO = {
+  def apply(in: ClientTileLinkIO, depth: Int): ClientTileLinkIO = {
     apply(in, TileLinkDepths(depth, depth, depth, depth, depth))
   }
-  def apply(in: ClientUncachedTileLinkIO, depths: UncachedTileLinkDepths)(implicit p: Parameters): ClientUncachedTileLinkIO = {
-    val t = Module(new ClientUncachedTileLinkEnqueuer(depths))
+  def apply(in: ClientUncachedTileLinkIO, depths: UncachedTileLinkDepths): ClientUncachedTileLinkIO = {
+    val t = Module(new ClientUncachedTileLinkEnqueuer(depths)(in.p))
     t.io.inner <> in
     t.io.outer
   }
-  def apply(in: ClientUncachedTileLinkIO, depth: Int)(implicit p: Parameters): ClientUncachedTileLinkIO = {
+  def apply(in: ClientUncachedTileLinkIO, depth: Int): ClientUncachedTileLinkIO = {
     apply(in, UncachedTileLinkDepths(depth, depth))
   }
 }


### PR DESCRIPTION
There have been some changes to AXE which break our current implementation of TraceGen. These fixes help us get back on track. Basically, we have to make sure we store some known value to all of the addresses we are using before we do any other operation.