### PR TITLE
Add TL2 synthesizeable UnitTests for many adapters

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -52,7 +52,7 @@ endif
 
 ifeq ($(SUITE),UnittestSuite)
 PROJECT=unittest
-CONFIGS=JunctionsUnitTestConfig UncoreUnitTestConfig
+CONFIGS=JunctionsUnitTestConfig UncoreUnitTestConfig TLSimpleUnitTestConfig TLWidthUnitTestConfig TLXbarUnitTestConfig
 endif
 
 ifeq ($(SUITE), JtagDtmSuite)

--- a/src/main/scala/uncore/tilelink2/AtomicAutomata.scala
+++ b/src/main/scala/uncore/tilelink2/AtomicAutomata.scala
@@ -283,3 +283,25 @@ object TLAtomicAutomata
     atomics.node
   }
 }
+
+/** Synthesizeable unit tests */
+import unittest._
+
+//TODO ensure handler will pass through operations to clients that can handle them themselves
+
+class TLRAMAtomicAutomata() extends LazyModule {
+  val fuzz = LazyModule(new TLFuzzer(5000))
+  val model = LazyModule(new TLRAMModel)
+  val ram  = LazyModule(new TLRAM(AddressSet(0x0, 0x3ff)))
+
+  model.node := fuzz.node
+  ram.node := TLFragmenter(4, 256)(TLAtomicAutomata()(model.node))
+
+  lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
+    io.finished := fuzz.module.io.finished
+  }
+}
+
+class TLRAMAtomicAutomataTest extends UnitTest(timeout = 500000) {
+  io.finished := Module(LazyModule(new TLRAMAtomicAutomata).module).io.finished
+}

--- a/src/main/scala/uncore/tilelink2/Fragmenter.scala
+++ b/src/main/scala/uncore/tilelink2/Fragmenter.scala
@@ -250,3 +250,24 @@ object TLFragmenter
     fragmenter.node
   }
 }
+
+/** Synthesizeable unit tests */
+import unittest._
+
+class TLRAMFragmenter(ramBeatBytes: Int, maxSize: Int) extends LazyModule {
+  val fuzz = LazyModule(new TLFuzzer(5000))
+  val model = LazyModule(new TLRAMModel)
+  val ram  = LazyModule(new TLRAM(AddressSet(0x0, 0x3ff), beatBytes = ramBeatBytes))
+
+  model.node := fuzz.node
+  ram.node := TLFragmenter(ramBeatBytes, maxSize)(model.node)
+
+  lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
+    io.finished := fuzz.module.io.finished
+  }
+}
+
+class TLRAMFragmenterTest(ramBeatBytes: Int, maxSize: Int) extends UnitTest(timeout = 500000) {
+  io.finished := Module(LazyModule(new TLRAMFragmenter(ramBeatBytes,maxSize)).module).io.finished
+}
+

--- a/src/main/scala/uncore/tilelink2/Fuzzer.scala
+++ b/src/main/scala/uncore/tilelink2/Fuzzer.scala
@@ -2,8 +2,6 @@
 package uncore.tilelink2
 
 import Chisel._
-import unittest._
-import util.Pow2ClockDivider
 
 class IDMapGenerator(numIds: Int) extends Module {
   val w = log2Up(numIds)
@@ -208,6 +206,9 @@ class TLFuzzer(
   }
 }
 
+/** Synthesizeable integration test */
+import unittest._
+
 class TLFuzzRAM extends LazyModule
 {
   val model = LazyModule(new TLRAMModel)
@@ -231,7 +232,7 @@ class TLFuzzRAM extends LazyModule
     io.finished := fuzz.module.io.finished
 
     // Shove the RAM into another clock domain
-    val clocks = Module(new Pow2ClockDivider(2))
+    val clocks = Module(new util.Pow2ClockDivider(2))
     ram.module.clock := clocks.io.clock_out
 
     // ... and safely cross TL2 into it

--- a/src/main/scala/uncore/tilelink2/HintHandler.scala
+++ b/src/main/scala/uncore/tilelink2/HintHandler.scala
@@ -141,3 +141,25 @@ object TLHintHandler
     hints.node
   }
 }
+
+/** Synthesizeable unit tests */
+import unittest._
+
+//TODO ensure handler will pass through hints to clients that can handle them themselves
+
+class TLRAMHintHandler() extends LazyModule {
+  val fuzz = LazyModule(new TLFuzzer(5000))
+  val model = LazyModule(new TLRAMModel)
+  val ram  = LazyModule(new TLRAM(AddressSet(0x0, 0x3ff)))
+
+  model.node := fuzz.node
+  ram.node := TLFragmenter(4, 256)(TLHintHandler()(model.node))
+
+  lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
+    io.finished := fuzz.module.io.finished
+  }
+}
+
+class TLRAMHintHandlerTest extends UnitTest(timeout = 500000) {
+  io.finished := Module(LazyModule(new TLRAMHintHandler).module).io.finished
+}

