### PR TITLE
Give TileLink keys more sensible names

### DIFF
--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -31,7 +31,7 @@ trait HasCoreplexParameters {
   lazy val nBanksPerMemChannel = p(NBanksPerMemoryChannel)
   lazy val lsb = p(BankIdLSB)
   lazy val innerParams = p.alterPartial({ case TLId => "L1toL2" })
-  lazy val outermostParams = p.alterPartial({ case TLId => "Outermost" })
+  lazy val outerParams = p.alterPartial({ case TLId => "L2toMC" })
   lazy val outerMMIOParams = p.alterPartial({ case TLId => "L2toMMIO" })
   lazy val globalAddrMap = p(rocketchip.GlobalAddrMap)
 }
@@ -50,7 +50,7 @@ abstract class BaseCoreplex(c: CoreplexConfig)(implicit p: Parameters) extends L
 
 abstract class BaseCoreplexBundle(val c: CoreplexConfig)(implicit val p: Parameters) extends Bundle with HasCoreplexParameters {
   val master = new Bundle {
-    val mem = Vec(c.nMemChannels, new ClientUncachedTileLinkIO()(outermostParams))
+    val mem = Vec(c.nMemChannels, new ClientUncachedTileLinkIO()(outerParams))
     val mmio = new ClientUncachedTileLinkIO()(outerMMIOParams)
   }
   val slave = Vec(c.nSlaves, new ClientUncachedTileLinkIO()(innerParams)).flip
@@ -112,14 +112,12 @@ abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](
     l1tol2net.io.managers <> managerEndpoints.map(_.innerTL) :+ mmioManager.io.inner
 
     // Create a converter between TileLinkIO and MemIO for each channel
-    val mem_ic = Module(new TileLinkMemoryInterconnect(nBanksPerMemChannel, c.nMemChannels)(outermostParams))
+    val mem_ic = Module(new TileLinkMemoryInterconnect(nBanksPerMemChannel, c.nMemChannels)(outerParams))
 
-    val outerTLParams = p.alterPartial({ case TLId => "L2toMC" })
     val backendBuffering = TileLinkDepths(0,0,0,0,0)
     for ((bank, icPort) <- managerEndpoints zip mem_ic.io.in) {
       val enqueued = TileLinkEnqueuer(bank.outerTL, backendBuffering)
-      val unwrapped = TileLinkIOUnwrapper(enqueued)
-      TileLinkWidthAdapter(icPort, unwrapped)
+      icPort <> TileLinkIOUnwrapper(enqueued)
     }
 
     io.master.mem <> mem_ic.io.out

--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -132,15 +132,11 @@ class BaseCoreplexConfig extends Config (
           nManagers = 1,
           nCachingClients = site(NBanksPerMemoryChannel),
           nCachelessClients = 0,
-          maxClientXacts = 1,
-          maxClientsPerPort = site(NAcquireTransactors) + 2,
+          maxClientXacts = site(NAcquireTransactors) + 2,
+          maxClientsPerPort = site(NBanksPerMemoryChannel),
           maxManagerXacts = 1,
           dataBeats = innerDataBeats,
           dataBits = site(CacheBlockBytes)*8)
-      case TLKey("Outermost") => site(TLKey("L2toMC")).copy(
-        maxClientXacts = site(NAcquireTransactors) + 2,
-        maxClientsPerPort = site(NBanksPerMemoryChannel),
-        dataBeats = site(MIFDataBeats))
       case TLKey("L2toMMIO") => {
         TileLinkParameters(
           coherencePolicy = new MICoherence(
@@ -154,7 +150,6 @@ class BaseCoreplexConfig extends Config (
           dataBeats = innerDataBeats,
           dataBits = site(CacheBlockBytes) * 8)
       }
-      case TLKey("MMIO_Outermost") => site(TLKey("L2toMMIO")).copy(dataBeats = site(MIFDataBeats))
 
       case BootROMFile => "./bootrom/bootrom.img"
       case NTiles => 1

--- a/src/main/scala/groundtest/NastiTest.scala
+++ b/src/main/scala/groundtest/NastiTest.scala
@@ -115,7 +115,7 @@ class NastiConverterTest(implicit p: Parameters) extends GroundTest()(p)
 
   val test = Module(new NastiGenerator(genId))
   val converter = Module(new TileLinkIONastiIOConverter()(
-    p.alterPartial { case TLId => "Outermost" }))
+    p.alterPartial { case TLId => "MCtoEdge" }))
 
   converter.io.nasti <> test.io.mem
   TileLinkWidthAdapter(io.mem.head, converter.io.tl)

--- a/src/main/scala/groundtest/NastiTest.scala
+++ b/src/main/scala/groundtest/NastiTest.scala
@@ -115,7 +115,7 @@ class NastiConverterTest(implicit p: Parameters) extends GroundTest()(p)
 
   val test = Module(new NastiGenerator(genId))
   val converter = Module(new TileLinkIONastiIOConverter()(
-    p.alterPartial { case TLId => "MCtoEdge" }))
+    p.alterPartial { case TLId => "EdgetoSlave" }))
 
   converter.io.nasti <> test.io.mem
   TileLinkWidthAdapter(io.mem.head, converter.io.tl)

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -39,6 +39,10 @@ class BasePlatformConfig extends Config(
             addrBits = Dump("MEM_ADDR_BITS", site(PAddrBits)),
             idBits = Dump("MEM_ID_BITS", site(MIFTagBits)))
         }
