### PR TITLE
Suggest sane names for common objects

### DIFF
--- a/src/main/scala/uncore/tilelink2/RegisterCrossing.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterCrossing.scala
@@ -147,15 +147,18 @@ object AsyncRWSlaveRegField {
     slave_reset: Bool,
     width:  Int,
     init: Int,
+    name: Option[String] = None,
     master_allow: Bool = Bool(true),
     slave_allow: Bool = Bool(true)
   ): (UInt, RegField) = {
 
     val async_slave_reg = Module(new AsyncResetRegVec(width, init))
+    if (name.isDefined) {async_slave_reg.suggestName(name.get)}
     async_slave_reg.reset := slave_reset
     async_slave_reg.clock := slave_clock
 
     val wr_crossing = Module (new RegisterWriteCrossing(UInt(width = width)))
+    if (name.isDefined){wr_crossing.suggestName(s"${name.get}_wcrossing")}
 
     val scope = Module (new AsyncScope())
 
@@ -170,6 +173,7 @@ object AsyncRWSlaveRegField {
     async_slave_reg.io.d  := wr_crossing.io.slave_register
 
     val rd_crossing = Module (new RegisterReadCrossing(UInt(width = width )))
+    if (name.isDefined){rd_crossing.suggestName(s"${name.get}_rcrossing")}
 
     rd_crossing.io.master_clock := scope.clock
     rd_crossing.io.master_reset := scope.reset

--- a/src/main/scala/uncore/tilelink2/RegisterCrossing.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterCrossing.scala
@@ -153,12 +153,12 @@ object AsyncRWSlaveRegField {
   ): (UInt, RegField) = {
 
     val async_slave_reg = Module(new AsyncResetRegVec(width, init))
-    if (name.isDefined) {async_slave_reg.suggestName(name.get)}
+    name.foreach(async_slave_reg.suggestName(_))
     async_slave_reg.reset := slave_reset
     async_slave_reg.clock := slave_clock
 
     val wr_crossing = Module (new RegisterWriteCrossing(UInt(width = width)))
-    if (name.isDefined){wr_crossing.suggestName(s"${name.get}_wcrossing")}
+    name.foreach(n => wr_crossing.suggestName(s"${n}_wcrossing"))
 
     val scope = Module (new AsyncScope())
 
@@ -173,7 +173,7 @@ object AsyncRWSlaveRegField {
     async_slave_reg.io.d  := wr_crossing.io.slave_register
 
     val rd_crossing = Module (new RegisterReadCrossing(UInt(width = width )))
-    if (name.isDefined){rd_crossing.suggestName(s"${name.get}_rcrossing")}
+    name.foreach(n => rd_crossing.suggestName(s"${n}_rcrossing"))
 
     rd_crossing.io.master_clock := scope.clock
     rd_crossing.io.master_reset := scope.reset

--- a/src/main/scala/util/BlackBoxRegs.scala
+++ b/src/main/scala/util/BlackBoxRegs.scala
@@ -90,7 +90,7 @@ object AsyncResetReg {
     reg.io.clk := clk
     reg.io.rst := rst
     reg.io.en  := Bool(true)
-    if (name.isDefined) reg.suggestName(name.get)
+    name.foreach(reg.suggestName(_))
     reg.io.q
   }
 
@@ -101,7 +101,7 @@ object AsyncResetReg {
   def apply(updateData: UInt, resetData: BigInt, enable: Bool, name: Option[String] = None): UInt = {
     val w = updateData.getWidth max resetData.bitLength
     val reg = Module(new AsyncResetRegVec(w, resetData))
-    if (name.isDefined) {reg.suggestName(name.get)}
+    name.foreach(reg.suggestName(_))
     reg.io.d := updateData
     reg.io.en := enable
     reg.io.q

--- a/src/main/scala/util/BlackBoxRegs.scala
+++ b/src/main/scala/util/BlackBoxRegs.scala
@@ -59,8 +59,6 @@ class AsyncResetRegVec(val w: Int, val init: BigInt) extends Module {
 
   val io = new SimpleRegIO(w)
 
-  val bb_d = Mux(io.en, io.d, io.q)
-
   val async_regs: List[AbstractBBReg] = List.tabulate(w)(
     i => Module (
       if (((init >> i) % 2) > 0)
@@ -74,14 +72,17 @@ class AsyncResetRegVec(val w: Int, val init: BigInt) extends Module {
   for ((reg, idx) <- async_regs.zipWithIndex) {
     reg.io.clk := clock
     reg.io.rst := reset
-    reg.io.d   := bb_d(idx)
+    reg.io.d   := io.d(idx)
     reg.io.en  := io.en
+    reg.suggestName(s"reg_$idx")
   }
 
 }
 
 object AsyncResetReg {
-  def apply(d: Bool, clk: Clock, rst: Bool, init: Boolean): Bool = {
+
+  // Create Single Registers
+  def apply(d: Bool, clk: Clock, rst: Bool, init: Boolean, name: Option[String]): Bool = {
     val reg: AbstractBBReg =
       if (init) Module (new AsyncSetReg)
       else Module(new AsyncResetReg)
@@ -89,22 +90,33 @@ object AsyncResetReg {
     reg.io.clk := clk
     reg.io.rst := rst
     reg.io.en  := Bool(true)
+    if (name.isDefined) reg.suggestName(name.get)
     reg.io.q
   }
 
-  def apply(d: Bool, clk: Clock, rst: Bool): Bool = apply(d, clk, rst, false)
+  def apply(d: Bool, clk: Clock, rst: Bool): Bool = apply(d, clk, rst, false, None)
+  def apply(d: Bool, clk: Clock, rst: Bool, name: String): Bool = apply(d, clk, rst, false, Some(name))
 
-  def apply(updateData: UInt, resetData: BigInt, enable: Bool): UInt = {
+  // Create Vectors of Registers
+  def apply(updateData: UInt, resetData: BigInt, enable: Bool, name: Option[String] = None): UInt = {
     val w = updateData.getWidth max resetData.bitLength
     val reg = Module(new AsyncResetRegVec(w, resetData))
+    if (name.isDefined) {reg.suggestName(name.get)}
     reg.io.d := updateData
     reg.io.en := enable
     reg.io.q
   }
+  def apply(updateData: UInt, resetData: BigInt, enable: Bool, name: String): UInt = apply(updateData,
+    resetData, enable, Some(name))
+
 
   def apply(updateData: UInt, resetData: BigInt): UInt = apply(updateData, resetData, enable=Bool(true))
+  def apply(updateData: UInt, resetData: BigInt, name: String): UInt = apply(updateData, resetData, enable=Bool(true), Some(name))
 
   def apply(updateData: UInt, enable: Bool): UInt = apply(updateData, resetData=BigInt(0), enable)
+  def apply(updateData: UInt, enable: Bool, name: String): UInt = apply(updateData, resetData=BigInt(0), enable, Some(name))
 
   def apply(updateData: UInt): UInt = apply(updateData, resetData=BigInt(0), enable=Bool(true))
+  def apply(updateData: UInt, name:String): UInt = apply(updateData, resetData=BigInt(0), enable=Bool(true), Some(name))
+
 }


### PR DESCRIPTION
I find that I end up with a bunch of "AsyncResetRegVec_N" and other commonly used structures in my hierarchy. I'd prefer to give them names like "myReg", "yourReg", "myReg_rcrossing", etc.

I'm not sure this is the right way to go about this, happy for feedback and suggestions.

This is an example of where https://github.com/ucb-bar/chisel3/issues/303 would make a difference.

This PR also resolves the difference in behavior between instantiating a single AsyncResetReg (with a Bool) and a AsyncResetReg (UInt).
