### PR TITLE
clint & plic: Move the default addresses

### DIFF
--- a/src/main/scala/rocketchip/Utils.scala
+++ b/src/main/scala/rocketchip/Utils.scala
@@ -56,7 +56,7 @@ object GenerateGlobalAddrMap {
     lazy val cBusIOAddrMap: AddrMap = {
       val entries = collection.mutable.ArrayBuffer[AddrMapEntry]()
       entries += AddrMapEntry("debug", MemSize(4096, MemAttr(AddrMapProt.RWX)))
-      entries += AddrMapEntry("plic", MemRange(0x40000000, 0x4000000, MemAttr(AddrMapProt.RW)))
+      entries += AddrMapEntry("plic", MemRange(0x0C000000, 0x4000000, MemAttr(AddrMapProt.RW)))
       if (p(DataScratchpadSize) > 0) { // TODO heterogeneous tiles
         require(p(NTiles) == 1) // TODO relax this
         require(p(NMemoryChannels) == 0) // TODO allow both scratchpad & DRAM

--- a/src/main/scala/uncore/devices/Prci.scala
+++ b/src/main/scala/uncore/devices/Prci.scala
@@ -19,7 +19,7 @@ class CoreplexLocalInterrupts extends Bundle {
   val msip = Bool()
 }
 
-case class CoreplexLocalInterrupterConfig(beatBytes: Int, address: BigInt = 0x44000000) {
+case class CoreplexLocalInterrupterConfig(beatBytes: Int, address: BigInt = 0x02000000) {
   def msipOffset(hart: Int) = hart * msipBytes
   def msipAddress(hart: Int) = address + msipOffset(hart)
   def timecmpOffset(hart: Int) = 0x4000 + hart * timecmpBytes


### PR DESCRIPTION
CLInt (local interrupt control)  moves to 0x0200_0000.
PLIC (external interrupt control) moves to 0x0C00_0000.

@aswaterman 