### PR TITLE
tilelink2 WidthWidget: Gets must have their mask adjusted

### DIFF
--- a/src/main/scala/uncore/tilelink2/WidthWidget.scala
+++ b/src/main/scala/uncore/tilelink2/WidthWidget.scala
@@ -65,7 +65,8 @@ class TLWidthWidget(innerBeatBytes: Int) extends LazyModule
       }
 
       val dataOut = if (edgeIn.staticHasData(in.bits) == Some(false)) UInt(0) else dataMux(size)
-      val maskOut = maskMux(size) & edgeOut.mask(addr_lo, size)
+      val maskFull = edgeOut.mask(addr_lo, size)
+      val maskOut = Mux(hasData, maskMux(size) & maskFull, maskFull)
 
       in.ready := out.ready || !last
       out.valid := in.valid && last


### PR DESCRIPTION
The mask of a Get should also be converted.

This manifested as a bug when going from 32=>64 bits. A large Get
could end up with mask that was not full.