### PR TITLE
Configs: use a uniform syntax without Match exceptions

### DIFF
--- a/src/main/scala/config/Config.scala
+++ b/src/main/scala/config/Config.scala
@@ -3,9 +3,6 @@
 package config
 
 class Field[T]
-class CDEMatchError() extends Exception {
-  override def fillInStackTrace() = this
-}
 
 abstract class View {
   final def apply[T](pname: Field[T]): T = apply(pname, this)
@@ -15,37 +12,27 @@ abstract class View {
 }
 
 abstract class Parameters extends View {
-  final def ++ (x: Parameters):                        Parameters = new ChainParameters(this, x)
-  final def alter(f: (Any, View, View, View) => Any):  Parameters = Parameters(f) ++ this
-  final def alter(m: Map[Any,Any]):                    Parameters = Parameters(m) ++ this
-  final def alter(f: PartialFunction[Any,Any]):        Parameters = Parameters(f) ++ this
-  final def alterPartial(f: PartialFunction[Any,Any]): Parameters = Parameters(f) ++ this
+  final def ++ (x: Parameters):                                       Parameters = new ChainParameters(this, x)
+  final def alter(f: (View, View, View) => PartialFunction[Any,Any]): Parameters = Parameters(f) ++ this
+  final def alterPartial(f: PartialFunction[Any,Any]):                Parameters = Parameters((_,_,_) => f) ++ this
 
   protected[config] def chain(site: View, tail: View, pname: Any): Any
   protected[config] def find(pname: Any, site: View) = chain(site, new TerminalView, pname)
 }
 
 object Parameters {
-  def empty:                                    Parameters = new EmptyParameters
-  def apply(f: (Any, View, View, View) => Any): Parameters = new FunctionParameters(f)
-  def apply(m: Map[Any,Any]):                   Parameters = new MapParameters(m)
-  def apply(f: PartialFunction[Any,Any]):       Parameters = new PartialParameters(f)
-  def partial(f: PartialFunction[Any,Any]):     Parameters = new PartialParameters(f)
+  def empty:                                                    Parameters = new EmptyParameters
+  def apply(f: (View, View, View) => PartialFunction[Any,Any]): Parameters = new PartialParameters(f)
   def root(p: Parameters) = p
 }
 
 class Config(p: Parameters) extends Parameters {
-  def this(f: (Any, View, View)       => Any) = this(Parameters((p,s,h,u) => f(p,s,h))) // backwards compat; don't use
-  def this(f: (Any, View, View, View) => Any) = this(Parameters(f))
-  def this(m: Map[Any,Any])                   = this(Parameters(m))
-  def this(f: PartialFunction[Any,Any])       = this(Parameters(f))
+  def this(f: (View, View, View) => PartialFunction[Any,Any]) = this(Parameters(f))
 
   protected[config] def chain(site: View, tail: View, pname: Any) = p.chain(site, tail, pname)
   override def toString = this.getClass.getSimpleName
   def toInstance = this
 }
-
-class ConfigPartial(f: PartialFunction[Any,Any]) extends Config(Parameters(f))
 
 // Internal implementation:
 
@@ -66,22 +53,9 @@ private class EmptyParameters extends Parameters {
   def chain(site: View, tail: View, pname: Any) = tail.find(pname, site)
 }
 
-private class FunctionParameters(f: (Any, View, View, View) => Any) extends Parameters {
+private class PartialParameters(f: (View, View, View) => PartialFunction[Any,Any]) extends Parameters {
   protected[config] def chain(site: View, tail: View, pname: Any) = {
-    try f(pname, site, this, tail)
-    catch {
-      case e: CDEMatchError    => tail.find(pname, site)
-      case e: scala.MatchError => tail.find(pname, site) 
-    }
+    val g = f(site, this, tail)
+    if (g.isDefinedAt(pname)) g.apply(pname) else tail.find(pname, site)
   }
-}
-
-private class MapParameters(map: Map[Any, Any]) extends Parameters {
-  protected[config] def chain(site: View, tail: View, pname: Any) =
-    map.get(pname).getOrElse(find(pname, site))
-}
-
-private class PartialParameters(f: PartialFunction[Any,Any]) extends Parameters {
-  protected[config] def chain(site: View, tail: View, pname: Any) =
-    if (f.isDefinedAt(pname)) f.apply(pname) else tail.find(pname, site)
 }

--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -17,179 +17,151 @@ import uncore.converters._
 import uncore.util._
 import util._
 
-class BaseCoreplexConfig extends Config (
-  { (pname,site,here) =>
-    lazy val innerDataBits = site(XLen)
-    lazy val innerDataBeats = (8 * site(CacheBlockBytes)) / innerDataBits
-    pname match {
-      //Memory Parameters
-      case PAddrBits => 32
-      case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
-      case ASIdBits => 7
-      //Params used by all caches
-      case CacheName("L1I") => CacheConfig(
-        nSets         = 64,
-        nWays         = 4,
-        rowBits       = site(L1toL2Config).beatBytes*8,
-        nTLBEntries   = 8,
-        cacheIdBits   = 0,
-        splitMetadata = false)
-      case CacheName("L1D") => CacheConfig(
-        nSets         = 64,
-        nWays         = 4,
-        rowBits       = site(L1toL2Config).beatBytes*8,
-        nTLBEntries   = 8,
-        cacheIdBits   = 0,
-        splitMetadata = false)
-      case ECCCode => None
-      case Replacer => () => new RandomReplacement(site(site(CacheName)).nWays)
-      //L1InstCache
-      case BtbKey => BtbParameters()
-      //L1DataCache
-      case DCacheKey => DCacheConfig(nMSHRs = 2)
-      case DataScratchpadSize => 0
-      //L2 Memory System Params
-      case AmoAluOperandBits => site(XLen)
-      case NAcquireTransactors => 7
-      case L2StoreDataQueueDepth => 1
-      case L2DirectoryRepresentation => new NullRepresentation(site(NTiles))
-      //Tile Constants
-      case BuildRoCC => Nil
-      case RoccNMemChannels => site(BuildRoCC).map(_.nMemChannels).foldLeft(0)(_ + _)
-      case RoccNPTWPorts => site(BuildRoCC).map(_.nPTWPorts).foldLeft(0)(_ + _)
-      //Rocket Core Constants
-      case CoreInstBits => if (site(UseCompressed)) 16 else 32
-      case FetchWidth => if (site(UseCompressed)) 2 else 1
-      case RetireWidth => 1
-      case UseVM => true
-      case UseUser => false
-      case UseDebug => true
-      case NBreakpoints => 1
-      case NPerfCounters => 0
-      case NPerfEvents => 0
-      case FastLoadWord => true
-      case FastLoadByte => false
-      case FastJAL => false
-      case XLen => 64
-      case FPUKey => Some(FPUConfig())
-      case MulDivKey => Some(MulDivConfig(mulUnroll = 8, mulEarlyOut = (site(XLen) > 32), divEarlyOut = true))
-      case UseAtomics => true
-      case UseCompressed => true
-      case DMKey => new DefaultDebugModuleConfig(site(NTiles), site(XLen))
-      case NCustomMRWCSRs => 0
-      case MtvecInit => Some(BigInt(0))
-      case MtvecWritable => true
-      //Uncore Paramters
-      case LNEndpoints => site(TLKey(site(TLId))).nManagers + site(TLKey(site(TLId))).nClients
-      case LNHeaderBits => log2Ceil(site(TLKey(site(TLId))).nManagers) +
-                             log2Up(site(TLKey(site(TLId))).nClients)
-      case CBusConfig => TLBusConfig(beatBytes = site(XLen)/8)
-      case L1toL2Config => TLBusConfig(beatBytes = site(XLen)/8) // increase for more PCIe bandwidth
-      case TLKey("L1toL2") => {
-        val useMEI = site(NTiles) <= 1
-        TileLinkParameters(
-          coherencePolicy = (
-            if (useMEI) new MEICoherence(site(L2DirectoryRepresentation))
-            else new MESICoherence(site(L2DirectoryRepresentation))),
-          nManagers = site(BankedL2Config).nBanks + 1 /* MMIO */,
-          nCachingClients = 1,
-          nCachelessClients = 1,
-          maxClientXacts = List(
-              // L1 cache
-              site(DCacheKey).nMSHRs + 1 /* IOMSHR */,
-              // RoCC
-              if (site(BuildRoCC).isEmpty) 1 else site(RoccMaxTaggedMemXacts)).max,
-          maxClientsPerPort = if (site(BuildRoCC).isEmpty) 1 else 2,
-          maxManagerXacts = site(NAcquireTransactors) + 2,
-          dataBeats = innerDataBeats,
-          dataBits = site(CacheBlockBytes)*8)
-      }
-      case BootROMFile => "./bootrom/bootrom.img"
-      case NTiles => 1
-      case BroadcastConfig => BroadcastConfig()
-      case BankedL2Config => BankedL2Config()
-      case CacheBlockBytes => 64
-      case CacheBlockOffsetBits => log2Up(site(CacheBlockBytes))
-      case EnableL2Logging => false
-      case _ => throw new CDEMatchError
-    }
+class BaseCoreplexConfig extends Config ((site, here, up) => {
+  //Memory Parameters
+  case PAddrBits => 32
+  case PgLevels => if (site(XLen) == 64) 3 /* Sv39 */ else 2 /* Sv32 */
+  case ASIdBits => 7
+  //Params used by all caches
+  case CacheName("L1I") => CacheConfig(
+    nSets         = 64,
+    nWays         = 4,
+    rowBits       = site(L1toL2Config).beatBytes*8,
+    nTLBEntries   = 8,
+    cacheIdBits   = 0,
+    splitMetadata = false)
+  case CacheName("L1D") => CacheConfig(
+    nSets         = 64,
+    nWays         = 4,
+    rowBits       = site(L1toL2Config).beatBytes*8,
+    nTLBEntries   = 8,
+    cacheIdBits   = 0,
+    splitMetadata = false)
+  case ECCCode => None
+  case Replacer => () => new RandomReplacement(site(site(CacheName)).nWays)
+  //L1InstCache
+  case BtbKey => BtbParameters()
+  //L1DataCache
+  case DCacheKey => DCacheConfig(nMSHRs = 2)
+  case DataScratchpadSize => 0
+  //L2 Memory System Params
+  case AmoAluOperandBits => site(XLen)
+  case NAcquireTransactors => 7
+  case L2StoreDataQueueDepth => 1
+  case L2DirectoryRepresentation => new NullRepresentation(site(NTiles))
+  //Tile Constants
+  case BuildRoCC => Nil
+  case RoccNMemChannels => site(BuildRoCC).map(_.nMemChannels).foldLeft(0)(_ + _)
+  case RoccNPTWPorts => site(BuildRoCC).map(_.nPTWPorts).foldLeft(0)(_ + _)
+  //Rocket Core Constants
+  case CoreInstBits => if (site(UseCompressed)) 16 else 32
+  case FetchWidth => if (site(UseCompressed)) 2 else 1
+  case RetireWidth => 1
+  case UseVM => true
+  case UseUser => false
+  case UseDebug => true
+  case NBreakpoints => 1
+  case NPerfCounters => 0
+  case NPerfEvents => 0
+  case FastLoadWord => true
+  case FastLoadByte => false
+  case FastJAL => false
+  case XLen => 64
+  case FPUKey => Some(FPUConfig())
+  case MulDivKey => Some(MulDivConfig(mulUnroll = 8, mulEarlyOut = (site(XLen) > 32), divEarlyOut = true))
+  case UseAtomics => true
+  case UseCompressed => true
+  case DMKey => new DefaultDebugModuleConfig(site(NTiles), site(XLen))
+  case NCustomMRWCSRs => 0
+  case MtvecInit => Some(BigInt(0))
+  case MtvecWritable => true
+  //Uncore Paramters
+  case LNEndpoints => site(TLKey(site(TLId))).nManagers + site(TLKey(site(TLId))).nClients
+  case LNHeaderBits => log2Ceil(site(TLKey(site(TLId))).nManagers) +
+                         log2Up(site(TLKey(site(TLId))).nClients)
+  case CBusConfig => TLBusConfig(beatBytes = site(XLen)/8)
+  case L1toL2Config => TLBusConfig(beatBytes = site(XLen)/8) // increase for more PCIe bandwidth
+  case TLKey("L1toL2") => {
+    val useMEI = site(NTiles) <= 1
+    TileLinkParameters(
+      coherencePolicy = (
+        if (useMEI) new MEICoherence(site(L2DirectoryRepresentation))
+        else new MESICoherence(site(L2DirectoryRepresentation))),
+      nManagers = site(BankedL2Config).nBanks + 1 /* MMIO */,
+      nCachingClients = 1,
+      nCachelessClients = 1,
+      maxClientXacts = List(
+          // L1 cache
+          site(DCacheKey).nMSHRs + 1 /* IOMSHR */,
+          // RoCC
+          if (site(BuildRoCC).isEmpty) 1 else site(RoccMaxTaggedMemXacts)).max,
+      maxClientsPerPort = if (site(BuildRoCC).isEmpty) 1 else 2,
+      maxManagerXacts = site(NAcquireTransactors) + 2,
+      dataBeats = (8 * site(CacheBlockBytes)) / site(XLen),
+      dataBits = site(CacheBlockBytes)*8)
   }
-)
+  case BootROMFile => "./bootrom/bootrom.img"
+  case NTiles => 1
+  case BroadcastConfig => BroadcastConfig()
+  case BankedL2Config => BankedL2Config()
+  case CacheBlockBytes => 64
+  case CacheBlockOffsetBits => log2Up(site(CacheBlockBytes))
+  case EnableL2Logging => false
+})
 
-class WithNCores(n: Int) extends Config(
-  (pname,site,here) => pname match {
-    case NTiles => n
-    case _ => throw new CDEMatchError
-  })
+class WithNCores(n: Int) extends Config((site, here, up) => {
+  case NTiles => n
+})
 
-class WithNBanksPerMemChannel(n: Int) extends Config(
-  (pname, site, here, up) => pname match {
-    case BankedL2Config => up(BankedL2Config, site).copy(nBanksPerChannel = n)
-    case _ => throw new CDEMatchError
-  })
+class WithNBanksPerMemChannel(n: Int) extends Config((site, here, up) => {
+  case BankedL2Config => up(BankedL2Config, site).copy(nBanksPerChannel = n)
+})
 
-class WithNTrackersPerBank(n: Int) extends Config(
-  (pname, site, here, up) => pname match {
-    case BroadcastConfig => up(BroadcastConfig, site).copy(nTrackers = n)
-    case _ => throw new CDEMatchError
-  })
-
-// This is the number of sets **per way**
-class WithL1ICacheSets(sets: Int) extends Config(
-  (pname, site, here, up) => pname match {
-    case CacheName("L1I") => up(CacheName("L1I"), site).copy(nSets = sets)
-    case _ => throw new CDEMatchError
-  })
+class WithNTrackersPerBank(n: Int) extends Config((site, here, up) => {
+  case BroadcastConfig => up(BroadcastConfig, site).copy(nTrackers = n)
+})
 
 // This is the number of sets **per way**
-class WithL1DCacheSets(sets: Int) extends Config(
-  (pname, site, here, up) => pname match {
-    case CacheName("L1D") => up(CacheName("L1D"), site).copy(nSets = sets)
-    case _ => throw new CDEMatchError
-  })
+class WithL1ICacheSets(sets: Int) extends Config((site, here, up) => {
+  case CacheName("L1I") => up(CacheName("L1I"), site).copy(nSets = sets)
+})
 
-class WithL1ICacheWays(ways: Int) extends Config(
-  (pname, site, here, up) => pname match {
-    case CacheName("L1I") => up(CacheName("L1I"), site).copy(nWays = ways)
-    case _ => throw new CDEMatchError
-  })
+// This is the number of sets **per way**
+class WithL1DCacheSets(sets: Int) extends Config((site, here, up) => {
+  case CacheName("L1D") => up(CacheName("L1D"), site).copy(nSets = sets)
+})
 
-class WithL1DCacheWays(ways: Int) extends Config(
-  (pname, site, here, up) => pname match {
-    case CacheName("L1D") => up(CacheName("L1D"), site).copy(nWays = ways)
-    case _ => throw new CDEMatchError
-  })
+class WithL1ICacheWays(ways: Int) extends Config((site, here, up) => {
+  case CacheName("L1I") => up(CacheName("L1I"), site).copy(nWays = ways)
+})
 
-class WithCacheBlockBytes(linesize: Int) extends Config(
-  (pname,site,here) => pname match {
-    case CacheBlockBytes => linesize
-    case _ => throw new CDEMatchError
-  })
+class WithL1DCacheWays(ways: Int) extends Config((site, here, up) => {
+  case CacheName("L1D") => up(CacheName("L1D"), site).copy(nWays = ways)
+})
 
-class WithDataScratchpad(n: Int) extends Config(
-  (pname,site,here,up) => pname match {
-    case DataScratchpadSize => n
-    case CacheName("L1D") => up(CacheName("L1D"), site).copy(nSets = n / site(CacheBlockBytes))
-    case _ => throw new CDEMatchError
-  })
+class WithCacheBlockBytes(linesize: Int) extends Config((site, here, up) => {
+  case CacheBlockBytes => linesize
+})
+
+class WithDataScratchpad(n: Int) extends Config((site, here, up) => {
+  case DataScratchpadSize => n
+  case CacheName("L1D") => up(CacheName("L1D"), site).copy(nSets = n / site(CacheBlockBytes))
+})
 
 // TODO: re-add L2
-class WithL2Cache extends Config(
-  (pname,site,here) => pname match {
-    case CacheName("L2") => CacheConfig(
-      nSets         = 1024,
-      nWays         = 1,
-      rowBits       = site(L1toL2Config).beatBytes*8,
-      nTLBEntries   = 0,
-      cacheIdBits   = 1,
-      splitMetadata = false)
-    case _ => throw new CDEMatchError
-  })
+class WithL2Cache extends Config((site, here, up) => {
+  case CacheName("L2") => CacheConfig(
+    nSets         = 1024,
+    nWays         = 1,
+    rowBits       = site(L1toL2Config).beatBytes*8,
+    nTLBEntries   = 0,
+    cacheIdBits   = 1,
+    splitMetadata = false)
+})
 
-class WithBufferlessBroadcastHub extends Config(
-  (pname, site, here, up) => pname match {
-    case BroadcastConfig => up(BroadcastConfig, site).copy(bufferless = true)
-  })
+class WithBufferlessBroadcastHub extends Config((site, here, up) => {
+  case BroadcastConfig => up(BroadcastConfig, site).copy(bufferless = true)
+})
 
 /**
  * WARNING!!! IGNORE AT YOUR OWN PERIL!!!
@@ -203,103 +175,74 @@ class WithBufferlessBroadcastHub extends Config(
  * system depends on coherence between channels in any way,
  * DO NOT use this configuration.
  */
-class WithStatelessBridge extends Config(
-  (pname,site,here,up) => pname match {
+class WithStatelessBridge extends Config((site, here, up) => {
 /* !!! FIXME
     case BankedL2Config => up(BankedL2Config, site).copy(coherenceManager = { case (_, _) =>
       val pass = LazyModule(new TLBuffer(0)(site))
       (pass.node, pass.node)
     })
 */
-    case DCacheKey => up(DCacheKey, site).copy(nMSHRs = 0)
-    case _ => throw new CDEMatchError
-  })
+  case DCacheKey => up(DCacheKey, site).copy(nMSHRs = 0)
+})
 
-class WithPLRU extends Config(
-  (pname, site, here) => pname match {
-    case _ => throw new CDEMatchError
-  })
+class WithL2Capacity(size_kb: Int) extends Config(Parameters.empty)
 
-class WithL2Capacity(size_kb: Int) extends Config(
-  (pname,site,here) => pname match {
-    case _ => throw new CDEMatchError
-  })
+class WithNL2Ways(n: Int) extends Config((site, here, up) => {
+  case CacheName("L2") => up(CacheName("L2"), site).copy(nWays = n)
+})
 
-class WithNL2Ways(n: Int) extends Config(
-  (pname,site,here,up) => pname match {
-    case CacheName("L2") => up(CacheName("L2"), site).copy(nWays = n)
-  })
+class WithRV32 extends Config((site, here, up) => {
+  case XLen => 32
+  case FPUKey => Some(FPUConfig(divSqrt = false))
+})
 
-class WithRV32 extends Config(
-  (pname,site,here) => pname match {
-    case XLen => 32
-    case FPUKey => Some(FPUConfig(divSqrt = false))
-    case _ => throw new CDEMatchError
-  })
+class WithBlockingL1 extends Config((site, here, up) => {
+  case DCacheKey => up(DCacheKey, site).copy(nMSHRs = 0)
+})
 
-class WithBlockingL1 extends Config(
-  (pname,site,here,up) => pname match {
-    case DCacheKey => up(DCacheKey, site).copy(nMSHRs = 0)
-    case _ => throw new CDEMatchError
-  })
+class WithSmallCores extends Config((site, here, up) => {
+  case MulDivKey => Some(MulDivConfig())
+  case FPUKey => None
+  case UseVM => false
+  case BtbKey => BtbParameters(nEntries = 0)
+  case NAcquireTransactors => 2
+  case CacheName("L1D") => up(CacheName("L1D"), site).copy(nSets = 64, nWays = 1, nTLBEntries = 4)
+  case CacheName("L1I") => up(CacheName("L1I"), site).copy(nSets = 64, nWays = 1, nTLBEntries = 4)
+  case DCacheKey => up(DCacheKey, site).copy(nMSHRs = 0)
+})
 
-class WithSmallCores extends Config(
-  (pname,site,here,up) => pname match {
-    case MulDivKey => Some(MulDivConfig())
-    case FPUKey => None
-    case UseVM => false
-    case BtbKey => BtbParameters(nEntries = 0)
-    case NAcquireTransactors => 2
-    case CacheName("L1D") => up(CacheName("L1D"), site).copy(nSets = 64, nWays = 1, nTLBEntries = 4)
-    case CacheName("L1I") => up(CacheName("L1I"), site).copy(nSets = 64, nWays = 1, nTLBEntries = 4)
-    case DCacheKey => up(DCacheKey, site).copy(nMSHRs = 0)
-    case _ => throw new CDEMatchError
-  })
+class WithRoccExample extends Config((site, here, up) => {
+  case BuildRoCC => Seq(
+    RoccParameters(
+      opcodes = OpcodeSet.custom0,
+      generator = (p: Parameters) => Module(new AccumulatorExample()(p))),
+    RoccParameters(
+      opcodes = OpcodeSet.custom1,
+      generator = (p: Parameters) => Module(new TranslatorExample()(p)),
+      nPTWPorts = 1),
+    RoccParameters(
+      opcodes = OpcodeSet.custom2,
+      generator = (p: Parameters) => Module(new CharacterCountExample()(p))))
 
-class WithRoccExample extends Config(
-  (pname, site, here) => pname match {
-    case BuildRoCC => Seq(
-      RoccParameters(
-        opcodes = OpcodeSet.custom0,
-        generator = (p: Parameters) => Module(new AccumulatorExample()(p))),
-      RoccParameters(
-        opcodes = OpcodeSet.custom1,
-        generator = (p: Parameters) => Module(new TranslatorExample()(p)),
-        nPTWPorts = 1),
-      RoccParameters(
-        opcodes = OpcodeSet.custom2,
-        generator = (p: Parameters) => Module(new CharacterCountExample()(p))))
+  case RoccMaxTaggedMemXacts => 1
+})
 
-    case RoccMaxTaggedMemXacts => 1
-    case _ => throw new CDEMatchError
-  })
+class WithDefaultBtb extends Config((site, here, up) => {
+  case BtbKey => BtbParameters()
+})
 
-class WithDefaultBtb extends Config(
-  (pname,site,here) => pname match {
-    case BtbKey => BtbParameters()
-    case _ => throw new CDEMatchError
-  })
+class WithFastMulDiv extends Config((site, here, up) => {
+  case MulDivKey => Some(MulDivConfig(mulUnroll = 8, mulEarlyOut = (site(XLen) > 32), divEarlyOut = true))
+})
 
-class WithFastMulDiv extends Config(
-  (pname,site,here) => pname match {
-    case MulDivKey => Some(MulDivConfig(mulUnroll = 8, mulEarlyOut = (site(XLen) > 32), divEarlyOut = true))
-    case _ => throw new CDEMatchError
-  })
+class WithoutMulDiv extends Config((site, here, up) => {
+  case MulDivKey => None
+})
 
-class WithoutMulDiv extends Config(
-  (pname, site, here) => pname match {
-    case MulDivKey => None
-    case _ => throw new CDEMatchError
-  })
+class WithoutFPU extends Config((site, here, up) => {
+  case FPUKey => None
+})
 
-class WithoutFPU extends Config(
-  (pname, site, here) => pname match {
-    case FPUKey => None
-    case _ => throw new CDEMatchError
-  })
-
-class WithFPUWithoutDivSqrt extends Config (
-  (pname, site, here) => pname match {
-    case FPUKey => Some(FPUConfig(divSqrt = false))
-    case _ => throw new CDEMatchError
-  })
+class WithFPUWithoutDivSqrt extends Config((site, here, up) => {
+  case FPUKey => Some(FPUConfig(divSqrt = false))
+})

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -45,7 +45,7 @@ class FancyMemtestConfig extends Config(
   new WithL2Cache ++ new GroundTestConfig)
 
 class CacheFillTestConfig extends Config(
-  new WithNL2Ways(4) ++ new WithL2Capacity(4) ++ new WithCacheFillTest ++ new WithPLRU ++ new WithL2Cache ++ new GroundTestConfig)
+  new WithNL2Ways(4) ++ new WithL2Capacity(4) ++ new WithCacheFillTest ++ new WithL2Cache ++ new GroundTestConfig)
 
 class BroadcastRegressionTestConfig extends Config(
   new WithBroadcastRegressionTest ++ new GroundTestConfig)

--- a/src/main/scala/groundtest/Configs.scala
+++ b/src/main/scala/groundtest/Configs.scala
@@ -73,137 +73,117 @@ class Edge32BitMemtestConfig extends Config(
   new WithEdgeDataBits(32) ++ new MemtestConfig)
 
 /* Composable Configs to set individual parameters */
-class WithGroundTest extends Config(
-  (pname, site, here) => pname match {
-    case TLKey("L1toL2") => {
-      val useMEI = site(NTiles) <= 1
-      val dataBeats = (8 * site(CacheBlockBytes)) / site(XLen)
-      TileLinkParameters(
-        coherencePolicy = (
-          if (useMEI) new MEICoherence(site(L2DirectoryRepresentation))
-          else new MESICoherence(site(L2DirectoryRepresentation))),
-        nManagers = site(BankedL2Config).nBanks + 1,
-        nCachingClients = 1,
-        nCachelessClients = 1,
-        maxClientXacts = ((site(DCacheKey).nMSHRs + 1) +:
-                           site(GroundTestKey).map(_.maxXacts))
-                             .reduce(max(_, _)),
-        maxClientsPerPort = site(GroundTestKey).map(_.uncached).sum,
-        maxManagerXacts = site(NAcquireTransactors) + 2,
-        dataBeats = dataBeats,
-        dataBits = site(CacheBlockBytes)*8)
-    }
-    case FPUKey => None
-    case UseAtomics => false
-    case UseCompressed => false
-    case _ => throw new CDEMatchError
-  })
+class WithGroundTest extends Config((site, here, up) => {
+  case TLKey("L1toL2") => {
+    val useMEI = site(NTiles) <= 1
+    val dataBeats = (8 * site(CacheBlockBytes)) / site(XLen)
+    TileLinkParameters(
+      coherencePolicy = (
+        if (useMEI) new MEICoherence(site(L2DirectoryRepresentation))
+        else new MESICoherence(site(L2DirectoryRepresentation))),
+      nManagers = site(BankedL2Config).nBanks + 1,
+      nCachingClients = 1,
+      nCachelessClients = 1,
+      maxClientXacts = ((site(DCacheKey).nMSHRs + 1) +:
+                         site(GroundTestKey).map(_.maxXacts))
+                           .reduce(max(_, _)),
+      maxClientsPerPort = site(GroundTestKey).map(_.uncached).sum,
+      maxManagerXacts = site(NAcquireTransactors) + 2,
+      dataBeats = dataBeats,
+      dataBits = site(CacheBlockBytes)*8)
+  }
+  case FPUKey => None
+  case UseAtomics => false
+  case UseCompressed => false
+})
 
-class WithComparator extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(uncached = 2)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new ComparatorCore()(p))
-    case ComparatorKey => ComparatorParameters(
-      targets    = Seq(site(ExtMem).base, testRamAddr),
-      width      = 8,
-      operations = 1000,
-      atomics    = site(UseAtomics),
-      prefetches = false)
-    case FPUConfig => None
-    case UseAtomics => false
-    case _ => throw new CDEMatchError
-  })
+class WithComparator extends Config((site, here, up) => {
+  case GroundTestKey => Seq.fill(site(NTiles)) {
+    GroundTestTileSettings(uncached = 2)
+  }
+  case BuildGroundTest =>
+    (p: Parameters) => Module(new ComparatorCore()(p))
+  case ComparatorKey => ComparatorParameters(
+    targets    = Seq(site(ExtMem).base, testRamAddr),
+    width      = 8,
+    operations = 1000,
+    atomics    = site(UseAtomics),
+    prefetches = false)
+  case FPUConfig => None
+  case UseAtomics => false
+})
 
