### PR TITLE
BankedL2Config: use the same LazyModule for all L2 banks

### DIFF
--- a/src/main/scala/coreplex/Configs.scala
+++ b/src/main/scala/coreplex/Configs.scala
@@ -144,10 +144,12 @@ class WithBufferlessBroadcastHub extends Config((site, here, up) => {
  * DO NOT use this configuration.
  */
 class WithStatelessBridge extends Config((site, here, up) => {
-  case BankedL2Config => up(BankedL2Config, site).copy(coherenceManager = { case (q, _, _) =>
+  case BankedL2Config => up(BankedL2Config, site).copy(coherenceManager = { case (q, _) =>
     implicit val p = q
     val cork = LazyModule(new TLCacheCork(unsafe = true))
-    (cork.node, TLWidthWidget(p(L1toL2Config).beatBytes)(cork.node))
+    val ww = LazyModule(new TLWidthWidget(p(L1toL2Config).beatBytes))
+    ww.node :*= cork.node
+    (cork.node, ww.node)
   })
   case DCacheKey => up(DCacheKey, site).copy(nMSHRs = 0)
 })

--- a/src/main/scala/coreplex/CoreplexNetwork.scala
+++ b/src/main/scala/coreplex/CoreplexNetwork.scala
@@ -77,13 +77,13 @@ trait BankedL2CoherenceManagers extends CoreplexNetwork {
   val mem = TLOutputNode()
   for (channel <- 0 until l2Config.nMemoryChannels) {
     val bankBar = LazyModule(new TLXbar)
+    val (in, out) = l2Config.coherenceManager(p, this)
 
+    in :*= l1tol2.node
     mem := bankBar.node
+
     val mask = ~BigInt((l2Config.nBanksPerChannel-1) * l1tol2_lineBytes)
     for (bank <- 0 until l2Config.nBanksPerChannel) {
-      val geometry = BankedL2Geometry(bank, l2Config.nBanksPerChannel, channel, l2Config.nMemoryChannels)
-      val (in, out) = l2Config.coherenceManager(p, this, geometry)
-      in := l1tol2.node
       bankBar.node := TLFilter(AddressSet(bank * l1tol2_lineBytes, mask))(out)
     }
   }

--- a/src/main/scala/diplomacy/LazyModule.scala
+++ b/src/main/scala/diplomacy/LazyModule.scala
@@ -27,10 +27,15 @@ abstract class LazyModule()(implicit val p: Parameters)
       m.getName != "children"
     }.flatMap { m =>
       if (classOf[LazyModule].isAssignableFrom(m.getReturnType)) {
-        Seq((m.getName, m.invoke(this)))
+        val obj = m.invoke(this)
+        if (obj eq null) Seq() else Seq((m.getName, obj))
       } else if (classOf[Seq[LazyModule]].isAssignableFrom(m.getReturnType)) {
-        m.invoke(this).asInstanceOf[Seq[Object]].zipWithIndex.map { case (l, i) =>
-          (m.getName + "_"  + i, l)
+        val obj = m.invoke(this)
+        if (obj eq null) Seq() else {
+          val seq = try { obj.asInstanceOf[Seq[Object]] } catch { case _ => null }
+          if (seq eq null) Seq() else {
+            seq.zipWithIndex.map { case (l, i) => (m.getName + "_"  + i, l) }
+          }
         }
       } else Seq()
     }


### PR DESCRIPTION
This makes it much easier for banked coherence managers to support
cross-bank functionality, like a common control port, for example.