### PR TITLE
AXI Fragmenter

### DIFF
--- a/src/main/scala/uncore/converters/Nasti.scala
+++ b/src/main/scala/uncore/converters/Nasti.scala
@@ -383,3 +383,21 @@ class TileLinkIONastiIOConverter(implicit p: Parameters) extends TLModule()(p)
   io.tl.grant.ready := Mux(tl_b_grant(io.tl.grant.bits),
     io.nasti.b.ready, io.nasti.r.ready)
 }
+
+class NastiConverterTest(implicit p: Parameters) extends unittest.UnitTest {
+  val driver = Module(new junctions.NastiDriver(32, 4, 2))
+  val frag = Module(new junctions.NastiFragmenter)
+  val conv = Module(new TileLinkIONastiIOConverter)
+  val ram = Module(new uncore.devices.TileLinkTestRAM(8))
+
+  driver.io.start := io.start
+  io.finished := driver.io.finished
+
+  frag.io.in <> driver.io.nasti
+  conv.io.nasti.ar <> frag.io.out.ar
+  conv.io.nasti.aw <> Queue(frag.io.out.aw)
+  conv.io.nasti.w  <> Queue(frag.io.out.w)
+  frag.io.out.b <> conv.io.nasti.b
+  frag.io.out.r <> conv.io.nasti.r
+  ram.io <> conv.io.tl
+}

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -25,6 +25,7 @@ class WithUncoreUnitTests extends Config(
     case UnitTests => (p: Parameters) => Seq(
       Module(new uncore.devices.ROMSlaveTest()(p)),
       Module(new uncore.devices.TileLinkRAMTest()(p)),
+      Module(new uncore.converters.NastiConverterTest()(p)),
       Module(new uncore.tilelink2.TLFuzzRAMTest))
     case _ => throw new CDEMatchError
   }


### PR DESCRIPTION
Not sure what happened to Wes' AXI fragmenter for the RISCV workshop demo. We need something like it for our CRAFT verification work, so I figured I would add my own.

For multibeat aw, we wait for the input w request before sending both an aw and w out.

For multibeat ar, we take in the input request and then send some number of output requests. This could be optimized for the case of single beat requests, but I don't think the extra logic is worth it.

We don't forward b responses except for the last one. For r responses, we just mess with the "last" field.

Only one set of transactions with the same ID is allowed to be inflight at a time. We save the lens for each transaction in registers index by the ID.

Since we have the fragmenter, we can also avoid handling multibeat requests in AXI -> TL converter.