### PR TITLE
Fix Verilog compile warning from Cadence Incisive

### DIFF
--- a/vsrc/TestDriver.v
+++ b/vsrc/TestDriver.v
@@ -22,7 +22,7 @@ module TestDriver;
   int unsigned rand_value;
   initial
   begin
-    $value$plusargs("max-cycles=%d", max_cycles);
+    void'($value$plusargs("max-cycles=%d", max_cycles));
     verbose = $test$plusargs("verbose");
 
     // do not delete the line below.


### PR DESCRIPTION
Fixes the following warning:

```
    $value$plusargs("max-cycles=%d", max_cycles);
                  |
ncvlog: *W,NOSYST (/home/scottj/work/federation/rocket-chip/vsrc/TestDriver.v,25|18): System function '$value$plusargs' invoked as a task. Return value will be ignored.
```