### PR TITLE
correctly initialize $random with seed

### DIFF
--- a/vsrc/TestDriver.v
+++ b/vsrc/TestDriver.v
@@ -21,6 +21,12 @@ module TestDriver;
   reg [1023:0] vcdfile = 0;
   initial
   begin
+    // do not delete the line below
+    // $random function needs to be called with the seed once
+    // to affect all the downstream $random functions within the
+    // Chisel-generated Verilog code
+    $fdisplay(stderr, "seed %0d, testing $random %0x", unsigned'($get_initial_random_seed), $random($get_initial_random_seed));
+
     $value$plusargs("max-cycles=%d", max_cycles);
     verbose = $test$plusargs("verbose");
 `ifdef DEBUG


### PR DESCRIPTION
I've gone back and forth on this, and regardless of whether we use $urandom or $random, this code seems necessary anyways, so we should merge this in.