### PR TITLE
asyncqueue: Fix typo in the Async Queue 

### DIFF
--- a/src/main/scala/util/AsyncQueue.scala
+++ b/src/main/scala/util/AsyncQueue.scala
@@ -21,7 +21,7 @@ object AsyncGrayCounter {
         sink.io.d := source.io.q
         sink.io.en := Bool(true)
       }
-    syncv(0).io.d
+    sync.head.io.q
   }
 }
 

--- a/src/main/scala/util/AsyncQueue.scala
+++ b/src/main/scala/util/AsyncQueue.scala
@@ -21,7 +21,7 @@ object AsyncGrayCounter {
         sink.io.d := source.io.q
         sink.io.en := Bool(true)
       }
-    sync.head.io.q
+    syncv.head.io.q
   }
 }
 


### PR DESCRIPTION
This fixes a bug that would cause the Async Queue sync depth to be one less than expected.