-class WithAtomics extends Config(
-  (pname, site, here) => pname match {
-    case UseAtomics => true
-    case _ => throw new CDEMatchError
-  })
+class WithAtomics extends Config((site, here, up) => {
+  case UseAtomics => true
+})
 
-class WithPrefetches extends Config(
-  (pname, site, here, up) => pname match {
-    case ComparatorKey => up(ComparatorKey, site).copy(prefetches = true)
-    case _ => throw new CDEMatchError
-  })
+class WithPrefetches extends Config((site, here, up) => {
+  case ComparatorKey => up(ComparatorKey, site).copy(prefetches = true)
+})
 
-class WithMemtest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(1, 1)
-    }
-    case GeneratorKey => TrafficGeneratorParameters(
-      maxRequests = 128,
-      startAddress = BigInt(site(ExtMem).base))
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new GeneratorTest()(p))
-    case _ => throw new CDEMatchError
-  })
+class WithMemtest extends Config((site, here, up) => {
+  case GroundTestKey => Seq.fill(site(NTiles)) {
+    GroundTestTileSettings(1, 1)
+  }
+  case GeneratorKey => TrafficGeneratorParameters(
+    maxRequests = 128,
+    startAddress = BigInt(site(ExtMem).base))
+  case BuildGroundTest =>
+    (p: Parameters) => Module(new GeneratorTest()(p))
+})
 
