### PR TITLE
Corrected csr address of misa register

### DIFF
--- a/src/main/scala/rocket/instructions.scala
+++ b/src/main/scala/rocket/instructions.scala
@@ -289,7 +289,6 @@ object CSRs {
   val sip = 0x144
   val sptbr = 0x180
   val mstatus = 0x300
-  val misa = 0x301
   val medeleg = 0x302
   val mideleg = 0x303
   val mie = 0x304
@@ -368,6 +367,7 @@ object CSRs {
   val mhpmevent29 = 0x33d
   val mhpmevent30 = 0x33e
   val mhpmevent31 = 0x33f
+  val misa = 0xf10
   val mvendorid = 0xf11
   val marchid = 0xf12
   val mimpid = 0xf13


### PR DESCRIPTION
Done to comply with
'The RISC-V Instruction Set Manual - Volume II: Privileged Architecture'
'Privileged Architecture Version 1.9'
'July 8, 2016'