### PR TITLE
Fix emulator argument processing for unknown DTM arguments

### DIFF
--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -118,10 +118,6 @@ int main(int argc, char** argv)
       // we've hit the binary. The binary is expected to be a
       // non-option and not start with '-' or '+'.
       case 1: {
-        if (optarg[0] != '+') {
-          to_dtm.push_back(optarg);
-          goto done_processing;
-        }
         std::string arg = optarg;
         if (arg == "+verbose")
           verbose = true;
@@ -134,9 +130,8 @@ int main(int argc, char** argv)
         else if (arg.substr(0, 12) == "+cycle-count")
           print_cycles = true;
         else {
-          fprintf(stderr, "%s: unrecognized option '%s'\n", argv[0], optarg);
-          usage(argv[0]);
-          return 1;
+          to_dtm.push_back(optarg);
+          goto done_processing;
         }
         break;
       }


### PR DESCRIPTION
Revision 7e79421 (issue #484) makes emulator.cc rejecting any unrecognized
+arg "legacy" arguments, however, this breaks riscv-torture emulator tests
as it needs to pass +signature to the DTM.

I think it is actually impossible to check for unknown argument here
unless we hardcode a list of all arguments recognized by fesrv. Fix this
issue by passing all arguments starting with the first unknown argument
to DTM.

Updates #484.