### PR TITLE
Multiclocked Coreplex attempt #2

### DIFF
--- a/src/main/scala/coreplex/Coreplex.scala
+++ b/src/main/scala/coreplex/Coreplex.scala
@@ -61,9 +61,10 @@ trait AsyncConnection {
 
     val ti = tile.io.interrupts
     val ui = uncore.interrupts
+    // These two are already synchronized outside the coreplex
+    ti.mtip := ui.mtip
+    ti.msip := ui.msip
     ti.debug := LevelSyncTo(tcr.clock, ui.debug)
-    ti.mtip := LevelSyncTo(tcr.clock, ui.mtip)
-    ti.msip := LevelSyncTo(tcr.clock, ui.msip)
     ti.meip := LevelSyncTo(tcr.clock, ui.meip)
     ti.seip.foreach { _ := LevelSyncTo(tcr.clock, ui.seip.get) }
 

--- a/src/main/scala/rocketchip/BaseTop.scala
+++ b/src/main/scala/rocketchip/BaseTop.scala
@@ -69,10 +69,20 @@ abstract class BaseTopModule[+L <: BaseTop, +B <: BaseTopBundle](
   val coreplex = p(BuildCoreplex)(outer.c, p)
   val coreplexIO = coreplex.io
 
+  val coreplexDebug = Wire(coreplexIO.debug)
+  val coreplexLocalInt = Wire(coreplexIO.clint)
+  val coreplexMem = Wire(coreplexIO.master.mem)
+  val coreplexMMIO = Wire(coreplexIO.master.mmio)
+  val coreplexSuccess = Wire(Bool())
+  val coreplexSlave = Wire(coreplexIO.slave)
+
+  val coreplexClock = coreplex.clock
+  val coreplexReset = coreplex.reset
+
   val pBus =
     Module(new TileLinkRecursiveInterconnect(1, p(GlobalAddrMap).subMap("io:pbus"))(
       p.alterPartial({ case TLId => "L2toMMIO" })))
-  pBus.io.in.head <> coreplexIO.master.mmio
+  pBus.io.in.head <> coreplexMMIO
   outer.legacy.module.io.legacy <> pBus.port("TL2")
 
   println("Generated Address Map")

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -189,3 +189,14 @@ class WithJtagDTM extends Config (
     case _ => throw new CDEMatchError
   }
 )
+
+class WithMultiClock extends Config(
+  (pname, site, here) => pname match {
+    case BuildCoreplex => (c: CoreplexConfig, p: Parameters) =>
+      LazyModule(new MultiClockCoreplex(c)(p)).module
+    case BuildExampleTop => (p: Parameters) =>
+      LazyModule(new ExampleMultiClockTop(p))
+    case _ => throw new CDEMatchError
+  })
+
+class MultiClockConfig extends Config(new WithMultiClock ++ new BaseConfig)

--- a/src/main/scala/rocketchip/ExampleTop.scala
+++ b/src/main/scala/rocketchip/ExampleTop.scala
@@ -7,6 +7,7 @@ import cde.{Parameters, Field}
 import junctions._
 import coreplex._
 import rocketchip._
+import util.Pow2ClockDivider
 
 /** Example Top with Periphery */
 class ExampleTop(q: Parameters) extends BaseTop(q)
@@ -59,11 +60,13 @@ class ExampleMultiClockTop(q: Parameters) extends ExampleTop(q)
 
 class ExampleMultiClockTopBundle(p: Parameters) extends ExampleTopBundle(p)
 
-class ExampleMultiClockTopModule[+L <: ExampleMultiClockTop, +B <: ExampleMultiClockTopBundle](p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b) {
-  val multiClockCoreplexIO = coreplexIO.asInstanceOf[MultiClockCoreplexBundle]
+class ExampleMultiClockTopModule[+L <: ExampleMultiClockTop, +B <: ExampleMultiClockTopBundle]
+    (p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b) {
+  val multiClockCoreplexIO = coreplexIO.asInstanceOf[TileClockResetBundle]
 
   multiClockCoreplexIO.tcrs foreach { tcr =>
-    tcr.clock := clock
+    val tileDivider = Module(new Pow2ClockDivider(1))
+    tcr.clock := tileDivider.io.clock_out
     tcr.reset := reset
   }
 }

--- a/src/main/scala/rocketchip/ExampleTop.scala
+++ b/src/main/scala/rocketchip/ExampleTop.scala
@@ -9,19 +9,16 @@ import coreplex._
 import rocketchip._
 import util.Pow2ClockDivider
 
-/** Example Top with Periphery */
-class ExampleTop(q: Parameters) extends BaseTop(q)
+abstract class BaseExampleTop(q: Parameters) extends BaseTop(q)
     with PeripheryBootROM
     with PeripheryDebug
     with PeripheryExtInterrupts
     with PeripheryCoreplexLocalInterrupter
     with PeripheryMasterMem
     with PeripheryMasterMMIO
-    with PeripherySlave {
-  override lazy val module = Module(new ExampleTopModule(p, this, new ExampleTopBundle(p)))
-}
+    with PeripherySlave
 
-class ExampleTopBundle(p: Parameters) extends BaseTopBundle(p)
+abstract class BaseExampleTopBundle(p: Parameters) extends BaseTopBundle(p)
     with PeripheryBootROMBundle
     with PeripheryDebugBundle
     with PeripheryExtInterruptsBundle
@@ -30,7 +27,8 @@ class ExampleTopBundle(p: Parameters) extends BaseTopBundle(p)
     with PeripheryMasterMMIOBundle
     with PeripherySlaveBundle
 
-class ExampleTopModule[+L <: ExampleTop, +B <: ExampleTopBundle](p: Parameters, l: L, b: => B) extends BaseTopModule(p, l, b)
+abstract class BaseExampleTopModule[+L <: BaseExampleTop, +B <: BaseExampleTopBundle]
+    (p: Parameters, l: L, b: => B) extends BaseTopModule(p, l, b)
     with PeripheryBootROMModule
     with PeripheryDebugModule
     with PeripheryExtInterruptsModule
@@ -39,6 +37,21 @@ class ExampleTopModule[+L <: ExampleTop, +B <: ExampleTopBundle](p: Parameters, 
     with PeripheryMasterMMIOModule
     with PeripherySlaveModule
     with HardwiredResetVector
+
+/** Example Top with Periphery */
+class ExampleTop(q: Parameters) extends BaseExampleTop(q) {
+  override lazy val module = Module(new ExampleTopModule(p, this, new ExampleTopBundle(p)))
+}
+
+class ExampleTopBundle(p: Parameters) extends BaseExampleTopBundle(p)
+
+class ExampleTopModule[+L <: ExampleTop, +B <: ExampleTopBundle]
+    (p: Parameters, l: L, b: => B) extends BaseExampleTopModule(p, l, b)
+    with DirectDebugConnection
+    with DirectCoreplexLocalInterruptConnection
+    with DirectMemoryConnection
+    with DirectMMIOConnection
+    with DirectSlaveConnection
 
 /** Example Top with TestRAM */
 class ExampleTopWithTestRAM(q: Parameters) extends ExampleTop(q)
@@ -52,21 +65,35 @@ class ExampleTopWithTestRAMBundle(p: Parameters) extends ExampleTopBundle(p)
 class ExampleTopWithTestRAMModule[+L <: ExampleTopWithTestRAM, +B <: ExampleTopWithTestRAMBundle](p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b)
     with PeripheryTestRAMModule
 
-/** Example Top with Multi Clock */
-class ExampleMultiClockTop(q: Parameters) extends ExampleTop(q)
-    with PeripheryTestRAM {
-  override lazy val module = Module(new ExampleMultiClockTopModule(p, this, new ExampleMultiClockTopBundle(p)))
-}
-
-class ExampleMultiClockTopBundle(p: Parameters) extends ExampleTopBundle(p)
-
-class ExampleMultiClockTopModule[+L <: ExampleMultiClockTop, +B <: ExampleMultiClockTopBundle]
-    (p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b) {
+trait HasMultiClockCoreplex {
+  val coreplex: Module
+  val coreplexIO: BaseCoreplexBundle
   val multiClockCoreplexIO = coreplexIO.asInstanceOf[TileClockResetBundle]
+  val tileClocks = multiClockCoreplexIO.tcrs.map(_.clock)
+  val reset: Bool
 
-  multiClockCoreplexIO.tcrs foreach { tcr =>
+  multiClockCoreplexIO.tcrs.foreach { tcr =>
     val tileDivider = Module(new Pow2ClockDivider(1))
     tcr.clock := tileDivider.io.clock_out
     tcr.reset := reset
   }
+
+  val coreplexDivider = Module(new Pow2ClockDivider(2))
+  coreplex.clock := coreplexDivider.io.clock_out
 }
+
+/** Example Top with Multi Clock */
+class ExampleMultiClockTop(q: Parameters) extends BaseExampleTop(q) {
+  override lazy val module = Module(new ExampleMultiClockTopModule(p, this, new ExampleMultiClockTopBundle(p)))
+}
+
+class ExampleMultiClockTopBundle(p: Parameters) extends BaseExampleTopBundle(p)
+
+class ExampleMultiClockTopModule[+L <: ExampleMultiClockTop, +B <: ExampleMultiClockTopBundle]
+    (p: Parameters, l: L, b: => B) extends BaseExampleTopModule(p, l, b)
+    with HasMultiClockCoreplex
+    with AsyncDebugConnection
+    with AsyncCoreplexLocalInterruptConnection
+    with AsyncMemoryConnection
+    with AsyncMMIOConnection
+    with AsyncSlaveConnection

--- a/src/main/scala/rocketchip/TestHarness.scala
+++ b/src/main/scala/rocketchip/TestHarness.scala
@@ -9,7 +9,7 @@ import util.LatencyPipe
 import junctions._
 import junctions.NastiConstants._
 
-case object BuildExampleTop extends Field[Parameters => ExampleTop]
+case object BuildExampleTop extends Field[Parameters => BaseExampleTop]
 case object SimMemLatency extends Field[Int]
 
 class TestHarness(q: Parameters) extends Module {
@@ -17,6 +17,7 @@ class TestHarness(q: Parameters) extends Module {
     val success = Bool(OUTPUT)
   }
   val dut = q(BuildExampleTop)(q).module
+    .asInstanceOf[BaseExampleTopModule[BaseExampleTop, BaseExampleTopBundle]]
   implicit val p = dut.p
 
   // This test harness isn't especially flexible yet


### PR DESCRIPTION
The clock crossers have now been moved into Periphery traits. I'm not sure this is better, I had to mess around with the type system a lot to make this work. I suppose one advantage is that we need not instantiate clock crossers for the debug bus if the debug bus is disabled. I'm leaving the other PR up to in case we want to compare.