### PR TITLE
correctly initialize the active flag

### DIFF
--- a/src/main/scala/util/Timer.scala
+++ b/src/main/scala/util/Timer.scala
@@ -45,7 +45,7 @@ class SimpleTimer(initCount: Int) extends Module {
   }
 
   val countdown = Reg(UInt(width = log2Up(initCount)))
-  val active = Reg(Bool())
+  val active = Reg(init = Bool(false))
 
   when (active) { countdown := countdown - UInt(1) }
 


### PR DESCRIPTION
I've reproduced the problem in #377, and this is the fix.  The SimpleTimer wasn't reseting the active flag, and depending on the random value, the timer was raising an error.