### PR TITLE
axi4 ToTL: fix decode error arbitration

### DIFF
--- a/src/main/scala/uncore/axi4/ToTL.scala
+++ b/src/main/scala/uncore/axi4/ToTL.scala
@@ -130,8 +130,8 @@ class AXI4ToTL extends LazyModule
     // Prioritize err over ok (b/c err_r.valid comes from a register)
     mux_r.valid := (!mux_lock_err && ok_r.valid) || (!mux_lock_ok && err_r.valid)
     mux_r.bits  := Mux(!mux_lock_ok && err_r.valid, err_r.bits, ok_r.bits)
-    ok_r.ready  := !mux_lock_err && mux_r.ready && !err_r.valid
-    err_r.ready := !mux_lock_ok  && mux_r.ready
+    ok_r.ready  := mux_r.ready && (mux_lock_ok || !err_r.valid)
+    err_r.ready := mux_r.ready && !mux_lock_ok
 
     // AXI4 needs irrevocable behaviour
     in.r <> Queue.irrevocable(mux_r, 1, flow=true)


### PR DESCRIPTION
When selecting between error generation on R and real data on R,
correctly calculate the R backpressure.

This bug manifests when a valid request is immediately followed by
an invalid request, wedging the R channel.