### PR TITLE
Print out seed if we can

### DIFF
--- a/vsrc/TestDriver.v
+++ b/vsrc/TestDriver.v
@@ -34,7 +34,11 @@ module TestDriver;
     rand_value = $urandom;
     rand_value = $random(rand_value);
     if (verbose) begin
+`ifdef VCS
+      $fdisplay(stderr, "testing $random %0x seed %d", rand_value, unsigned'($get_initial_random_seed));
+`else
       $fdisplay(stderr, "testing $random %0x", rand_value);
+`endif
     end
 
 `ifdef DEBUG


### PR DESCRIPTION
Now that we have ifdef VCS in here lets use it for something more than compatibility

This is a little diff I keep around for debugging non-determinism, thought others might find it useful. The reason I can't just use the stdout where VCS prints the seed is sometimes the non-determinism is rare and so I want to run a bunch of tests in parallel and correlating the stdout to the output file can be difficult. 