### PR TITLE
Match chisel3 userootunmanageddir - use RootProject/lib as unmanagedBase.

### DIFF
--- a/Makefrag
+++ b/Makefrag
@@ -23,6 +23,9 @@ FIRRTL ?= java -Xmx2G -Xss8M -XX:MaxPermSize=256M -cp $(FIRRTL_JAR) firrtl.Drive
 $(FIRRTL_JAR): $(shell find $(base_dir)/firrtl/src/main/scala -iname "*.scala")
 	$(MAKE) -C $(base_dir)/firrtl SBT="$(SBT)" root_dir=$(base_dir)/firrtl build-scala
 	touch $(FIRRTL_JAR)
+	mkdir -p $(base_dir)/lib
+	cp -p $(FIRRTL_JAR) $(base_dir)/lib
+# When chisel3 pr 448 is merged, the following extraneous copy may be removed.
 	mkdir -p $(base_dir)/chisel3/lib
 	cp -p $(FIRRTL_JAR) $(base_dir)/chisel3/lib
 


### PR DESCRIPTION
This anticipates ucb-bar/chisel3#448. When rocket-chip uses that version of chisel3, the extra copy to chisel3/lib may be removed.