-class WithNGenerators(nUncached: Int, nCached: Int) extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(nUncached, nCached)
-    }
-    case _ => throw new CDEMatchError
-  })
+class WithNGenerators(nUncached: Int, nCached: Int) extends Config((site, here, up) => {
+  case GroundTestKey => Seq.fill(site(NTiles)) {
+    GroundTestTileSettings(nUncached, nCached)
+  }
+})
 
-class WithCacheFillTest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(uncached = 1)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new CacheFillTest()(p))
-    case _ => throw new CDEMatchError
-  })
+class WithCacheFillTest extends Config((site, here, up) => {
+  case GroundTestKey => Seq.fill(site(NTiles)) {
+    GroundTestTileSettings(uncached = 1)
+  }
+  case BuildGroundTest =>
+    (p: Parameters) => Module(new CacheFillTest()(p))
+})
 
-class WithBroadcastRegressionTest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(1, 1, maxXacts = 3)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new RegressionTest()(p))
-    case GroundTestRegressions =>
-      (p: Parameters) => RegressionTests.broadcastRegressions(p)
-    case _ => throw new CDEMatchError
-  })
+class WithBroadcastRegressionTest extends Config((site, here, up) => {
+  case GroundTestKey => Seq.fill(site(NTiles)) {
+    GroundTestTileSettings(1, 1, maxXacts = 3)
+  }
+  case BuildGroundTest =>
+    (p: Parameters) => Module(new RegressionTest()(p))
+  case GroundTestRegressions =>
+    (p: Parameters) => RegressionTests.broadcastRegressions(p)
+})
 
