### PR TITLE
coreplex: CacheBlockOffsetBits was wrong!

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -109,7 +109,7 @@ class BaseCoreplexConfig extends Config (
       case BroadcastConfig => BroadcastConfig()
       case BankedL2Config => BankedL2Config()
       case CacheBlockBytes => 64
-      case CacheBlockOffsetBits => log2Up(here(CacheBlockBytes))
+      case CacheBlockOffsetBits => log2Up(site(CacheBlockBytes))
       case EnableL2Logging => false
       case _ => throw new CDEMatchError
     }


### PR DESCRIPTION
This bug is ancient. I don't understand how it never mattered before.
Anyway, in processors with a custom CacheBlockBytes, this value is wrong!
The symptom is that TL1 components end up missing high address bits.
This causes, for example, a system to jump to 0 instead of RAM.

I don't understand how this very serious bug did not cause problems before.