### PR TITLE
[WIP] Blackboxed TLRegisterRouter

### DIFF
--- a/src/main/scala/regmapper/RegField.scala
+++ b/src/main/scala/regmapper/RegField.scala
@@ -98,7 +98,7 @@ object RegField
 
   // This RegField wraps an explicit register
   // (e.g. Black-Boxed Register) to create a R/W register.
-  def rwReg(n: Int, bb: SimpleRegIO) : RegField =
+  def rwReg(n: Int, bb: SimpleRegIO): RegField =
     RegField(n, bb.q, RegWriteFn((valid, data) => {
       bb.en := valid
       bb.d := data

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -322,3 +322,14 @@ trait PeripheryTestBusMasterModule {
     val io: PeripheryTestBusMasterBundle
   } =>
 }
+
+////////
+
+trait CouldHavePeripheryTLBlackBoxRegisterRouter {
+  this: TopNetwork =>
+
+  p(BlackBoxedRegMapKey) foreach { params => 
+    val tlbbrm = LazyModule(new TLBlackBoxRegisterRouter(params))
+    tlbbrm.node := TLFragmenter(peripheryBusConfig.beatBytes, cacheBlockBytes)(peripheryBus.node)
+  }
+}

--- a/src/main/scala/uncore/devices/BlackBoxRegisterRouter.scala
+++ b/src/main/scala/uncore/devices/BlackBoxRegisterRouter.scala
@@ -1,0 +1,27 @@
+// See LICENSE.SiFive for license details.
+
+package uncore.devices
+
+import Chisel._
+
+import config._
+import diplomacy._
+import regmapper._
+import rocketchip.{PeripheryBusConfig}
+import uncore.tilelink2._
+import util.BlackBoxedRegsWrapper
+
+case class  BlackBoxedRegMapParams(address: BigInt, numRegs: Int, widthBytes: Int)
+case object BlackBoxedRegMapKey extends Field[Seq[BlackBoxedRegMapParams]]
+
+trait HasBlackBoxedRegMap extends Module with HasRegMap {
+  val params: BlackBoxedRegMapParams
+  val w = params.widthBytes*8
+  val regs = Module(new BlackBoxedRegsWrapper(params.numRegs, w))
+  regmap((regs.io.v.zipWithIndex.map { case(r, i) => i*params.widthBytes -> Seq(RegField.rwReg(w,r)) }):_*)
+}
+
+class TLBlackBoxRegisterRouter(val bbrmp: BlackBoxedRegMapParams)(implicit p: Parameters)
+  extends TLRegisterRouter(bbrmp.address, beatBytes = bbrmp.widthBytes)(
+  new TLRegBundle(bbrmp, _))(
+  new TLRegModule(bbrmp, _, _) with HasBlackBoxedRegMap)

--- a/src/main/scala/uncore/tilelink2/Example.scala
+++ b/src/main/scala/uncore/tilelink2/Example.scala
@@ -4,7 +4,13 @@ package uncore.tilelink2
 
 import Chisel._
 import config._
+import diplomacy._
 import regmapper._
+
+/** This is an example of how to create and test a simple
+  * TL slave device that uses the regmapper library to
+  * manage access to its registers.
+  */
 
 case class ExampleParams(num: Int, address: BigInt)
 
@@ -37,3 +43,84 @@ trait ExampleModule extends HasRegMap
 class TLExample(params: ExampleParams)(implicit p: Parameters) extends TLRegisterRouter(params.address, 4)(
   new TLRegBundle(params, _)    with ExampleBundle)(
   new TLRegModule(params, _, _) with ExampleModule)
+
+////////
+
+/** This is an example of how to create a blackboxed slave device
+  * that implements TL2-UL.
+  */
+
+/** This wrapper negotiates parameters diplomatically with the external TileLink network */
+class TLExampleBlackBoxedSlave(base: BigInt, size: Int, executable: Boolean = true, beatBytes: Int = 4)(implicit p: Parameters) extends LazyModule {
+  val node = TLManagerNode(TLManagerPortParameters(
+    Seq(TLManagerParameters(
+      address            = List(AddressSet(base, size-1)),
+      regionType         = RegionType.UNCACHED,
+      executable         = executable,
+      supportsGet        = TransferSizes(1, beatBytes),
+      supportsPutPartial = TransferSizes(1, beatBytes),
+      supportsPutFull    = TransferSizes(1, beatBytes))),
+    beatBytes = beatBytes))
+
+  // We require the address range to include an entire beat (for the write mask)
+  require (size > beatBytes)
+
+  // The concrete module implementation simply instantiates the black box
+  lazy val module = new LazyModuleImp(this) {
+    val io = new Bundle {
+      val in = node.bundleIn
+    }
+    val in = io.in(0)
+    val edge = node.edgesIn(0)
+
+    // Create and wire the blackbox
+    val bb = new TLULSlaveExample(size, edge)
+    in.a <> bb.io.slave_a
+    in.d <> bb.io.slave_d
+
+    // Tie off unused channels
+    in.b.valid := Bool(false)
+    in.c.ready := Bool(true)
+    in.e.ready := Bool(true)
+  }
+}
+
+/** The actual paramterized blackbox; there must exist a verilog module
+  * with an exactly matching name. */
+import chisel3.core.IntParam
+class TLULSlaveExample(size: Int, edge: TLEdgeIn) extends BlackBox(Map(
+  "SIZEBYTES"   -> IntParam(size),
+  "SIZEBITS"    -> IntParam(edge.bundle.sizeBits),
+  "SOURCEBITS"  -> IntParam(edge.bundle.sourceBits),
+  "ADDRESSBITS" -> IntParam(edge.bundle.addressBits),
+  "MASKBITS"    -> IntParam(edge.bundle.dataBits/8),
+  "DATABITS"    -> IntParam(edge.bundle.dataBits),
+  "SINKBITS"    -> IntParam(edge.bundle.sinkBits),
+  "ADDRLOBITS"  -> IntParam(edge.bundle.addrLoBits)
+)) {
+  val io = new Bundle {
+    val slave_a = Decoupled(new TLBundleA(edge.bundle))
+    val slave_d = Decoupled(new TLBundleD(edge.bundle))
+  }
+}
+
+
+/** Synthesizeable unit test */
+import unittest._
+
+class TLExampleBlackBoxedSlaveFuzz(implicit p: Parameters) extends LazyModule {
+  val fuzz = LazyModule(new TLFuzzer(5000))
+  val model = LazyModule(new TLRAMModel)
+  val ram  = LazyModule(new TLExampleBlackBoxedSlave(0, 64, beatBytes = 4))
+
+  model.node := fuzz.node
+  ram.node := model.node
+
+  lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
+    io.finished := fuzz.module.io.finished
+  }
+}
+
+class TLExampleBlackBoxedSlaveFuzzTest(ramBeatBytes: Int)(implicit p: Parameters) extends UnitTest(timeout = 500000) {
+  io.finished := Module(LazyModule(new TLExampleBlackBoxedSlaveFuzz).module).io.finished
+}

--- a/vsrc/BlackBoxedRegs.v
+++ b/vsrc/BlackBoxedRegs.v
@@ -1,0 +1,36 @@
+// See LICENSE.SiFive for license details.
+
+/** This black-boxes a configurable number
+  * of configurable width registers
+  *  
+  *  @param i Index Input
+  *  @param d Data Input
+  *  @param q Vector Data Output
+  *  @param en Write Enable Input
+  *  @param clk Clock Input
+  *  
+  */
+
+module BlackBoxedRegs #(
+  parameter int NREGS=1,
+  parameter int WIDTH=1,
+  parameter int IDXWIDTH = 1
+) (
+                      input  [IDXWIDTH-1:0] i,
+                      input  [WIDTH-1:0] d,
+                      output [WIDTH-1:0] q,
+                      input  en,
+                      input  clk);
+
+    reg [WIDTH-1:0] regs [0:NREGS-1];
+
+    always @(posedge clk) begin
+        if (en) begin
+            regs[i] <= d;
+        end
+    end
+
+    assign q = regs[i];
+   
+endmodule // BlackBoxedRegs
+