--- a/src/main/scala/uncore/tilelink2/RAMModel.scala
+++ b/src/main/scala/uncore/tilelink2/RAMModel.scala
@@ -43,7 +43,7 @@ class TLRAMModel extends LazyModule
     val endAddressHi = (endAddress / beatBytes).intValue
     val maxLgBeats   = log2Up(maxTransfer/beatBytes)
     val shift        = log2Ceil(beatBytes)
-    val decTrees     = log2Ceil(maxTransfer/beatBytes)
+    val decTrees     = log2Up(maxTransfer/beatBytes)
     val addressBits  = log2Up(endAddress)
     val countBits    = log2Up(endSourceId)
     val sizeBits     = edge.bundle.sizeBits

--- a/src/main/scala/uncore/tilelink2/RegisterRouterTest.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterRouterTest.scala
@@ -3,6 +3,7 @@
 package uncore.tilelink2
 
 import Chisel._
+import unittest._
 import util.Pow2ClockDivider
 
 object LFSR16Seed
@@ -258,3 +259,34 @@ trait RRTest1Module extends Module with HasRegMap
 class RRTest1(address: BigInt) extends TLRegisterRouter(address, 0, 32, 6, 4)(
   new TLRegBundle((), _)    with RRTest1Bundle)(
   new TLRegModule((), _, _) with RRTest1Module)
+
+class FuzzRRTest0 extends LazyModule {
+  val fuzz = LazyModule(new TLFuzzer(5000))
+  val rrtr = LazyModule(new RRTest0(0x400))
+
+  rrtr.node := TLFragmenter(4, 32)(TLBuffer()(fuzz.node))
+
+  lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
+    io.finished := fuzz.module.io.finished
+  }
+}
+
+class TLRR0Test extends UnitTest(timeout = 500000) {
+  io.finished := Module(LazyModule(new FuzzRRTest0).module).io.finished
+}
+
+class FuzzRRTest1 extends LazyModule {
+  val fuzz = LazyModule(new TLFuzzer(5000))
+  val rrtr = LazyModule(new RRTest1(0x400))
+
+  rrtr.node := TLFragmenter(4, 32)(TLBuffer()(fuzz.node))
+
+  lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
+    io.finished := fuzz.module.io.finished
+  }
+}
+
+class TLRR1Test extends UnitTest(timeout = 500000) {
+  io.finished := Module(LazyModule(new FuzzRRTest1).module).io.finished
+}
+

--- a/src/main/scala/uncore/tilelink2/Xbar.scala
+++ b/src/main/scala/uncore/tilelink2/Xbar.scala
@@ -178,3 +178,50 @@ class TLXbar(policy: TLArbiter.Policy = TLArbiter.lowestIndexFirst) extends Lazy
     }
   }
 }
+
+/** Synthesizeable unit tests */
+import unittest._
+
+class TLRAMXbar(nManagers: Int) extends LazyModule {
+  val fuzz = LazyModule(new TLFuzzer(5000))
+  val model = LazyModule(new TLRAMModel)
+  val xbar = LazyModule(new TLXbar)
+
+  model.node := fuzz.node
+  xbar.node := model.node
+  (0 until nManagers) foreach { n =>
+    val ram  = LazyModule(new TLRAM(AddressSet(0x0+0x400*n, 0x3ff)))
+    ram.node := TLFragmenter(4, 256)(xbar.node)
+  }
+
+  lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
+    io.finished := fuzz.module.io.finished
+  }
+}
+
+class TLRAMXbarTest(nManagers: Int) extends UnitTest(timeout = 500000) {
+  io.finished := Module(LazyModule(new TLRAMXbar(nManagers)).module).io.finished
+}
+
+class TLMulticlientXbar(nManagers: Int, nClients: Int) extends LazyModule {
+  val xbar = LazyModule(new TLXbar)
+
+  val fuzzers = (0 until nClients) map { n =>
+    val fuzz = LazyModule(new TLFuzzer(5000))
+    xbar.node := fuzz.node
+    fuzz
+  }
+
+  (0 until nManagers) foreach { n =>
+    val ram  = LazyModule(new TLRAM(AddressSet(0x0+0x400*n, 0x3ff)))
+    ram.node := TLFragmenter(4, 256)(xbar.node)
+  }
+
+  lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
+    io.finished := fuzzers.last.module.io.finished
+  }
+}
+
+class TLMulticlientXbarTest(nManagers: Int, nClients: Int) extends UnitTest(timeout = 5000000) {
+  io.finished := Module(LazyModule(new TLMulticlientXbar(nManagers, nClients)).module).io.finished
+}

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -31,3 +31,33 @@ class WithUncoreUnitTests extends Config(
 )
 
 class UncoreUnitTestConfig extends Config(new WithUncoreUnitTests ++ new BaseConfig)
