### PR TITLE
Ignore the built firrtl.jar.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ project/target
 *.swp
 *~
 .addons-dont-touch
+/lib/


### PR DESCRIPTION
In #526, we now build firrtl.jar to rocket-chip's `lib/` directory. This adds a gitignore rule for the entire `lib/` directory.