--- a/vsrc/TLULSlaveExample.v
+++ b/vsrc/TLULSlaveExample.v
@@ -1,0 +1,53 @@
+// See LICENSE.SiFive for license details.
+
+/** This is a parameterized template for
+  * a TL-UL compliant slave device
+  *  
+  *  @param io_slave_a_* Decoupled request interface
+  *  @param io_slave_d_* Decoupled response interface
+  *  
+  */
+
+module TLULSlaveExample #(
+  parameter int NREGS  2,
+  parameter int SIZEBITS = 4,
+  parameter int SOURCEBITS = 3, 
+  parameter int ADDRESSBITS = 12,
+  parameter int MASKBITS = 4,
+  parameter int DATABITS = 32,
+  parameter int SINKBITS = 1,
+  parameter int ADDRLOBITS = 4
+) (
+    input   clock,
+    input   reset,
+    input   io_slave_a_ready,
+    input   io_slave_a_valid,
+    input   [2:0] io_slave_a_bits_opcode,
+    input   [2:0] io_slave_a_bits_param,
+    input   [SIZEBITS-1:0] io_slave_a_bits_size,
+    input   [SOURCEBITS-1:0] io_slave_a_bits_source,
+    input   [ADDRESSBITS-1:0] io_slave_a_bits_address,
+    input   [MASKBITS-1:0] io_slave_a_bits_mask,
+    input   [DATABITS-1:0] io_slave_a_bits_data,
+    input   io_slave_d_ready,
+    output  io_slave_d_valid,
+    output  [2:0] io_slave_d_bits_opcode,
+    output  [1:0] io_slave_d_bits_param,
+    output  [SIZEBITS-1:0] io_slave_d_bits_size,
+    output  [SOURCEBITS-1:0] io_slave_d_bits_source,
+    output  [SINKBITS-1:0] io_slave_d_bits_sink,
+    output  [ADDRLOBITS-1:0] io_slave_d_bits_addr_lo,
+    output  [DATABITS-1:0] io_slave_d_bits_data,
+    output   io_slave_d_bits_error
+  );
+
+    reg [DATABITS-1:0] regs [0:NREGS-1];
+  
+    always @(posedge clk) begin
+        if (io_slave_a_valid && io_slave_a_opcode == 3'd4) begin
+            regs[io_slave_a_bits_address[0]] <= d;
+        end
+    end
+
+
+endmodule // TLULSlaveTemplate


### PR DESCRIPTION
Uses parameterized Blackbox to create an arbitrarily-sized register file in verilog, while also connecting it to the periphery bus using a TLRegisterRouter. Inserting arbitrary verilog devices into BlackBoxedRegs.v is left to the user for now; module BlackBoxedRegs merely defines the io semantics expected by the register router.