### PR TITLE
rocketchip: rename identically names devices with _%d

### DIFF
--- a/src/main/scala/junctions/addrmap.scala
+++ b/src/main/scala/junctions/addrmap.scala
@@ -75,6 +75,8 @@ class AddrMap(
     var prot = 0
     var cacheable = true
     for (AddrMapEntry(name, r) <- entriesIn) {
+      require (!mapping.contains(name))
+
       if (r.start != 0) {
         base = r.start
       } else {

--- a/src/main/scala/rocketchip/Utils.scala
+++ b/src/main/scala/rocketchip/Utils.scala
@@ -83,7 +83,12 @@ object GenerateGlobalAddrMap {
       }
     }.flatten
 
-    lazy val tl2AddrMap = new AddrMap(tl2Devices, collapse = true)
+    lazy val uniquelyNamedTL2Devices =
+      tl2Devices.groupBy(_.name).values.map(_.zipWithIndex.map {
+        case (e, i) => if (i == 0) e else e.copy(name = e.name + "_" + i)
+      }).flatten.toList
+
+    lazy val tl2AddrMap = new AddrMap(uniquelyNamedTL2Devices, collapse = true)
     lazy val pBusIOAddrMap = new AddrMap(AddrMapEntry("TL2", tl2AddrMap) +: (p(ExtMMIOPorts) ++ pDevicesEntries), collapse = true)
 
     val memBase = 0x80000000L


### PR DESCRIPTION
If you connect two devices with the same name in TL2 (totally ok there),
when they get put into the TL1 addrmap, one gets silently overwritten.
This renames the second occurance as _1, third as _2, and so on.