### PR TITLE
clint: undefined registers must be zero

### DIFF
--- a/src/main/scala/uncore/devices/Prci.scala
+++ b/src/main/scala/uncore/devices/Prci.scala
@@ -84,7 +84,7 @@ trait CoreplexLocalInterrupterModule extends Module with HasRegMap with MixCorep
 /** Power, Reset, Clock, Interrupt */
 // Magic TL2 Incantation to create a TL2 Slave
 class CoreplexLocalInterrupter(address: BigInt = 0x02000000)(implicit val p: Parameters)
-  extends TLRegisterRouter(address, size = ClintConsts.size, beatBytes = p(rocket.XLen)/8, undefZero = false)(
+  extends TLRegisterRouter(address, size = ClintConsts.size, beatBytes = p(rocket.XLen)/8, undefZero = true)(
   new TLRegBundle(p, _)    with CoreplexLocalInterrupterBundle)(
   new TLRegModule(p, _, _) with CoreplexLocalInterrupterModule)
 {


### PR DESCRIPTION
This is needed so that SMP-safe boot loaders can safely
read/write to the IPI register of non-existent harts.