### PR TITLE
Fix up Absolute value.

### DIFF
--- a/src/main/scala/util/Misc.scala
+++ b/src/main/scala/util/Misc.scala
@@ -89,7 +89,7 @@ object Str
   def apply(x: SInt): UInt = apply(x, 10)
   def apply(x: SInt, radix: Int): UInt = {
     val neg = x < SInt(0)
-    val abs = x.abs
+    val abs = x.abs.asUInt
     if (radix != 10) {
       Cat(Mux(neg, Str('-'), Str(' ')), Str(abs, radix))
     } else {


### PR DESCRIPTION
As of ucb-bar/chisel3#491, `abs` now returns the same type as its argument. Add a cast to UInt.

**NOTE**: This is compatible with the version of [chisel3](https://github.com/ucb-bar/chisel3/tree/3ef63639284b2b56f415e1540c58d85d88c360db) currently used by rocket-chip