### PR TITLE
Support new execution harness and options.

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -19,9 +19,12 @@ SHELL := /bin/bash
 FIRRTL_JAR ?= $(base_dir)/firrtl/utils/bin/firrtl.jar
 FIRRTL ?= java -Xmx2G -Xss8M -XX:MaxPermSize=256M -cp $(FIRRTL_JAR) firrtl.Driver
 
+# Build firrtl.jar and put it where chisel3 can find it.
 $(FIRRTL_JAR): $(shell find $(base_dir)/firrtl/src/main/scala -iname "*.scala")
 	$(MAKE) -C $(base_dir)/firrtl SBT="$(SBT)" root_dir=$(base_dir)/firrtl build-scala
 	touch $(FIRRTL_JAR)
+	mkdir -p $(base_dir)/chisel3/lib
+	cp -p $(FIRRTL_JAR) $(base_dir)/chisel3/lib
 
 src_path = src/main/scala
 default_submodules = . hardfloat context-dependent-environments chisel3

--- a/vsim/Makefrag-verilog
+++ b/vsim/Makefrag-verilog
@@ -14,7 +14,7 @@ $(generated_dir)/%.fir $(generated_dir)/%.prm $(generated_dir)/%.d: $(chisel_src
 
 $(generated_dir)/$(long_name).v $(generated_dir)/$(long_name).conf : $(firrtl) $(FIRRTL_JAR)
 	mkdir -p $(dir $@)
-	$(FIRRTL) -i $< -o $(generated_dir)/$(long_name).v -X verilog --inferRW $(MODEL) --replSeqMem -c:$(MODEL):-o:$(generated_dir)/$(long_name).conf
+	$(FIRRTL) -i $< -o $(generated_dir)/$(long_name).v -X verilog --infer-rw $(MODEL) --repl-seq-mem -c:$(MODEL):-o:$(generated_dir)/$(long_name).conf
 
 $(generated_dir)/$(long_name).behav_srams.v : $(generated_dir)/$(long_name).conf $(mem_gen)
 	cd $(generated_dir) && \


### PR DESCRIPTION
Manually copy firrtl jar into unmanaged chisel3 lib so it replaces anything we'd download via sbt.
Update option spelling.

** DON'T MERGE THIS **.

This pr is largely to demonstrate the changes required to support the new chisel/firrtl execute harness, and provide us with something that should track master and allow us to continue to test rocket-chip with newer versions of chisel3 and firrtl.