### PR TITLE
Bump firrtl and update vsim Makefrag-verilog

### DIFF
--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -14,7 +14,7 @@ $(generated_dir)/%.fir $(generated_dir)/%.prm $(generated_dir)/%.d: $(chisel_src
 
 $(generated_dir)/$(long_name).v $(generated_dir)/$(long_name).conf : $(firrtl) $(FIRRTL_JAR)
 	mkdir -p $(dir $@)
-	$(FIRRTL) -i $< -o $(generated_dir)/$(long_name).v -X verilog --inferRW $(MODEL) --replSeqMem -c:$(MODEL):-o:$(generated_dir)/$(long_name).conf
+	$(FIRRTL) -i $< -o $(generated_dir)/$(long_name).v -X verilog --infer-rw $(MODEL) --repl-seq-mem -c:$(MODEL):-o:$(generated_dir)/$(long_name).conf
 
 $(generated_dir)/$(long_name).behav_srams.v : $(generated_dir)/$(long_name).conf $(mem_gen)
 	cd $(generated_dir) && \


### PR DESCRIPTION
We still should move to invoking Firrtl programmatically rather than via the command-line, but this commit updates Firrtl for now.