### PR TITLE
Tl2 addr width0

### DIFF
--- a/src/main/scala/uncore/tilelink2/Edges.scala
+++ b/src/main/scala/uncore/tilelink2/Edges.scala
@@ -253,7 +253,7 @@ class TLEdgeOut(
     a.param   := growPermissions
     a.size    := lgSize
     a.source  := fromSource
-    a.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
+    a.addr_hi := addr_hi(toAddress)
     a.mask    := SInt(-1).asUInt
     a.data    := UInt(0)
     (legal, a)
@@ -267,8 +267,8 @@ class TLEdgeOut(
     c.param   := shrinkPermissions
     c.size    := lgSize
     c.source  := fromSource
-    c.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
-    c.addr_lo := toAddress
+    c.addr_hi := addr_hi(toAddress)
+    c.addr_lo := addr_lo(toAddress)
     c.data    := UInt(0)
     c.error   := Bool(false)
     (legal, c)
@@ -282,8 +282,8 @@ class TLEdgeOut(
     c.param   := shrinkPermissions
     c.size    := lgSize
     c.source  := fromSource
-    c.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
-    c.addr_lo := toAddress
+    c.addr_hi := addr_hi(toAddress)
+    c.addr_lo := addr_lo(toAddress)
     c.data    := data
     c.error   := Bool(false)
     (legal, c)
@@ -295,8 +295,8 @@ class TLEdgeOut(
     c.param   := reportPermissions
     c.size    := lgSize
     c.source  := fromSource
-    c.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
-    c.addr_lo := toAddress
+    c.addr_hi := addr_hi(toAddress)
+    c.addr_lo := addr_lo(toAddress)
     c.data    := UInt(0)
     c.error   := Bool(false)
     c
@@ -308,8 +308,8 @@ class TLEdgeOut(
     c.param   := reportPermissions
     c.size    := lgSize
     c.source  := fromSource
-    c.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
-    c.addr_lo := toAddress
+    c.addr_hi := addr_hi(toAddress)
+    c.addr_lo := addr_lo(toAddress)
     c.data    := data
     c.error   := Bool(false)
     c
@@ -330,7 +330,7 @@ class TLEdgeOut(
     a.param   := UInt(0)
     a.size    := lgSize
     a.source  := fromSource
-    a.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
+    a.addr_hi := addr_hi(toAddress)
     a.mask    := mask(toAddress, lgSize)
     a.data    := UInt(0)
     (legal, a)
@@ -344,7 +344,7 @@ class TLEdgeOut(
     a.param   := UInt(0)
     a.size    := lgSize
     a.source  := fromSource
-    a.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
+    a.addr_hi := addr_hi(toAddress)
     a.mask    := mask(toAddress, lgSize)
     a.data    := data
     (legal, a)
@@ -358,7 +358,7 @@ class TLEdgeOut(
     a.param   := UInt(0)
     a.size    := lgSize
     a.source  := fromSource
-    a.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
+    a.addr_hi := addr_hi(toAddress)
     a.mask    := mask
     a.data    := data
     (legal, a)
@@ -372,7 +372,7 @@ class TLEdgeOut(
     a.param   := atomic
     a.size    := lgSize
     a.source  := fromSource
-    a.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
+    a.addr_hi := addr_hi(toAddress)
     a.mask    := mask(toAddress, lgSize)
     a.data    := data
     (legal, a)
@@ -386,7 +386,7 @@ class TLEdgeOut(
     a.param   := atomic
     a.size    := lgSize
     a.source  := fromSource
-    a.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
+    a.addr_hi := addr_hi(toAddress)
     a.mask    := mask(toAddress, lgSize)
     a.data    := data
     (legal, a)
@@ -400,7 +400,7 @@ class TLEdgeOut(
     a.param   := param
     a.size    := lgSize
     a.source  := fromSource
-    a.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
+    a.addr_hi := addr_hi(toAddress)
     a.mask    := mask(toAddress, lgSize)
     a.data    := UInt(0)
     (legal, a)
@@ -415,8 +415,8 @@ class TLEdgeOut(
     c.param   := UInt(0)
     c.size    := lgSize
     c.source  := fromSource
-    c.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
-    c.addr_lo := toAddress
+    c.addr_hi := addr_hi(toAddress)
+    c.addr_lo := addr_lo(toAddress)
     c.data    := UInt(0)
     c.error   := error
     c
@@ -431,8 +431,8 @@ class TLEdgeOut(
     c.param   := UInt(0)
     c.size    := lgSize
     c.source  := fromSource
-    c.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
-    c.addr_lo := toAddress
+    c.addr_hi := addr_hi(toAddress)
+    c.addr_lo := addr_lo(toAddress)
     c.data    := data
     c.error   := error
     c
@@ -445,8 +445,8 @@ class TLEdgeOut(
     c.param   := UInt(0)
     c.size    := lgSize
     c.source  := fromSource
-    c.addr_hi := toAddress >> log2Ceil(manager.beatBytes)
-    c.addr_lo := toAddress
+    c.addr_hi := addr_hi(toAddress)
+    c.addr_lo := addr_lo(toAddress)
     c.data    := UInt(0)
     c.error   := Bool(false)
     c
@@ -467,7 +467,7 @@ class TLEdgeIn(
     b.param   := capPermissions
     b.size    := lgSize
     b.source  := toSource
-    b.addr_hi := fromAddress >> log2Ceil(manager.beatBytes)
+    b.addr_hi := addr_hi(fromAddress)
     b.mask    := SInt(-1).asUInt
     b.data    := UInt(0)
     (legal, b)
@@ -481,7 +481,7 @@ class TLEdgeIn(
     d.size    := lgSize
     d.source  := toSource
     d.sink    := fromSink
-    d.addr_lo := fromAddress
+    d.addr_lo := addr_lo(fromAddress)
     d.data    := UInt(0)
     d.error   := error
     d
@@ -495,7 +495,7 @@ class TLEdgeIn(
     d.size    := lgSize
     d.source  := toSource
     d.sink    := fromSink
-    d.addr_lo := fromAddress
+    d.addr_lo := addr_lo(fromAddress)
     d.data    := data
     d.error   := error
     d
@@ -508,7 +508,7 @@ class TLEdgeIn(
     d.size    := lgSize
     d.source  := toSource
     d.sink    := fromSink
-    d.addr_lo := fromAddress
+    d.addr_lo := addr_lo(fromAddress)
     d.data    := UInt(0)
     d.error   := Bool(false)
     d
@@ -523,7 +523,7 @@ class TLEdgeIn(
     b.param   := UInt(0)
     b.size    := lgSize
     b.source  := toSource
-    b.addr_hi := fromAddress >> log2Ceil(manager.beatBytes)
+    b.addr_hi := addr_hi(fromAddress)
     b.mask    := mask(fromAddress, lgSize)
     b.data    := UInt(0)
     (legal, b)
@@ -537,7 +537,7 @@ class TLEdgeIn(
     b.param   := UInt(0)
     b.size    := lgSize
     b.source  := toSource
-    b.addr_hi := fromAddress >> log2Ceil(manager.beatBytes)
+    b.addr_hi := addr_hi(fromAddress)
     b.mask    := mask(fromAddress, lgSize)
     b.data    := data
     (legal, b)
@@ -551,7 +551,7 @@ class TLEdgeIn(
     b.param   := UInt(0)
     b.size    := lgSize
     b.source  := toSource
-    b.addr_hi := fromAddress >> log2Ceil(manager.beatBytes)
+    b.addr_hi := addr_hi(fromAddress)
     b.mask    := mask
     b.data    := data
     (legal, b)
@@ -565,7 +565,7 @@ class TLEdgeIn(
     b.param   := atomic
     b.size    := lgSize
     b.source  := toSource
-    b.addr_hi := fromAddress >> log2Ceil(manager.beatBytes)
+    b.addr_hi := addr_hi(fromAddress)
     b.mask    := mask(fromAddress, lgSize)
     b.data    := data
     (legal, b)
@@ -579,7 +579,7 @@ class TLEdgeIn(
     b.param   := atomic
     b.size    := lgSize
     b.source  := toSource
-    b.addr_hi := fromAddress >> log2Ceil(manager.beatBytes)
+    b.addr_hi := addr_hi(fromAddress)
     b.mask    := mask(fromAddress, lgSize)
     b.data    := data
     (legal, b)
@@ -593,7 +593,7 @@ class TLEdgeIn(
     b.param   := param
     b.size    := lgSize
     b.source  := toSource
-    b.addr_hi := fromAddress >> log2Ceil(manager.beatBytes)
+    b.addr_hi := addr_hi(fromAddress)
     b.mask    := mask(fromAddress, lgSize)
     b.data    := UInt(0)
     (legal, b)
@@ -609,7 +609,7 @@ class TLEdgeIn(
     d.size    := lgSize
     d.source  := toSource
     d.sink    := fromSink
-    d.addr_lo := fromAddress
+    d.addr_lo := addr_lo(fromAddress)
     d.data    := UInt(0)
     d.error   := error
     d
@@ -625,7 +625,7 @@ class TLEdgeIn(
     d.size    := lgSize
     d.source  := toSource
     d.sink    := fromSink
-    d.addr_lo := fromAddress
+    d.addr_lo := addr_lo(fromAddress)
     d.data    := data
     d.error   := error
     d
@@ -639,7 +639,7 @@ class TLEdgeIn(
     d.size    := lgSize
     d.source  := toSource
     d.sink    := fromSink
-    d.addr_lo := fromAddress
+    d.addr_lo := addr_lo(fromAddress)
     d.data    := UInt(0)
     d.error   := Bool(false)
     d

--- a/src/main/scala/uncore/tilelink2/Edges.scala
+++ b/src/main/scala/uncore/tilelink2/Edges.scala
@@ -171,15 +171,6 @@ class TLEdge(
     }
   }
 
-  def addr_lo(x: TLDataChannel): UInt = {
-    x match {
-      case a: TLBundleA => addr_lo(a.mask, a.size)
-      case b: TLBundleB => addr_lo(b.mask, b.size)
-      case c: TLBundleC => c.addr_lo
-      case d: TLBundleD => d.addr_lo
-    }
-  }
-
   def full_mask(x: TLDataChannel): UInt = {
     x match {
       case a: TLBundleA => full_mask(a.mask, a.size)
@@ -189,13 +180,34 @@ class TLEdge(
     }
   }
 
-  def address(x: TLAddrChannel): UInt = {
-    val hi = x match {
+  def addr_lo(x: TLDataChannel): UInt = {
+    x match {
+      case a: TLBundleA => addr_lo(a.mask, a.size)
+      case b: TLBundleB => addr_lo(b.mask, b.size)
+      case c: TLBundleC => c.addr_lo
+      case d: TLBundleD => d.addr_lo
+    }
+  }
+
+  def addr_hi(x: TLAddrChannel): UInt = {
+    x match {
       case a: TLBundleA => a.addr_hi
       case b: TLBundleB => b.addr_hi
       case c: TLBundleC => c.addr_hi
     }
+  }
+
+  def address(x: TLAddrChannel): UInt = {
+    val hi = addr_hi(x)
     if (manager.beatBytes == 1) hi else Cat(hi, addr_lo(x))
+  }
+
+  def addr_lo(x: UInt): UInt = {
+    if (manager.beatBytes == 1) UInt(0) else x(log2Ceil(manager.beatBytes)-1, 0)
+  }
+
+  def addr_hi(x: UInt): UInt = {
+    x >> log2Ceil(manager.beatBytes)
   }
 
   def numBeats(x: TLChannel): UInt = {

--- a/src/main/scala/uncore/tilelink2/WidthWidget.scala
+++ b/src/main/scala/uncore/tilelink2/WidthWidget.scala
@@ -32,11 +32,12 @@ class TLWidthWidget(innerBeatBytes: Int) extends LazyModule
       val mask = Cat(edgeIn.mask(in.bits), rmask)
       val size = edgeIn.size(in.bits)
       val hasData = edgeIn.hasData(in.bits)
-      val addr_lo = in.bits match {
+      val addr_all = in.bits match {
         case x: TLAddrChannel => edgeIn.address(x)
         case _ => UInt(0)
       }
-      val addr = addr_lo >> log2Ceil(outBytes)
+      val addr_hi = edgeOut.addr_hi(addr_all)
+      val addr_lo = edgeOut.addr_lo(addr_all)
 
       val count = RegInit(UInt(0, width = log2Ceil(ratio)))
       val first = count === UInt(0)
@@ -72,9 +73,9 @@ class TLWidthWidget(innerBeatBytes: Int) extends LazyModule
       edgeOut.data(out.bits) := dataOut
 
       out.bits match {
-        case a: TLBundleA => a.addr_hi := addr; a.mask := maskOut
-        case b: TLBundleB => b.addr_hi := addr; b.mask := maskOut
-        case c: TLBundleC => c.addr_hi := addr; c.addr_lo := addr_lo
+        case a: TLBundleA => a.addr_hi := addr_hi; a.mask := maskOut
+        case b: TLBundleB => b.addr_hi := addr_hi; b.mask := maskOut
+        case c: TLBundleC => c.addr_hi := addr_hi; c.addr_lo := addr_lo
         case d: TLBundleD => ()
           // addr_lo gets padded with 0s on D channel, the only lossy transform in this core
           // this should be safe, because we only care about addr_log on D to determine which


### PR DESCRIPTION
Refactor use of the address into accessor methods addr_{lo,hi}.
This should solve the problem @a0u had with beatBytes==1 on SPI.
This should also make it easier when we bite the bullet and have address (lo+hi) on ABC.