### PR TITLE
Make instantiated RoCC use dcacheParams

### DIFF
--- a/src/main/scala/rocket/rocc.scala
+++ b/src/main/scala/rocket/rocc.scala
@@ -42,10 +42,10 @@ class RoCCResponse(implicit p: Parameters) extends CoreBundle()(p) {
 class RoCCInterface(implicit p: Parameters) extends CoreBundle()(p) {
   val cmd = Decoupled(new RoCCCommand).flip
   val resp = Decoupled(new RoCCResponse)
-  val mem = new HellaCacheIO()(p.alterPartial({ case CacheName => CacheName("L1D") }))
+  val mem = new HellaCacheIO
   val busy = Bool(OUTPUT)
   val interrupt = Bool(OUTPUT)
-  
+
   // These should be handled differently, eventually
   val autl = new ClientUncachedTileLinkIO
   val utl = Vec(p(RoccNMemChannels), new ClientUncachedTileLinkIO)

--- a/src/main/scala/rocket/tile.scala
+++ b/src/main/scala/rocket/tile.scala
@@ -54,9 +54,9 @@ class RocketTile(tileId: Int)(implicit p: Parameters) extends LazyModule {
   cachedOut := dcache.node
   uncachedOut := TLHintHandler()(ucLegacy.node)
   val masterNodes = List(cachedOut, uncachedOut)
-  
+
   (slaveNode zip scratch) foreach { case (node, lm) => lm.node := TLFragmenter(p(XLen)/8, p(CacheBlockBytes))(node) }
-  
+
   lazy val module = new LazyModuleImp(this) {
     val io = new Bundle {
       val cached = cachedOut.bundleOut
@@ -95,7 +95,7 @@ class RocketTile(tileId: Int)(implicit p: Parameters) extends LazyModule {
       cmdRouter.io.in <> core.io.rocc.cmd
 
       val roccs = buildRocc.zipWithIndex.map { case (accelParams, i) =>
-        val rocc = accelParams.generator(p.alterPartial({
+        val rocc = accelParams.generator(dcacheParams.alterPartial({
           case RoccNMemChannels => accelParams.nMemChannels
           case RoccNPTWPorts => accelParams.nPTWPorts
         }))


### PR DESCRIPTION
Get RoccExampleConfig back to building. See: [#450](https://github.com/ucb-bar/rocket-chip/issues/450#issuecomment-263743855)