+        case TLKey("Outermost") =>
+          site(TLKey("L2toMC")).copy(dataBeats = site(MIFDataBeats))
+        case TLKey("MMIO_Outermost") =>
+          site(TLKey("L2toMMIO")).copy(dataBeats = site(MIFDataBeats))
         case BuildCoreplex =>
           (c: CoreplexConfig, p: Parameters) => uncore.tilelink2.LazyModule(new DefaultCoreplex(c)(p)).module
         case NExtTopInterrupts => 2

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -39,9 +39,9 @@ class BasePlatformConfig extends Config(
             addrBits = Dump("MEM_ADDR_BITS", site(PAddrBits)),
             idBits = Dump("MEM_ID_BITS", site(MIFTagBits)))
         }
-        case TLKey("Outermost") =>
+        case TLKey("MCtoEdge") =>
           site(TLKey("L2toMC")).copy(dataBeats = site(MIFDataBeats))
-        case TLKey("MMIO_Outermost") =>
+        case TLKey("MMIOtoEdge") =>
           site(TLKey("L2toMMIO")).copy(dataBeats = site(MIFDataBeats))
         case BuildCoreplex =>
           (c: CoreplexConfig, p: Parameters) => uncore.tilelink2.LazyModule(new DefaultCoreplex(c)(p)).module

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -39,6 +39,8 @@ class BasePlatformConfig extends Config(
             addrBits = Dump("MEM_ADDR_BITS", site(PAddrBits)),
             idBits = Dump("MEM_ID_BITS", site(MIFTagBits)))
         }
+        case TLKey("EdgetoSlave") =>
+          site(TLKey("L1toL2")).copy(dataBeats = site(MIFDataBeats))
         case TLKey("MCtoEdge") =>
           site(TLKey("L2toMC")).copy(dataBeats = site(MIFDataBeats))
         case TLKey("MMIOtoEdge") =>

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -213,7 +213,7 @@ trait PeripheryMasterMMIOModule extends HasPeripheryParameters {
   val pBus: TileLinkRecursiveInterconnect
 
   val mmio_ports = p(ExtMMIOPorts) map { port =>
-    TileLinkWidthAdapter(pBus.port(port.name), outerMMIOParams)
+    TileLinkWidthAdapter(pBus.port(port.name), outermostMMIOParams)
   }
 
   val mmio_axi_start = 0


### PR DESCRIPTION
The "Outermost" and "MMIO_Outermost" keys are renamed to "MCtoEdge"
and "MMIOtoEdge". They are only used after width conversion to adapt to
external interfaces in the periphery.

That means there is no longer any width adapting done in the Coreplex,
the width adapter is moved to the Periphery just before conversion
to AXI/AHB or sending off chip.

We also add an additional TLKey "EdgetoSlave" for the bus_axi interface.
This means there is also a width adapter from the AXI -> TL converter
to the coreplex slave port.

This also fixes a bug introduced previously in which the wrong
parameters object is given to the width adapter for external MMIO.