-class WithCacheRegressionTest extends Config(
-  (pname, site, here) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(1, 1, maxXacts = 5)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new RegressionTest()(p))
-    case GroundTestRegressions =>
-      (p: Parameters) => RegressionTests.cacheRegressions(p)
-    case _ => throw new CDEMatchError
-  })
+class WithCacheRegressionTest extends Config((site, here, up) => {
+  case GroundTestKey => Seq.fill(site(NTiles)) {
+    GroundTestTileSettings(1, 1, maxXacts = 5)
+  }
+  case BuildGroundTest =>
+    (p: Parameters) => Module(new RegressionTest()(p))
+  case GroundTestRegressions =>
+    (p: Parameters) => RegressionTests.cacheRegressions(p)
+})
 
-class WithTraceGen extends Config(
-  (pname, site, here, up) => pname match {
-    case GroundTestKey => Seq.fill(site(NTiles)) {
-      GroundTestTileSettings(uncached = 1, cached = 1)
-    }
-    case BuildGroundTest =>
-      (p: Parameters) => Module(new GroundTestTraceGenerator()(p))
-    case GeneratorKey => TrafficGeneratorParameters(
-      maxRequests = 8192,
-      startAddress = 0)
-    case AddressBag => {
-      val nSets = 2
-      val nWays = 1
-      val blockOffset = site(CacheBlockOffsetBits)
-      val nBeats = site(TLKey("L1toL2")).dataBeats
-      List.tabulate(4 * nWays) { i =>
-        Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
-      }.flatten
-    }
-    case UseAtomics => true
-    case CacheName("L1D") => up(CacheName("L1D"), site).copy(nSets = 16, nWays = 1)
-    case _ => throw new CDEMatchError
-  })
+class WithTraceGen extends Config((site, here, up) => {
+  case GroundTestKey => Seq.fill(site(NTiles)) {
+    GroundTestTileSettings(uncached = 1, cached = 1)
+  }
+  case BuildGroundTest =>
+    (p: Parameters) => Module(new GroundTestTraceGenerator()(p))
+  case GeneratorKey => TrafficGeneratorParameters(
+    maxRequests = 8192,
+    startAddress = 0)
+  case AddressBag => {
+    val nSets = 2
+    val nWays = 1
+    val blockOffset = site(CacheBlockOffsetBits)
+    val nBeats = site(TLKey("L1toL2")).dataBeats
+    List.tabulate(4 * nWays) { i =>
+      Seq.tabulate(nBeats) { j => BigInt((j * 8) + ((i * nSets) << blockOffset)) }
+    }.flatten
+  }
+  case UseAtomics => true
+  case CacheName("L1D") => up(CacheName("L1D"), site).copy(nSets = 16, nWays = 1)
+})

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -52,8 +52,6 @@ class DefaultFPGAConfig extends Config(new FPGAConfig ++ new BaseConfig)
 class DefaultL2FPGAConfig extends Config(
   new WithL2Capacity(64) ++ new WithL2Cache ++ new DefaultFPGAConfig)
 
