### PR TITLE
Periphery: make bus width and arithmetic atomics configurable

### DIFF
--- a/src/main/scala/rocketchip/BaseTop.scala
+++ b/src/main/scala/rocketchip/BaseTop.scala
@@ -49,7 +49,12 @@ abstract class BaseTop(q: Parameters) extends LazyModule {
 
   val legacy = LazyModule(new TLLegacy()(p.alterPartial({ case TLId => "L2toMMIO" })))
 
-  peripheryBus.node := TLWidthWidget(legacy.tlDataBytes)(TLBuffer()(TLAtomicAutomata()(TLHintHandler()(legacy.node))))
+  peripheryBus.node :=
+    TLWidthWidget(legacy.tlDataBytes)(
+    TLBuffer()(
+    TLAtomicAutomata(arithmetic = p(PeripheryBusKey).arithAMO)(
+    TLHintHandler()(
+    legacy.node))))
 }
 
 abstract class BaseTopBundle(val p: Parameters) extends Bundle {

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -42,6 +42,7 @@ class BasePlatformConfig extends Config(
         case BuildCoreplex =>
           (c: CoreplexConfig, p: Parameters) => uncore.tilelink2.LazyModule(new DefaultCoreplex(c)(p)).module
         case NExtTopInterrupts => 2
+        case PeripheryBusKey => PeripheryBusConfig(arithAMO = true, beatBytes = 4)
         // Note that PLIC asserts that this is > 0.
         case AsyncDebugBus => false
         case IncludeJtagDTM => false

--- a/src/main/scala/uncore/devices/Prci.scala
+++ b/src/main/scala/uncore/devices/Prci.scala
@@ -48,7 +48,7 @@ trait CoreplexLocalInterrupterModule extends Module with HasRegMap with MixCorep
   val timeWidth = 64
   val regWidth = 32
   // demand atomic accesses for RV64
-  require(c.beatBytes == (p(rocket.XLen) min timeWidth)/8)
+  require(c.beatBytes >= (p(rocket.XLen) min timeWidth)/8)
 
   val time = Seq.fill(timeWidth/regWidth)(Reg(init=UInt(0, width = regWidth)))
   when (io.rtcTick) {


### PR DESCRIPTION
This removes the hard-coded constants that had started pervading the design and leverages the new RegisterRouter's flexibility of bus width.