### PR TITLE
tilelink2 AddressSet: add .misaligned(low, size) helper method

### DIFF
--- a/src/main/scala/uncore/tilelink2/Parameters.scala
+++ b/src/main/scala/uncore/tilelink2/Parameters.scala
@@ -121,6 +121,29 @@ case class AddressSet(base: BigInt, mask: BigInt) extends Ordered[AddressSet]
   }
 }
 
+object AddressSet
+{
+  def misaligned(base: BigInt, size: BigInt): Seq[AddressSet] = {
+    val largestPow2 = BigInt(1) << log2Floor(size)
+    val mostZeros = (base + size - 1) & ~(largestPow2 - 1)
+    def splitLo(low: BigInt, high: BigInt, tail: Seq[AddressSet]): Seq[AddressSet] = {
+      if (low == high) tail else {
+        val toggleBits = low ^ high
+        val misalignment = toggleBits & (-toggleBits)
+        splitLo(low+misalignment, high, AddressSet(low, misalignment-1) +: tail)
+      }
+    }
+    def splitHi(low: BigInt, high: BigInt, tail: Seq[AddressSet]): Seq[AddressSet] = {
+      if (low == high) tail else {
+        val toggleBits = low ^ high
+        val misalignment = toggleBits & (-toggleBits)
+        splitHi(low, high-misalignment, AddressSet(high-misalignment, misalignment-1) +: tail)
+      }
+    }
+    splitLo(base, mostZeros, splitHi(mostZeros, base+size, Seq())).sorted
+  }
+}
+
 case class TLManagerParameters(
   address:            Seq[AddressSet],
   sinkId:             IdRange         = IdRange(0, 1),


### PR DESCRIPTION
This helps devices with misaligned ranges still connect to TL2.