### PR TITLE
Sanity check compile-time vs simulation-time options

### DIFF
--- a/vsrc/TestDriver.v
+++ b/vsrc/TestDriver.v
@@ -67,7 +67,15 @@ module TestDriver;
 `define VCDPLUSCLOSE $dumpoff;
 `endif
 `else
+  // No +define+DEBUG
 `define VCDPLUSCLOSE
+
+    if ($test$plusargs("vcdplusfile=") || $test$plusargs("vcdfile="))
+    begin
+      $fdisplay(stderr, "Error: +vcdfile or +vcdplusfile requested but compile did not have +define+DEBUG enabled");
+      $fatal;
+    end
+
 `endif
   end
 


### PR DESCRIPTION
If user compiles without +define+DEBUG but then requests +vcdfile at
simulation time, that request would be silently ignored. This changes
it to a fatal error.

It's good philosophy to treat plusargs like +vcdfile as commands, not
suggestions, and die immediately if they cannot be honored, instead of
silently ignoring them. Otherwise the user sits through the entire
simulation and then is left scratching his head wondering where his
waveforms are.