+
+class WithTL2UnitTests extends Config(
+  (pname, site, here) => pname match {
+    case UnitTests => (p: Parameters) => {
+      Seq(
+        //Module(new uncore.tilelink2.TLRAMSimpleTest(1)),
+        //Module(new uncore.tilelink2.TLRAMSimpleTest(4)),
+        //Module(new uncore.tilelink2.TLRAMSimpleTest(16)),
+        Module(new uncore.tilelink2.TLRAMFragmenterTest(4, 256)),
+        Module(new uncore.tilelink2.TLRAMFragmenterTest(16, 64)),
+        Module(new uncore.tilelink2.TLRAMFragmenterTest(4, 16)),
+        Module(new uncore.tilelink2.TLRAMXbarTest(1)),
+        Module(new uncore.tilelink2.TLRAMXbarTest(2)),
+        Module(new uncore.tilelink2.TLRAMXbarTest(8)),
+        //Module(new uncore.tilelink2.TLMulticlientXbarTest(4,4)),
+        //Module(new uncore.tilelink2.TLMulticlientXbarTest(1,4)),
+        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(1,1)),
+        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(4,4)),
+        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(16,16)),
+        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(4,64)),
+        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(64,4)),
+        Module(new uncore.tilelink2.TLRR0Test),
+        Module(new uncore.tilelink2.TLRR1Test),
+        Module(new uncore.tilelink2.TLRAMCrossingTest)
+      )
+    }
+    case _ => throw new CDEMatchError
+  })
+
+class TL2UnitTestConfig extends Config(new WithTL2UnitTests ++ new BasePlatformConfig)

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -32,32 +32,39 @@ class WithUncoreUnitTests extends Config(
 
 class UncoreUnitTestConfig extends Config(new WithUncoreUnitTests ++ new BaseConfig)
 
-class WithTL2UnitTests extends Config(
+class WithTLSimpleUnitTests extends Config(
   (pname, site, here) => pname match {
     case UnitTests => (p: Parameters) => {
       Seq(
-        //Module(new uncore.tilelink2.TLRAMSimpleTest(1)),
-        //Module(new uncore.tilelink2.TLRAMSimpleTest(4)),
-        //Module(new uncore.tilelink2.TLRAMSimpleTest(16)),
-        Module(new uncore.tilelink2.TLRAMFragmenterTest(4, 256)),
-        Module(new uncore.tilelink2.TLRAMFragmenterTest(16, 64)),
-        Module(new uncore.tilelink2.TLRAMFragmenterTest(4, 16)),
+        Module(new uncore.tilelink2.TLRAMSimpleTest(1)),
+        Module(new uncore.tilelink2.TLRAMSimpleTest(4)),
+        Module(new uncore.tilelink2.TLRAMSimpleTest(16)),
+        Module(new uncore.tilelink2.TLRR0Test),
+        Module(new uncore.tilelink2.TLRR1Test),
+        Module(new uncore.tilelink2.TLRAMCrossingTest) ) }
+    case _ => throw new CDEMatchError })
+
+class WithTLWidthUnitTests extends Config(
+  (pname, site, here) => pname match {
+    case UnitTests => (p: Parameters) => { Seq(
+        Module(new uncore.tilelink2.TLRAMFragmenterTest( 4, 256)),
+        Module(new uncore.tilelink2.TLRAMFragmenterTest(16,  64)),
+        Module(new uncore.tilelink2.TLRAMFragmenterTest( 4,  16)),
+        Module(new uncore.tilelink2.TLRAMWidthWidgetTest( 1,  1)),
+        Module(new uncore.tilelink2.TLRAMWidthWidgetTest( 4, 64)),
+        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(64,  4)) ) }
+    case _ => throw new CDEMatchError })
+
+class WithTLXbarUnitTests extends Config(
+  (pname, site, here) => pname match {
+    case UnitTests => (p: Parameters) => { Seq(
         Module(new uncore.tilelink2.TLRAMXbarTest(1)),
         Module(new uncore.tilelink2.TLRAMXbarTest(2)),
         Module(new uncore.tilelink2.TLRAMXbarTest(8)),
         //Module(new uncore.tilelink2.TLMulticlientXbarTest(4,4)),
-        //Module(new uncore.tilelink2.TLMulticlientXbarTest(1,4)),
-        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(1,1)),
-        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(4,4)),
-        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(16,16)),
-        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(4,64)),
-        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(64,4)),
-        Module(new uncore.tilelink2.TLRR0Test),
-        Module(new uncore.tilelink2.TLRR1Test),
-        Module(new uncore.tilelink2.TLRAMCrossingTest)
-      )
-    }
-    case _ => throw new CDEMatchError
-  })
+        Module(new uncore.tilelink2.TLMulticlientXbarTest(1,4)) ) }
+    case _ => throw new CDEMatchError })
 
-class TL2UnitTestConfig extends Config(new WithTL2UnitTests ++ new BasePlatformConfig)
+class TLSimpleUnitTestConfig extends Config(new WithTLSimpleUnitTests ++ new BasePlatformConfig)
+class TLWidthUnitTestConfig extends Config(new WithTLWidthUnitTests ++ new BasePlatformConfig)
+class TLXbarUnitTestConfig extends Config(new WithTLXbarUnitTests ++ new BasePlatformConfig)


### PR DESCRIPTION
These tests mostly use the Fuzzer and RAMModel to check that adapters correctly handle-randomly generated legal traffic, without deadlocking or corrupting data.

These tests are added to the UnittestSuite target in regression/Makefile. They should fit within the existing timeframe of the other suites but might have to be adjusted if they start taking too long to elaborate.