### PR TITLE
jtag_dtm: Update regression to run and pass.

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -218,9 +218,10 @@ stamps/%/emulator-torture-$(TORTURE_CONFIG).stamp: stamps/%/emulator-debug.stamp
 
 # Targets for JTAG DTM full-chain simulation
 
-OPENOCD_HEAD ?= riscv
+#OPENOCD_HEAD ?= riscv
 OPENOCD_INSTALL ?= $(abspath $(TOP))/openocd-install
-OPENOCD_VERSION = $(shell git ls-remote http://github.com/sifive/openocd.git $(OPENOCD_HEAD) | awk '{print $$1}')
+#OPENOCD_VERSION = $(shell git ls-remote http://github.com/sifive/openocd.git $(OPENOCD_HEAD) | awk '{print $$1}')
+OPENOCD_VERSION = 193f63094891cd3fe6a5032fef2c71d09f063ff4
 OPENOCD_DIR = $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/
 
 $(OPENOCD_DIR)/bin/openocd:
@@ -237,7 +238,7 @@ install_openocd: $(OPENOCD_DIR)/bin/openocd
 
 # If this is defined empty, then all tests would run.
 # Running a list of tests is not supported.
-JTAG_DTM_TEST ?= SimpleRegisterTest.test_s0
+JTAG_DTM_TEST ?= SimpleS0Test
 
 stamps/%/jtag-dtm-32-$(JTAG_DTM_TEST).stamp: install_openocd stamps/%/vsim-ndebug.stamp
 	$(abspath $(TOP))/riscv-tools/riscv-tests/debug/gdbserver.py \

--- a/src/main/scala/rocketchip/ExampleTop.scala
+++ b/src/main/scala/rocketchip/ExampleTop.scala
@@ -30,7 +30,7 @@ class ExampleTopModule[+L <: ExampleTop, +B <: ExampleTopBundle[L]](_outer: L, _
 
 class ExampleRocketTop(implicit p: Parameters) extends ExampleTop
     with PeripheryBootROM
-    with PeripheryDTM
+    with PeripheryDebug
     with PeripheryCounter
     with HardwiredResetVector
     with RocketPlexMaster {
@@ -39,14 +39,14 @@ class ExampleRocketTop(implicit p: Parameters) extends ExampleTop
 
 class ExampleRocketTopBundle[+L <: ExampleRocketTop](_outer: L) extends ExampleTopBundle(_outer)
     with PeripheryBootROMBundle
-    with PeripheryDTMBundle
+    with PeripheryDebugBundle
     with PeripheryCounterBundle
     with HardwiredResetVectorBundle
     with RocketPlexMasterBundle
 
 class ExampleRocketTopModule[+L <: ExampleRocketTop, +B <: ExampleRocketTopBundle[L]](_outer: L, _io: () => B) extends ExampleTopModule(_outer, _io)
     with PeripheryBootROMModule
-    with PeripheryDTMModule
+    with PeripheryDebugModule
     with PeripheryCounterModule
     with HardwiredResetVectorModule
     with RocketPlexMasterModule

--- a/src/main/scala/rocketchip/TestHarness.scala
+++ b/src/main/scala/rocketchip/TestHarness.scala
@@ -26,7 +26,11 @@ class TestHarness()(implicit p: Parameters) extends Module {
     }
   }
 
-  val dtm = Module(new SimDTM).connect(clock, reset, dut.io.debug, io.success)
+  if (!p(IncludeJtagDTM)) {
+    val dtm = Module(new SimDTM).connect(clock, reset, dut.io.debug.get, io.success)
+  } else {
+     val jtag = Module(new JTAGVPI).connect(dut.io.jtag.get, reset, io.success)		
+  }
 
   val mmio_sim = Module(LazyModule(new SimAXIMem(4096)).module)
   mmio_sim.io.axi4 <> dut.io.mmio_axi4


### PR DESCRIPTION
This reverts some changes to make ExampleRocketChipTop and its TestHarness actually absorb the WithJtagDTM configuration parameter. This allows us to (again) test the JTAG DTM.

Is it possible to add the test in regression to the suite? As of now I manually run it when I'm updating the JTAG DTM, but I think it would be good to automate this so it doesn't keep getting broken. Is there a limit on resources or time that we're in danger of hitting if I add this?


