### PR TITLE
TLB: do not access illegal addresses

### DIFF
--- a/src/main/scala/rocket/tlb.scala
+++ b/src/main/scala/rocket/tlb.scala
@@ -65,8 +65,10 @@ class TLB(implicit val p: Parameters) extends Module with HasTLBParameters {
   val refill_ppn = io.ptw.resp.bits.pte.ppn(ppnBits-1, 0)
   val do_refill = Bool(usingVM) && io.ptw.resp.valid
   val mpu_ppn = Mux(do_refill, refill_ppn, passthrough_ppn)
+  val mpu_physaddr = mpu_ppn << pgIdxBits
+  val legal_address = edge.manager.findSafe(mpu_physaddr).reduce(_||_)
   def fastCheck(member: TLManagerParameters => Boolean) =
-    Mux1H(edge.manager.findFast(mpu_ppn << pgIdxBits), edge.manager.managers.map(m => Bool(member(m))))
+    legal_address && Mux1H(edge.manager.findFast(mpu_physaddr), edge.manager.managers.map(m => Bool(member(m))))
   val prot_r = fastCheck(_.supportsGet)
   val prot_w = fastCheck(_.supportsPutFull)
   val prot_x = fastCheck(_.executable)


### PR DESCRIPTION
Speculative branches can some times go to addresses considered executable by the fast address decoding function. This showed up when running linux on FPGA.