### PR TITLE
Perform integer division when parsing rocketchip.DefaultConfig.conf

### DIFF
--- a/vsim/vlsi_mem_gen
+++ b/vsim/vlsi_mem_gen
@@ -30,7 +30,7 @@ def parse_line(line):
       mask_gran = int(tokens[i+1])
     else:
       sys.exit('%s: unknown argument %s' % (sys.argv[0], a))
-  return (name, width, depth, mask_gran, width/mask_gran, ports)
+  return (name, width, depth, mask_gran, width//mask_gran, ports)
 
 def gen_mem(name, width, depth, mask_gran, mask_seg, ports):
   addr_width = max(math.ceil(math.log(depth)/math.log(2)),1)


### PR DESCRIPTION
I got an error when performing `make verilog` in the vsim folder:

```
Traceback (most recent call last):
  File "/home/oguz286/Projects/rocket-chip/vsim/vlsi_mem_gen", line 177, in <module>
    main()
  File "/home/oguz286/Projects/rocket-chip/vsim/vlsi_mem_gen", line 174, in main
    print(gen_mem(*parse_line(line)))
  File "/home/oguz286/Projects/rocket-chip/vsim/vlsi_mem_gen", line 151, in gen_mem
    for i in range(mask_seg):
TypeError: 'float' object cannot be interpreted as an integer
```

This was due to the `parse_line` function performing a floating point division, and I changed it to an integer division.