### PR TITLE
Tl2 rr irrevocable fix

### DIFF
--- a/src/main/scala/uncore/tilelink2/RegField.scala
+++ b/src/main/scala/uncore/tilelink2/RegField.scala
@@ -3,7 +3,7 @@
 package uncore.tilelink2
 
 import Chisel._
-import chisel3.util.{Irrevocable, IrrevocableIO}
+import chisel3.util.{ReadyValidIO}
 import util.{SimpleRegIO}
 
 case class RegReadFn private(combinational: Boolean, fn: (Bool, Bool) => (Bool, Bool, UInt))
@@ -12,9 +12,8 @@ object RegReadFn
   // (ivalid: Bool, oready: Bool) => (iready: Bool, ovalid: Bool, data: UInt)
   // iready may combinationally depend on oready
   // all other combinational dependencies forbidden (e.g. ovalid <= ivalid)
-  // iready must eventually go high without requiring ivalid to go high
-  // ovalid must eventually go high without requiring oready to go high
   // effects must become visible on the cycle after ovalid && oready
+  // data is only inspected when ovalid && oready
   implicit def apply(x: (Bool, Bool) => (Bool, Bool, UInt)) =
     new RegReadFn(false, x)
   implicit def apply(x: RegisterReadIO[UInt]): RegReadFn =
@@ -25,17 +24,14 @@ object RegReadFn
     })
   // (ready: Bool) => (valid: Bool, data: UInt)
   // valid must not combinationally depend on ready
-  // valid must eventually go high without requiring ready to go high
-  // => this means that reading cannot trigger creation of the output data
-  //    if you need this, use the more general i&o ready-valid method above
   // effects must become visible on the cycle after valid && ready
   implicit def apply(x: Bool => (Bool, UInt)) =
     new RegReadFn(true, { case (_, oready) =>
       val (ovalid, data) = x(oready)
       (Bool(true), ovalid, data)
     })
-  // read from a IrrevocableIO (only safe if there is a consistent source of data)
-  implicit def apply(x: IrrevocableIO[UInt]):RegReadFn = RegReadFn(ready => { x.ready := ready; (x.valid, x.bits) })
+  // read from a ReadyValidIO (only safe if there is a consistent source of data)
+  implicit def apply(x: ReadyValidIO[UInt]):RegReadFn = RegReadFn(ready => { x.ready := ready; (x.valid, x.bits) })
   // read from a register
   implicit def apply(x: UInt):RegReadFn = RegReadFn(ready => (Bool(true), x))
   // noop
@@ -48,9 +44,8 @@ object RegWriteFn
   // (ivalid: Bool, oready: Bool, data: UInt) => (iready: Bool, ovalid: Bool)
   // iready may combinationally depend on both oready and data
   // all other combinational dependencies forbidden (e.g. ovalid <= ivalid)
-  // iready must eventually go high without requiring ivalid to go high
-  // ovalid must eventually go high without requiring oready to go high
   // effects must become visible on the cycle after ovalid && oready
+  // data should only be used for an effect when ivalid && iready
   implicit def apply(x: (Bool, Bool, UInt) => (Bool, Bool)) =
     new RegWriteFn(false, x)
   implicit def apply(x: RegisterWriteIO[UInt]): RegWriteFn =
@@ -62,15 +57,15 @@ object RegWriteFn
     })
   // (valid: Bool, data: UInt) => (ready: Bool)
   // ready may combinationally depend on data (but not valid)
-  // ready must eventually go high without requiring valid to go high
   // effects must become visible on the cycle after valid && ready
   implicit def apply(x: (Bool, UInt) => Bool) =
     // combinational => data valid on oready
     new RegWriteFn(true, { case (_, oready, data) =>
       (Bool(true), x(oready, data))
     })
-  // write to a IrrevocableIO (only safe if there is a consistent sink draining data)
-  implicit def apply(x: IrrevocableIO[UInt]): RegWriteFn = RegWriteFn((valid, data) => { x.valid := valid; x.bits := data; x.ready })
+  // write to a DecoupledIO (only safe if there is a consistent sink draining data)
+  // NOTE: this is not an IrrevocableIO (even on TL2) because other fields could cause a lowered valid
+  implicit def apply(x: DecoupledIO[UInt]): RegWriteFn = RegWriteFn((valid, data) => { x.valid := valid; x.bits := data; x.ready })
   // updates a register (or adds a mux to a wire)
   implicit def apply(x: UInt): RegWriteFn = RegWriteFn((valid, data) => { when (valid) { x := data }; Bool(true) })
   // noop

--- a/src/main/scala/uncore/tilelink2/RegMapper.scala
+++ b/src/main/scala/uncore/tilelink2/RegMapper.scala
@@ -3,7 +3,6 @@
 package uncore.tilelink2
 
 import Chisel._
-import chisel3.util.{Irrevocable, IrrevocableIO}
 
 // A bus agnostic register interface to a register-based device
 