-class PLRUL2Config extends Config(new WithPLRU ++ new DefaultL2Config)
-
 class WithNMemoryChannels(n: Int) extends Config((site, here, up) => {
   case BankedL2Config => up(BankedL2Config, site).copy(nMemoryChannels = n)
 })

--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -19,25 +19,23 @@ import scala.collection.immutable.HashMap
 import DefaultTestSuites._
 import config._
 
-class BasePlatformConfig extends Config(
-  (pname,site,here) => pname match {
-    // TileLink connection parameters
-    case TLMonitorBuilder => (args: TLMonitorArgs) => Some(LazyModule(new TLMonitor(args)))
-    case TLFuzzReadyValid => false
-    case TLCombinationalCheck => false
-    //Memory Parameters
-    case NExtTopInterrupts => 2
-    case SOCBusConfig => site(L1toL2Config)
-    case PeripheryBusConfig => TLBusConfig(beatBytes = 4)
-    case PeripheryBusArithmetic => true
-    // Note that PLIC asserts that this is > 0.
-    case IncludeJtagDTM => false
-    case ExtMem => MasterConfig(base=0x80000000L, size=0x10000000L, beatBytes=8, idBits=4)
-    case ExtBus => MasterConfig(base=0x60000000L, size=0x20000000L, beatBytes=8, idBits=4)
-    case ExtIn  => SlaveConfig(beatBytes=8, idBits=8, sourceBits=2)
-    case RTCPeriod => 100 // gives 10 MHz RTC assuming 1 GHz uncore clock
-    case _ => throw new CDEMatchError
-  })
+class BasePlatformConfig extends Config((site, here, up) => {
+  // TileLink connection parameters
+  case TLMonitorBuilder => (args: TLMonitorArgs) => Some(LazyModule(new TLMonitor(args)))
+  case TLFuzzReadyValid => false
+  case TLCombinationalCheck => false
+  //Memory Parameters
+  case NExtTopInterrupts => 2
+  case SOCBusConfig => site(L1toL2Config)
+  case PeripheryBusConfig => TLBusConfig(beatBytes = 4)
+  case PeripheryBusArithmetic => true
+  // Note that PLIC asserts that this is > 0.
+  case IncludeJtagDTM => false
+  case ExtMem => MasterConfig(base=0x80000000L, size=0x10000000L, beatBytes=8, idBits=4)
+  case ExtBus => MasterConfig(base=0x60000000L, size=0x20000000L, beatBytes=8, idBits=4)
+  case ExtIn  => SlaveConfig(beatBytes=8, idBits=8, sourceBits=2)
+  case RTCPeriod => 100 // gives 10 MHz RTC assuming 1 GHz uncore clock
+})
 
 class BaseConfig extends Config(new BaseCoreplexConfig ++ new BasePlatformConfig)
 class DefaultConfig extends Config(new WithBlockingL1 ++ new BaseConfig)
