### PR TITLE
Async rst async queue

### DIFF
--- a/src/main/scala/junctions/asyncqueue.scala
+++ b/src/main/scala/junctions/asyncqueue.scala
@@ -76,7 +76,10 @@ class AsyncQueueSink[T <: Data](gen: T, depth: Int, sync: Int, clockIn: Clock, r
   // On an FPGA, only one input changes at a time => mem updates don't cause glitches
   // The register only latches when the selected valued is not being written
   val index = if (depth == 1) UInt(0) else ridx(bits-1, 0) ^ (ridx(bits, bits) << (bits-1))
-  io.deq.bits  := RegEnable(io.mem(index), valid && !reset) // This does NOT need to be reset.
+  // This register does not NEED to be reset, as its contents will not
+  // be considered unless deq_reg is true.
+  io.deq.bits  := RegEnable(io.mem(index), valid) 
+    
 
   val deq_reg = AsyncResetReg(valid, 0)
   io.deq.valid := deq_reg

--- a/src/main/scala/junctions/asyncqueue.scala
+++ b/src/main/scala/junctions/asyncqueue.scala
@@ -5,19 +5,24 @@ import Chisel._
 
 object GrayCounter {
   def apply(bits: Int, increment: Bool = Bool(true)): UInt = {
-    val binary = RegInit(UInt(0, width = bits))
-    val incremented = binary + increment.asUInt()
-    binary := incremented
+    val binary = Module (new AsyncRegVec(w=bits, 0))//RegInit(UInt(0, width = bits))
+    val incremented = binary.io.q + increment.asUInt()
+    binary.io.d := incremented
+    binary.io.en := Bool(true)
     incremented ^ (incremented >> UInt(1))
   }
 }
 
 object AsyncGrayCounter {
   def apply(in: UInt, sync: Int): UInt = {
-    val syncv = RegInit(Vec.fill(sync){UInt(0, width = in.getWidth)})
-    syncv.last := in
-    (syncv.init zip syncv.tail).foreach { case (sink, source) => sink := source }
-    syncv(0)
+    val syncv = Vec.fill(sync)(new AsyncResetRegVec(w = in.getWidth, 0))//RegInit(Vec.fill(sync){UInt(0, width = in.getWidth)})
+    syncv.last.io.d := in
+      (syncv.init zip syncv.tail).foreach { case (sink, source) => {
+        sink.io.d := source.io.q
+        sink.io.en := Bool(true)
+      }
+      }
+    syncv(0).io.d
   }
 }
 
@@ -33,15 +38,23 @@ class AsyncQueueSource[T <: Data](gen: T, depth: Int, sync: Int, clockIn: Clock,
     val mem  = Vec(depth, gen).asOutput
   }
 
-  val mem = Reg(Vec(depth, gen))
+  val mem = Reg(Vec(depth, gen)) //This does NOT need to be asynchronously reset.
   val widx = GrayCounter(bits+1, io.enq.fire())
   val ridx = AsyncGrayCounter(io.ridx, sync)
   val ready = widx =/= (ridx ^ UInt(depth | depth >> 1))
 
   val index = if (depth == 1) UInt(0) else io.widx(bits-1, 0) ^ (io.widx(bits, bits) << (bits-1))
   when (io.enq.fire() && !reset) { mem(index) := io.enq.bits }
-  io.enq.ready := RegNext(ready, Bool(false))
-  io.widx := RegNext(widx, UInt(0))
+  val ready_reg = Module(neq AsyncResetRegVec(1, 0))
+  ready_reg.io.d := ready
+  ready_reg.io.en := Bool(true)
+  io.enq.ready := ready_reg.io.q
+
+  val widx_reg = Module (new AsyncResetRegVec(bits + 1, 0))
+  widx_reg.io.d := widx
+  widx_reg.io.en := Bool(true)
+  io.widx := widx_reg.io.q
+
   io.mem := mem
 }
 
@@ -66,9 +79,17 @@ class AsyncQueueSink[T <: Data](gen: T, depth: Int, sync: Int, clockIn: Clock, r
   // On an FPGA, only one input changes at a time => mem updates don't cause glitches
   // The register only latches when the selected valued is not being written
   val index = if (depth == 1) UInt(0) else ridx(bits-1, 0) ^ (ridx(bits, bits) << (bits-1))
-  io.deq.bits  := RegEnable(io.mem(index), valid && !reset)
-  io.deq.valid := RegNext(valid, Bool(false))
-  io.ridx := RegNext(ridx, UInt(0))
+  io.deq.bits  := RegEnable(io.mem(index), valid && !reset) // This does NOT need to be reset.
+
+  val deq_reg = Module (new AsyncResetRegVec(1, 0))
+  deq_reg.io.d := valid
+  deq_reg.io.en := Bool(true)
+  io.deq.valid := deq_reg.io.q //RegNext(valid, Bool(false))
+
+  val ridx_reg = Module (new AsyncResetRegVec(bits + 1, 0))
+  ridx_reg.io.d := ridx
+  ridx_reg.io.en := Bool(true)
+  io.ridx := ridx_reg.io.q //RegNext(ridx, UInt(0))
 }
 
 class AsyncQueue[T <: Data](gen: T, depth: Int = 8, sync: Int = 3) extends Crossing[T] {

--- a/src/main/scala/junctions/asyncqueue.scala
+++ b/src/main/scala/junctions/asyncqueue.scala
@@ -17,6 +17,7 @@ object AsyncGrayCounter {
   def apply(in: UInt, sync: Int): UInt = {
     val syncv = List.fill(sync)(Module (new AsyncResetRegVec(w = in.getWidth, 0)))
     syncv.last.io.d := in
+    syncv.last.io.en := Bool(true)
       (syncv.init zip syncv.tail).foreach { case (sink, source) => {
         sink.io.d := source.io.q
         sink.io.en := Bool(true)


### PR DESCRIPTION
@terpstra @yunsup 

In general, it's a good idea to have asynchronous reset on the crossing FIFOs, since the blocks may come out of reset at different times, clocks may not have started yet, etc.

This PR achieves that and blows away the non-async-reset option.

Are there any other low-level crossing primitives that need this treatment?