@@ -52,8 +51,8 @@ object RegMapper
     val inBits = inParams.indexBits
     assert (wordmap.keySet.max < (1 << inBits), "Register map does not fit in device")
 
-    val out = Wire(Irrevocable(new RegMapperOutput(inParams)))
-    val front = Wire(Irrevocable(new RegMapperInput(inParams)))
+    val out = Wire(Decoupled(new RegMapperOutput(inParams)))
+    val front = Wire(Decoupled(new RegMapperInput(inParams)))
     front.bits := in.bits
 
     // Must this device pipeline the control channel?

--- a/src/main/scala/uncore/tilelink2/RegisterCrossing.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterCrossing.scala
@@ -3,7 +3,7 @@
 package uncore.tilelink2
 
 import Chisel._
-import chisel3.util.{Irrevocable, IrrevocableIO}
+import chisel3.util.{Irrevocable}
 import util.{AsyncResetRegVec, AsyncQueue, AsyncScope}
 
 // A very simple flow control state machine, run in the specified clock domain
@@ -25,7 +25,7 @@ class BusyRegisterCrossing(clock: Clock, reset: Bool)
 
 // RegField should support connecting to one of these
 class RegisterWriteIO[T <: Data](gen: T) extends Bundle {
-  val request  = Irrevocable(gen).flip()
+  val request  = Decoupled(gen).flip()
   val response = Irrevocable(Bool()) // ignore .bits
 }
 
@@ -85,7 +85,7 @@ class RegisterWriteCrossing[T <: Data](gen: T, sync: Int = 3) extends Module {
 
 // RegField should support connecting to one of these
 class RegisterReadIO[T <: Data](gen: T) extends Bundle {
-  val request  = Irrevocable(Bool()).flip() // ignore .bits
+  val request  = Decoupled(Bool()).flip() // ignore .bits
   val response = Irrevocable(gen)
 }
 

--- a/src/main/scala/uncore/tilelink2/RegisterRouter.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterRouter.scala
@@ -37,8 +37,10 @@ class TLRegisterNode(address: AddressSet, concurrency: Int = 0, beatBytes: Int =
     in.bits.mask  := a.bits.mask
     in.bits.extra := Cat(edge.addr_lo(a.bits), a.bits.source, a.bits.size)
 
-    // Invoke the register map builder
-    val out = RegMapper(beatBytes, concurrency, undefZero, in, mapping:_*)
+    // Invoke the register map builder and make it Irrevocable
+    val out = Queue.irrevocable(
+      RegMapper(beatBytes, concurrency, undefZero, in, mapping:_*),
+      entries = 1, pipe = true, flow = true)
 
     // No flow control needed
     in.valid  := a.valid

--- a/src/main/scala/uncore/tilelink2/RegisterRouterTest.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterRouterTest.scala
@@ -35,7 +35,7 @@ class RRTestCombinational(val bits: Int, rvalid: Bool => Bool, wready: Bool => B
   io.rvalid := rvalid_s
   io.wready := wready_s
 
-  io.rdata := reg
+  io.rdata := Mux(rvalid_s && io.rready, reg, UInt(0))
   when (io.wvalid && wready_s) { reg := io.wdata }
 }
 
@@ -47,10 +47,7 @@ object RRTestCombinational
 
   def random: Bool => Bool = { ready =>
     seed = seed + 1
-    val lfsr = LFSR16Seed(seed)
-    val valid = RegInit(Bool(true))
-    valid := Mux(valid, !ready, lfsr(0) && lfsr(1))
-    valid
+    LFSR16Seed(seed)(0)
   }
 
   def delay(x: Int): Bool => Bool = { ready =>
@@ -97,7 +94,7 @@ class RRTestRequest(val bits: Int,
   val rofire = io.roready && rovalid
   val wofire = io.woready && wovalid
 
-  io.rdata := reg
+  io.rdata := Mux(rofire, reg, UInt(0))
   when (wofire) { reg := wdata }
 }
 
@@ -130,14 +127,11 @@ object RRTestRequest
       val lfsr = LFSR16Seed(seed)
       val busy = RegInit(Bool(false))
       val data = Reg(UInt(width = idata.getWidth))
-      val progress = RegInit(Bool(false))
+      val progress = lfsr(0)
       val iready = progress && !busy
       val ovalid = progress && busy
       when (progress) {
         busy := Mux(busy, !oready, ivalid)
-        progress := Mux(busy, !oready, !ivalid)
-      } .otherwise {
-        progress := lfsr(0)
       }
       when (ivalid && iready) { data := idata }
       (iready, ovalid, data)


### PR DESCRIPTION
The RegisterRouter fundamentally uses a Decoupled interface for arbitration amongst RegFields. Furthermore, a device might update a RegField while it is being read. This is Decoupled behaviour. This PR accepts the Decoupled nature of the RegisterRouter and uses a bypassable Queue to make the behaviour Irrevocable as required by TL2. The test case and API of RegField have been relaxed accordingly.