### PR TITLE
Factor coreplex IO connection into separate trait

### DIFF
--- a/src/main/scala/coreplex/BaseCoreplex.scala
+++ b/src/main/scala/coreplex/BaseCoreplex.scala
@@ -59,6 +59,8 @@ abstract class BaseCoreplexBundle(val c: CoreplexConfig)(implicit val p: Paramet
   val clint = Vec(c.nTiles, new CoreplexLocalInterrupts).asInput
   val resetVector = UInt(INPUT, p(XLen))
   val success = Bool(OUTPUT) // used for testing
+
+  override def cloneType = this.getClass.getConstructors.head.newInstance(c, p).asInstanceOf[this.type]
 }
 
 abstract class BaseCoreplexModule[+L <: BaseCoreplex, +B <: BaseCoreplexBundle](

--- a/src/main/scala/rocketchip/BaseTop.scala
+++ b/src/main/scala/rocketchip/BaseTop.scala
@@ -67,7 +67,7 @@ abstract class BaseTopModule[+L <: BaseTop, +B <: BaseTopBundle](
   val io: B = b
 
   val coreplex = p(BuildCoreplex)(outer.c, p)
-  val coreplexIO = coreplex.io
+  val coreplexIO = Wire(coreplex.io)
 
   val pBus =
     Module(new TileLinkRecursiveInterconnect(1, p(GlobalAddrMap).subMap("io:pbus"))(
@@ -94,4 +94,11 @@ abstract class BaseTopModule[+L <: BaseTop, +B <: BaseTopBundle](
   GraphMLOutput.contents = Some(outer.graphML)
 
   io.success := coreplexIO.success
+}
+
+trait DirectConnection {
+  val coreplexIO: BaseCoreplexBundle
+  val coreplex: BaseCoreplexModule[BaseCoreplex, BaseCoreplexBundle]
+
+  coreplexIO <> coreplex.io
 }

--- a/src/main/scala/rocketchip/ExampleTop.scala
+++ b/src/main/scala/rocketchip/ExampleTop.scala
@@ -38,6 +38,7 @@ class ExampleTopModule[+L <: ExampleTop, +B <: ExampleTopBundle](p: Parameters, 
     with PeripheryMasterMMIOModule
     with PeripherySlaveModule
     with HardwiredResetVector
+    with DirectConnection
 
 /** Example Top with TestRAM */
 class ExampleTopWithTestRAM(q: Parameters) extends ExampleTop(q)
@@ -50,20 +51,3 @@ class ExampleTopWithTestRAMBundle(p: Parameters) extends ExampleTopBundle(p)
 
 class ExampleTopWithTestRAMModule[+L <: ExampleTopWithTestRAM, +B <: ExampleTopWithTestRAMBundle](p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b)
     with PeripheryTestRAMModule
-
-/** Example Top with Multi Clock */
-class ExampleMultiClockTop(q: Parameters) extends ExampleTop(q)
-    with PeripheryTestRAM {
-  override lazy val module = Module(new ExampleMultiClockTopModule(p, this, new ExampleMultiClockTopBundle(p)))
-}
-
-class ExampleMultiClockTopBundle(p: Parameters) extends ExampleTopBundle(p)
-
-class ExampleMultiClockTopModule[+L <: ExampleMultiClockTop, +B <: ExampleMultiClockTopBundle](p: Parameters, l: L, b: => B) extends ExampleTopModule(p, l, b) {
-  val multiClockCoreplexIO = coreplexIO.asInstanceOf[MultiClockCoreplexBundle]
-
-  multiClockCoreplexIO.tcrs foreach { tcr =>
-    tcr.clock := clock
-    tcr.reset := reset
-  }
-}


### PR DESCRIPTION
This would allow, for instance, putting the coreplex on a separate clock
domain and crossing the IOs over through asynchronous queues.

The ExampleMultiClockTop* classes are removed since they no longer fit
into the class hierarchy.