@@ -46,12 +44,9 @@ class DefaultL2Config extends Config(new WithL2Cache ++ new BaseConfig)
 class DefaultBufferlessConfig extends Config(
   new WithBufferlessBroadcastHub ++ new BaseConfig)
 
-class FPGAConfig extends Config (
-  (pname,site,here) => pname match {
-    case NAcquireTransactors => 4
-    case _ => throw new CDEMatchError
-  }
-)
+class FPGAConfig extends Config ((site, here, up) => {
+  case NAcquireTransactors => 4
+})
 
 class DefaultFPGAConfig extends Config(new FPGAConfig ++ new BaseConfig)
 class DefaultL2FPGAConfig extends Config(
@@ -59,19 +54,13 @@ class DefaultL2FPGAConfig extends Config(
 
 class PLRUL2Config extends Config(new WithPLRU ++ new DefaultL2Config)
 
-class WithNMemoryChannels(n: Int) extends Config(
-  (pname,site,here,up) => pname match {
-    case BankedL2Config => up(BankedL2Config, site).copy(nMemoryChannels = n)
-    case _ => throw new CDEMatchError
-  }
-)
+class WithNMemoryChannels(n: Int) extends Config((site, here, up) => {
+  case BankedL2Config => up(BankedL2Config, site).copy(nMemoryChannels = n)
+})
 
-class WithExtMemSize(n: Long) extends Config(
-  (pname,site,here,up) => pname match {
-    case ExtMem => up(ExtMem, site).copy(size = n)
-    case _ => throw new CDEMatchError
-  }
-)
+class WithExtMemSize(n: Long) extends Config((site, here, up) => {
+  case ExtMem => up(ExtMem, site).copy(size = n)
+})
 
 class WithScratchpads extends Config(new WithNMemoryChannels(0) ++ new WithDataScratchpad(16384))
 
@@ -97,11 +86,9 @@ class DualChannelDualBankL2Config extends Config(
 
 class RoccExampleConfig extends Config(new WithRoccExample ++ new BaseConfig)
 
-class WithEdgeDataBits(dataBits: Int) extends Config(
-  (pname, site, here, up) => pname match {
-    case ExtMem => up(ExtMem, site).copy(beatBytes = dataBits/8)
-    case _ => throw new CDEMatchError
-  })
+class WithEdgeDataBits(dataBits: Int) extends Config((site, here, up) => {
+  case ExtMem => up(ExtMem, site).copy(beatBytes = dataBits/8)
+})
 
 class Edge128BitConfig extends Config(
   new WithEdgeDataBits(128) ++ new BaseConfig)
@@ -127,48 +114,30 @@ class TinyConfig extends Config(
   new WithSmallCores ++ new WithRV32 ++
   new WithStatelessBridge ++ new BaseConfig)
 
-class WithJtagDTM extends Config (
-  (pname, site, here) => pname match {
-    case IncludeJtagDTM => true
-    case _ => throw new CDEMatchError
-  }
-)
+class WithJtagDTM extends Config ((site, here, up) => {
+  case IncludeJtagDTM => true
+})
 
-class WithNoPeripheryArithAMO extends Config (
-  (pname, site, here) => pname match {
-    case PeripheryBusArithmetic => false
-  }
-)
+class WithNoPeripheryArithAMO extends Config ((site, here, up) => {
+  case PeripheryBusArithmetic => false
+})
 
-class With64BitPeriphery extends Config (
-  (pname, site, here) => pname match {
-    case PeripheryBusConfig => TLBusConfig(beatBytes = 8)
-  }
-)
+class With64BitPeriphery extends Config ((site, here, up) => {
+  case PeripheryBusConfig => TLBusConfig(beatBytes = 8)
+})
 
-class WithoutTLMonitors extends Config (
-  (pname, site, here) => pname match {
-    case TLMonitorBuilder => (args: TLMonitorArgs) => None
-    case _ => throw new CDEMatchError
-  }
-)
+class WithoutTLMonitors extends Config ((site, here, up) => {
+  case TLMonitorBuilder => (args: TLMonitorArgs) => None
+})
 
-class WithNExtTopInterrupts(nExtInts: Int) extends Config(
-  (pname, site, here) => pname match {
-    case NExtTopInterrupts => nExtInts
-    case _ => throw new CDEMatchError
-  }
-)
+class WithNExtTopInterrupts(nExtInts: Int) extends Config((site, here, up) => {
+  case NExtTopInterrupts => nExtInts
+})
 
-class WithNBreakpoints(hwbp: Int) extends Config (
-  (pname,site,here) => pname match {
-    case NBreakpoints => hwbp
-    case _ => throw new CDEMatchError
-  }
-)
+class WithNBreakpoints(hwbp: Int) extends Config ((site, here, up) => {
+  case NBreakpoints => hwbp
+})
 
-class WithRTCPeriod(nCycles: Int) extends Config(
-  (pname, site, here) => pname match {
-    case RTCPeriod => nCycles
-    case _ => throw new CDEMatchError
-  })
+class WithRTCPeriod(nCycles: Int) extends Config((site, here, up) => {
+  case RTCPeriod => nCycles
+})

--- a/src/main/scala/unittest/Configs.scala
+++ b/src/main/scala/unittest/Configs.scala
@@ -7,79 +7,71 @@ import config._
 import junctions._
 import rocketchip.{BaseConfig, BasePlatformConfig}
 
-class WithJunctionsUnitTests extends Config(
-  (pname, site, here) => pname match {
-    case HastiId => "HastiTest"
-    case HastiKey("HastiTest") => HastiParameters(addrBits = 32, dataBits = 64)
-    case NastiKey => NastiParameters(addrBits = 32, dataBits = 64, idBits = 4)
-    case junctions.PAddrBits => 32
-    case rocket.XLen => 64
-    case UnitTests => (p: Parameters) => Seq(
-      Module(new junctions.MultiWidthFifoTest),
-      Module(new junctions.HastiTest()(p)))
-    case _ => throw new CDEMatchError
-  })
+class WithJunctionsUnitTests extends Config((site, here, up) => {
+  case HastiId => "HastiTest"
+  case HastiKey("HastiTest") => HastiParameters(addrBits = 32, dataBits = 64)
+  case NastiKey => NastiParameters(addrBits = 32, dataBits = 64, idBits = 4)
+  case junctions.PAddrBits => 32
+  case rocket.XLen => 64
+  case UnitTests => (p: Parameters) => Seq(
+    Module(new junctions.MultiWidthFifoTest),
+    Module(new junctions.HastiTest()(p)))
+})
 
 class JunctionsUnitTestConfig extends Config(new WithJunctionsUnitTests ++ new BasePlatformConfig)
 
-class WithUncoreUnitTests extends Config(
-  (pname, site, here) => pname match {
-    case uncore.tilelink.TLId => "L1toL2"
-    case UnitTests => (q: Parameters) => {
-      implicit val p = q
-      Seq(
-        Module(new uncore.devices.ROMSlaveTest()),
-        Module(new uncore.devices.TileLinkRAMTest()),
-        Module(new uncore.converters.TileLinkWidthAdapterTest()),
-        Module(new uncore.tilelink2.TLFuzzRAMTest),
-        Module(new uncore.ahb.AHBBridgeTest),
-        Module(new uncore.apb.APBBridgeTest),
-        Module(new uncore.axi4.AXI4LiteFuzzRAMTest),
-        Module(new uncore.axi4.AXI4FullFuzzRAMTest),
-        Module(new uncore.axi4.AXI4BridgeTest)) }
-    case _ => throw new CDEMatchError
-  }
-)
+class WithUncoreUnitTests extends Config((site, here, up) => {
+  case uncore.tilelink.TLId => "L1toL2"
+  case UnitTests => (q: Parameters) => {
+    implicit val p = q
+    Seq(
+      Module(new uncore.devices.ROMSlaveTest()),
+      Module(new uncore.devices.TileLinkRAMTest()),
+      Module(new uncore.converters.TileLinkWidthAdapterTest()),
+      Module(new uncore.tilelink2.TLFuzzRAMTest),
+      Module(new uncore.ahb.AHBBridgeTest),
+      Module(new uncore.apb.APBBridgeTest),
+      Module(new uncore.axi4.AXI4LiteFuzzRAMTest),
+      Module(new uncore.axi4.AXI4FullFuzzRAMTest),
+      Module(new uncore.axi4.AXI4BridgeTest)) }
+})
 
 class UncoreUnitTestConfig extends Config(new WithUncoreUnitTests ++ new BaseConfig)
 
-class WithTLSimpleUnitTests extends Config(
-  (pname, site, here) => pname match {
-    case UnitTests => (q: Parameters) => {
-      implicit val p = q
-      Seq(
-        Module(new uncore.tilelink2.TLRAMSimpleTest(1)),
-        Module(new uncore.tilelink2.TLRAMSimpleTest(4)),
-        Module(new uncore.tilelink2.TLRAMSimpleTest(16)),
-        Module(new uncore.tilelink2.TLRR0Test),
-        Module(new uncore.tilelink2.TLRR1Test),
-        Module(new uncore.tilelink2.TLRAMCrossingTest) ) }
-    case _ => throw new CDEMatchError })
+class WithTLSimpleUnitTests extends Config((site, here, up) => {
+  case UnitTests => (q: Parameters) => {
+    implicit val p = q
+    Seq(
+      Module(new uncore.tilelink2.TLRAMSimpleTest(1)),
+      Module(new uncore.tilelink2.TLRAMSimpleTest(4)),
+      Module(new uncore.tilelink2.TLRAMSimpleTest(16)),
+      Module(new uncore.tilelink2.TLRR0Test),
+      Module(new uncore.tilelink2.TLRR1Test),
+      Module(new uncore.tilelink2.TLRAMCrossingTest) ) }
+})
 
-class WithTLWidthUnitTests extends Config(
-  (pname, site, here) => pname match {
-    case UnitTests => (q: Parameters) => {
-      implicit val p = q
-      Seq(
-        Module(new uncore.tilelink2.TLRAMFragmenterTest( 4, 256)),
-        Module(new uncore.tilelink2.TLRAMFragmenterTest(16,  64)),
-        Module(new uncore.tilelink2.TLRAMFragmenterTest( 4,  16)),
-        Module(new uncore.tilelink2.TLRAMWidthWidgetTest( 1,  1)),
-        Module(new uncore.tilelink2.TLRAMWidthWidgetTest( 4, 64)),
-        Module(new uncore.tilelink2.TLRAMWidthWidgetTest(64,  4)) ) }
-    case _ => throw new CDEMatchError })
+class WithTLWidthUnitTests extends Config((site, here, up) => {
+  case UnitTests => (q: Parameters) => {
+    implicit val p = q
+    Seq(
+      Module(new uncore.tilelink2.TLRAMFragmenterTest( 4, 256)),
+      Module(new uncore.tilelink2.TLRAMFragmenterTest(16,  64)),
+      Module(new uncore.tilelink2.TLRAMFragmenterTest( 4,  16)),
+      Module(new uncore.tilelink2.TLRAMWidthWidgetTest( 1,  1)),
+      Module(new uncore.tilelink2.TLRAMWidthWidgetTest( 4, 64)),
+      Module(new uncore.tilelink2.TLRAMWidthWidgetTest(64,  4)) ) }
+})
 
-class WithTLXbarUnitTests extends Config(
-  (pname, site, here) => pname match {
-    case UnitTests => (q: Parameters) => {
-      implicit val p = q
-      Seq(
-        Module(new uncore.tilelink2.TLRAMXbarTest(1)),
-        Module(new uncore.tilelink2.TLRAMXbarTest(2)),
-        Module(new uncore.tilelink2.TLRAMXbarTest(8)),
-        //Module(new uncore.tilelink2.TLMulticlientXbarTest(4,4)),
-        Module(new uncore.tilelink2.TLMulticlientXbarTest(1,4)) ) }
-    case _ => throw new CDEMatchError })
+class WithTLXbarUnitTests extends Config((site, here, up) => {
+  case UnitTests => (q: Parameters) => {
+    implicit val p = q
+    Seq(
+      Module(new uncore.tilelink2.TLRAMXbarTest(1)),
+      Module(new uncore.tilelink2.TLRAMXbarTest(2)),
+      Module(new uncore.tilelink2.TLRAMXbarTest(8)),
+      //Module(new uncore.tilelink2.TLMulticlientXbarTest(4,4)),
+      Module(new uncore.tilelink2.TLMulticlientXbarTest(1,4)) ) }
+})
 
 class TLSimpleUnitTestConfig extends Config(new WithTLSimpleUnitTests ++ new BasePlatformConfig)
 class TLWidthUnitTestConfig extends Config(new WithTLWidthUnitTests ++ new BasePlatformConfig)


### PR DESCRIPTION
The old style of specifying Configs used total functions.  The only way to
indicate that a key was not matched was to throw an exception.  Not only was
this a performance concern, but it also caused confusing error messages
whenever you had a match failure from a lookup within a lookup.  The
exception could get handled by an outer-lookup that then reported the wrong
key as missing.