### PR TITLE
Better crossing reset handling

### DIFF
--- a/src/main/scala/regmapper/RegisterCrossing.scala
+++ b/src/main/scala/regmapper/RegisterCrossing.scala
@@ -41,7 +41,10 @@ class RegisterCrossingAssertion extends Module {
     val slave_reset = Bool(INPUT)
   }
 
-  assert (io.master_bypass || !io.slave_reset)
+  val up = RegInit(Bool(false))
+  up := !io.slave_reset
+
+  assert (io.master_bypass || !up || !io.slave_reset)
 }
 
 // RegField should support connecting to one of these
@@ -88,7 +91,7 @@ class RegisterWriteCrossing[T <: Data](gen: T, sync: Int = 3) extends Module {
   val io = new RegisterWriteCrossingIO(gen)
   // The crossing must only allow one item inflight at a time
   val control = Module(new BusyRegisterCrossing)
-  val crossing = Module(new AsyncQueue(gen, 1, sync))
+  val crossing = Module(new AsyncQueue(gen, 1, sync, safe=false))
 
   control.clock := io.master_clock
   control.reset := io.master_reset
@@ -141,7 +144,7 @@ class RegisterReadCrossing[T <: Data](gen: T, sync: Int = 3) extends Module {
   val io = new RegisterReadCrossingIO(gen)
   // The crossing must only allow one item inflight at a time
   val control = Module(new BusyRegisterCrossing)
-  val crossing = Module(new AsyncQueue(gen, 1, sync))
+  val crossing = Module(new AsyncQueue(gen, 1, sync, safe=false))
 
   control.clock := io.master_clock
   control.reset := io.master_reset

--- a/src/main/scala/uncore/tilelink2/Crossing.scala
+++ b/src/main/scala/uncore/tilelink2/Crossing.scala
@@ -25,15 +25,10 @@ class TLAsyncCrossingSource(sync: Int = 3) extends LazyModule
       out.a <> ToAsyncBundle(in.a, depth, sync)
       in.d <> FromAsyncBundle(out.d, sync)
 
-      assert (!in.a.valid || sink_reset_n, "A channel request sent to a missing manager")
-
       if (bce) {
         in.b <> FromAsyncBundle(out.b, sync)
         out.c <> ToAsyncBundle(in.c, depth, sync)
         out.e <> ToAsyncBundle(in.e, depth, sync)
-
-        assert (!in.c.valid || sink_reset_n, "C channel response sent to a missing manager")
-        assert (!in.e.valid || sink_reset_n, "E channel response sent to a missing manager")
       } else {
         in.b.valid := Bool(false)
         in.c.ready := Bool(true)
@@ -63,14 +58,10 @@ class TLAsyncCrossingSink(depth: Int = 8, sync: Int = 3) extends LazyModule
       out.a <> FromAsyncBundle(in.a, sync)
       in.d <> ToAsyncBundle(out.d, depth, sync)
 
-      assert (!out.d.valid || source_reset_n, "D channel respose sent to missing client")
-
       if (bce) {
         in.b <> ToAsyncBundle(out.b, depth, sync)
         out.c <> FromAsyncBundle(in.c, sync)
         out.e <> FromAsyncBundle(in.e, sync)
-
-        assert (!out.b.valid || source_reset_n, "B channel request sent to missing client")
       } else {
         in.b.widx := UInt(0)
         in.c.ridx := UInt(0)


### PR DESCRIPTION
The source must wait for the sink's clock after the source was reset, and vice versa.
Also, be more precise about what exactly is an critical crossing failure.