### PR TITLE
tilelink2: don't use chisel3 namespace

### DIFF
--- a/src/main/scala/uncore/tilelink2/Bundles.scala
+++ b/src/main/scala/uncore/tilelink2/Bundles.scala
@@ -2,8 +2,8 @@
 
 package uncore.tilelink2
 
-import chisel3._
-import chisel3.util._
+import Chisel._
+import chisel3.util.{Irrevocable, IrrevocableIO}
 
 abstract class GenericParameterizedBundle[T <: Object](val params: T) extends Bundle
 {

--- a/src/main/scala/uncore/tilelink2/Fuzzer.scala
+++ b/src/main/scala/uncore/tilelink2/Fuzzer.scala
@@ -2,7 +2,6 @@
 package uncore.tilelink2
 
 import Chisel._
-import chisel3.util.LFSR16
 import unittest._
 import util.Pow2ClockDivider
 

--- a/src/main/scala/uncore/tilelink2/RAMModel.scala
+++ b/src/main/scala/uncore/tilelink2/RAMModel.scala
@@ -3,7 +3,6 @@
 package uncore.tilelink2
 
 import Chisel._
-import chisel3.util.LFSR16
 
 // We detect concurrent puts that put memory into an undefined state.
 // put0, put0Ack, put1, put1Ack => ok: defined

--- a/src/main/scala/uncore/tilelink2/RegMapper.scala
+++ b/src/main/scala/uncore/tilelink2/RegMapper.scala
@@ -2,8 +2,8 @@
 
 package uncore.tilelink2
 
-import chisel3._
-import chisel3.util._
+import Chisel._
+import chisel3.util.{Irrevocable, IrrevocableIO}
 
 // A bus agnostic register interface to a register-based device
 


### PR DESCRIPTION
@aswaterman This removes all uses of chisel3._ as requested