### PR TITLE
Add sbt-unidoc plugin; bump sbt-buildinfo version.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,8 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-pack" % "0.8.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")


### PR DESCRIPTION
We'd like to use the sbt-unidoc plugin in Chisel3. Unfortunately, sbt's treatment of subproject plugins requires we add this to the parent project's plugins.