### PR TITLE
[Rocket] Send correct type for iomshr reqs

### DIFF
--- a/src/main/scala/rocket/nbdcache.scala
+++ b/src/main/scala/rocket/nbdcache.scala
@@ -202,7 +202,7 @@ class IOMSHR(id: Int)(implicit p: Parameters) extends L1HellaCacheModule()(p) {
     addr_block = addr_block,
     addr_beat = addr_beat,
     addr_byte = addr_byte,
-    operand_size = req.typ,
+    operand_size = storegen.size,
     alloc = Bool(false))
 
   val put_acquire = Put(
@@ -219,7 +219,7 @@ class IOMSHR(id: Int)(implicit p: Parameters) extends L1HellaCacheModule()(p) {
     addr_beat = addr_beat,
     addr_byte = addr_byte,
     atomic_opcode = req.cmd,
-    operand_size = req.typ,
+    operand_size = storegen.size,
     data = beat_data)
 
   io.acquire.valid := (state === s_acquire)


### PR DESCRIPTION
If you configure rocket-chip to use a larger tilelink data size, say 128 bits rather than 64, you will end up using the bottom three bits of operand_size rather than just 2 as rocket expects. This eventually leads to a TL_Monitor assertion firing because the request address is not aligned with this large size.
StoreGen already correctly handles this so we should use it.

I know this might be a throwaway fix given the rapid TL2 transfer but that PR doesn't touch these lines yet.