### PR TITLE
Rational config

### DIFF
--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -47,6 +47,11 @@ $(output_dir)/%.vpd: $(output_dir)/% $(emu_debug)
 	vcd2vpd $@.vcd $@ > /dev/null &
 	./$(emu_debug) +max-cycles=$(timeout_cycles) +verbose -v$@.vcd $< $(disasm) $(patsubst %.vpd,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
 
+$(output_dir)/%.fst: $(output_dir)/% $(emu_debug)
+	rm -rf $@.vcd && mkfifo $@.vcd
+	vcd2fst -Z $@.vcd $@ &
+	./$(emu_debug) +max-cycles=$(timeout_cycles) +verbose -v$@.vcd $< $(disasm) $(patsubst %.fst,%.out,$@) && [ $$PIPESTATUS -eq 0 ]
+
 run: run-asm-tests run-bmark-tests
 run-debug: run-asm-tests-debug run-bmark-tests-debug
 run-fast: run-asm-tests-fast run-bmark-tests-fast

--- a/src/main/scala/coreplex/RocketTiles.scala
+++ b/src/main/scala/coreplex/RocketTiles.scala
@@ -73,7 +73,7 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
       }
       case Rational => {
         val wrapper = LazyModule(new RationalRocketTile(c)(pWithExtra))
-        val sink = LazyModule(new TLRationalCrossingSink)
+        val sink = LazyModule(new TLRationalCrossingSink(util.FastToSlow))
         val source = LazyModule(new TLRationalCrossingSource)
         sink.node :=* wrapper.masterNode
         l1tol2.node :=* sink.node

--- a/src/main/scala/rocket/Tile.scala
+++ b/src/main/scala/rocket/Tile.scala
@@ -103,7 +103,7 @@ class RationalRocketTile(rtp: RocketTileParams)(implicit p: Parameters) extends 
   masterNode :=* source.node
 
   val slaveNode = TLRationalInputNode()
-  val sink = LazyModule(new TLRationalCrossingSink)
+  val sink = LazyModule(new TLRationalCrossingSink(util.SlowToFast))
   rocket.slaveNode :*= sink.node
   sink.node :*= slaveNode
 

--- a/src/main/scala/rocketchip/RocketTestSuite.scala
+++ b/src/main/scala/rocketchip/RocketTestSuite.scala
@@ -26,6 +26,9 @@ run-$makeTargetName: $$(addprefix $$(output_dir)/, $$(addsuffix .out, $$($makeTa
 
 run-$makeTargetName-debug: $$(addprefix $$(output_dir)/, $$(addsuffix .vpd, $$($makeTargetName)))
 \t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$(patsubst %.vpd,%.out,$$^) /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
+
+run-$makeTargetName-fst: $$(addprefix $$(output_dir)/, $$(addsuffix .fst, $$($makeTargetName)))
+\t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$(patsubst %.fst,%.out,$$^) /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
 """
 }
 
@@ -78,6 +81,8 @@ run-$kind-$env-tests: $$(addprefix $$(output_dir)/, $$(addsuffix .out, $suites))
 \t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$^ /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
 run-$kind-$env-tests-debug: $$(addprefix $$(output_dir)/, $$(addsuffix .vpd, $suites))
 \t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$(patsubst %.vpd,%.out,$$^) /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
+run-$kind-$env-tests-fst: $$(addprefix $$(output_dir)/, $$(addsuffix .fst, $suites))
+\t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$(patsubst %.fst,%.out,$$^) /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
 run-$kind-$env-tests-fast: $$(addprefix $$(output_dir)/, $$(addsuffix .run, $suites))
 \t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$^ /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
 """} } ).mkString("\n") + s"""
@@ -85,6 +90,8 @@ run-$kind-tests: $$(addprefix $$(output_dir)/, $$(addsuffix .out, $targets))
 \t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$^ /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
 run-$kind-tests-debug: $$(addprefix $$(output_dir)/, $$(addsuffix .vpd, $targets))
 \t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$(patsubst %.vpd,%.out,$$^) /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
+run-$kind-tests-fst: $$(addprefix $$(output_dir)/, $$(addsuffix .fst, $targets))
+\t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$(patsubst %.fst,%.out,$$^) /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
 run-$kind-tests-fast: $$(addprefix $$(output_dir)/, $$(addsuffix .run, $targets))
 \t@echo; perl -ne 'print "  [$$$$1] $$$$ARGV \\t$$$$2\\n" if( /\\*{3}(.{8})\\*{3}(.*)/ || /ASSERTION (FAILED)/i )' $$^ /dev/null | perl -ne 'if(/(.*)/){print "$$$$1\\n\\n"; exit(1) if eof()}'
 """

--- a/src/main/scala/uncore/tilelink2/Parameters.scala
+++ b/src/main/scala/uncore/tilelink2/Parameters.scala
@@ -5,6 +5,7 @@ package uncore.tilelink2
 import Chisel._
 import diplomacy._
 import scala.math.max
+import util.RationalDirection
 
 case class TLManagerParameters(
   address:            Seq[AddressSet],
@@ -324,6 +325,14 @@ object TLAsyncBundleParameters
 case class TLAsyncEdgeParameters(client: TLAsyncClientPortParameters, manager: TLAsyncManagerPortParameters)
 {
   val bundle = TLAsyncBundleParameters(manager.depth, TLBundleParameters(client.base, manager.base))
+}
+
+case class TLRationalManagerPortParameters(direction: RationalDirection, base: TLManagerPortParameters)
+case class TLRationalClientPortParameters(base: TLClientPortParameters)
+
+case class TLRationalEdgeParameters(client: TLRationalClientPortParameters, manager: TLRationalManagerPortParameters)
+{
+  val bundle = TLBundleParameters(client.base, manager.base)
 }
 
 object ManagerUnification

--- a/src/main/scala/uncore/tilelink2/package.scala
+++ b/src/main/scala/uncore/tilelink2/package.scala
@@ -10,7 +10,7 @@ package object tilelink2
   type TLInwardNode = InwardNodeHandle[TLClientPortParameters, TLManagerPortParameters, TLBundle]
   type TLOutwardNode = OutwardNodeHandle[TLClientPortParameters, TLManagerPortParameters, TLBundle]
   type TLAsyncOutwardNode = OutwardNodeHandle[TLAsyncClientPortParameters, TLAsyncManagerPortParameters, TLAsyncBundle]
-  type TLRationalOutwardNode = OutwardNodeHandle[TLClientPortParameters, TLManagerPortParameters, TLRationalBundle]
+  type TLRationalOutwardNode = OutwardNodeHandle[TLRationalClientPortParameters, TLRationalManagerPortParameters, TLRationalBundle]
   type IntOutwardNode = OutwardNodeHandle[IntSourcePortParameters, IntSinkPortParameters, Vec[Bool]]
 
   def OH1ToOH(x: UInt) = (x << 1 | UInt(1)) & ~Cat(UInt(0, width=1), x)

--- a/src/main/scala/util/ClockDivider.scala
+++ b/src/main/scala/util/ClockDivider.scala
@@ -5,15 +5,11 @@ package util
 import Chisel._
 
 /** Divide the clock by 2 */
-class ClockDivider2 extends Module {
+class ClockDivider2 extends BlackBox {
   val io = new Bundle {
-    val clock_out = Clock(OUTPUT)
+    val clk_out = Clock(OUTPUT)
+    val clk_in  = Clock(INPUT)
   }
-
-  val clock_reg = Reg(Bool())
-  clock_reg := !clock_reg
-
-  io.clock_out := clock_reg.asClock
 }
 
 /** Divide the clock by power of 2 times.
@@ -30,9 +26,10 @@ class Pow2ClockDivider(pow2: Int) extends Module {
     val dividers = Seq.fill(pow2) { Module(new ClockDivider2) }
 
     dividers.init.zip(dividers.tail).map { case (last, next) =>
-      next.clock := last.io.clock_out
+      next.io.clk_in := last.io.clk_out
     }
 
-    io.clock_out := dividers.last.io.clock_out
+    dividers.head.io.clk_in := clock
+    io.clock_out := dividers.last.io.clk_out
   }
 }

--- a/src/main/scala/util/ClockDivider.scala
+++ b/src/main/scala/util/ClockDivider.scala
@@ -4,7 +4,15 @@ package util
 
 import Chisel._
 
-/** Divide the clock by 2 */
+/** This black-boxes a Clock Divider by 2.
+  * The output clock is phase-aligned to the input clock.
+  * If you use this in synthesis, make sure your sdc
+  * declares that you want it to do the same.
+  *
+  * Because Chisel does not support
+  * blocking assignments, it is impossible
+  * to create a deterministic divided clock.
+  */
 class ClockDivider2 extends BlackBox {
   val io = new Bundle {
     val clk_out = Clock(OUTPUT)

--- a/src/main/scala/util/RationalCrossing.scala
+++ b/src/main/scala/util/RationalCrossing.scala
@@ -7,6 +7,32 @@
 package util
 import Chisel._
 
+// A rational crossing must put registers on the slow side.
+// This trait covers the options of how/where to put the registers.
+// BEWARE: the source+sink must agree on the direction!
+sealed trait RationalDirection {
+  def flip: RationalDirection
+}
+
+// If it's unclear which side will be slow (or it is variable),
+// place registers on both sides of the crossing, by splitting
+// a Queue into flow and pipe parts on either side. This is safe
+// for all possible clock ratios, but has the downside that the
+// path from the slow domain must close timing in the fast domain.
+case object Symmetric extends RationalDirection {
+  def flip = Symmetric
+}
+
+// If the source is fast, place the registers at the sink.
+case object FastToSlow extends RationalDirection {
+  def flip = SlowToFast
+}
+
+// If the source is slow, place the registers at the source.
+case object SlowToFast extends RationalDirection {
+  def flip = FastToSlow
+}
+
 final class RationalIO[T <: Data](gen: T) extends Bundle
 {
   val bits   = gen.chiselCloneType
@@ -23,15 +49,19 @@ object RationalIO
   def apply[T <: Data](gen: T) = new RationalIO(gen)
 }
 
-class RationalCrossingSource[T <: Data](gen: T) extends Module
+class RationalCrossingSource[T <: Data](gen: T, direction: RationalDirection = Symmetric) extends Module
 {
   val io = new Bundle {
     val enq = DecoupledIO(gen).flip
     val deq = RationalIO(gen)
   }
 
-  val enq = Queue(io.enq, 1, flow=true)
   val deq = io.deq
+  val enq = direction match {
+    case Symmetric  => Queue(io.enq, 1, flow=true)
+    case FastToSlow => io.enq
+    case SlowToFast => Queue(io.enq, 2)
+  }
 
   val count = RegInit(UInt(0, width = 2))
   val equal = count === deq.sink
@@ -42,9 +72,16 @@ class RationalCrossingSource[T <: Data](gen: T) extends Module
   enq.ready  := Mux(equal, deq.ready, count(1) =/= deq.sink(0))
 
   when (enq.fire()) { count := Cat(count(0), !count(1)) }
+
+  // Ensure the clocking is setup correctly
+  direction match {
+    case Symmetric  => () // always safe
+    case FastToSlow => assert (equal || count(1) === deq.sink(0))
+    case SlowToFast => assert (equal || count(1) =/= deq.sink(0))
+  }
 }
 
-class RationalCrossingSink[T <: Data](gen: T) extends Module
+class RationalCrossingSink[T <: Data](gen: T, direction: RationalDirection = Symmetric) extends Module
 {
   val io = new Bundle {
     val enq = RationalIO(gen).flip
@@ -53,7 +90,11 @@ class RationalCrossingSink[T <: Data](gen: T) extends Module
 
   val enq = io.enq
   val deq = Wire(io.deq)
-  io.deq <> Queue(deq, 1, pipe=true)
+  direction match {
+    case Symmetric  => io.deq <> Queue(deq, 1, pipe=true)
+    case FastToSlow => io.deq <> Queue(deq, 2)
+    case SlowToFast => io.deq <> deq
+  }
 
   val count = RegInit(UInt(0, width = 2))
   val equal = count === enq.source
@@ -64,14 +105,21 @@ class RationalCrossingSink[T <: Data](gen: T) extends Module
   deq.valid := Mux(equal, enq.valid, count(1) =/= enq.source(0))
 
   when (deq.fire()) { count := Cat(count(0), !count(1)) }
+
+  // Ensure the clocking is setup correctly
+  direction match {
+    case Symmetric  => () // always safe
+    case FastToSlow => assert (equal || count(1) =/= enq.source(0))
+    case SlowToFast => assert (equal || count(1) === enq.source(0))
+  }
 }
 
-class RationalCrossing[T <: Data](gen: T) extends Module
+class RationalCrossing[T <: Data](gen: T, direction: RationalDirection = Symmetric) extends Module
 {
   val io = new CrossingIO(gen)
 
-  val source = Module(new RationalCrossingSource(gen))
-  val sink   = Module(new RationalCrossingSink(gen))
+  val source = Module(new RationalCrossingSource(gen, direction))
+  val sink   = Module(new RationalCrossingSink(gen, direction))
 
   source.clock := io.enq_clock
   source.reset := io.enq_reset
@@ -84,8 +132,8 @@ class RationalCrossing[T <: Data](gen: T) extends Module
 
 object ToRational
 {
-  def apply[T <: Data](x: DecoupledIO[T]): RationalIO[T] = {
-    val source = Module(new RationalCrossingSource(x.bits))
+  def apply[T <: Data](x: DecoupledIO[T], direction: RationalDirection = Symmetric): RationalIO[T] = {
+    val source = Module(new RationalCrossingSource(x.bits, direction))
     source.io.enq <> x
     source.io.deq
   }
@@ -93,8 +141,8 @@ object ToRational
 
 object FromRational
 {
-  def apply[T <: Data](x: RationalIO[T]): DecoupledIO[T] = {
-    val sink = Module(new RationalCrossingSink(x.bits))
+  def apply[T <: Data](x: RationalIO[T], direction: RationalDirection = Symmetric): DecoupledIO[T] = {
+    val sink = Module(new RationalCrossingSink(x.bits, direction))
     sink.io.enq <> x
     sink.io.deq
   }

--- a/vsim/Makefrag
+++ b/vsim/Makefrag
@@ -6,6 +6,7 @@
 
 bb_vsrcs = $(base_dir)/vsrc/DebugTransportModuleJtag.v \
 	$(base_dir)/vsrc/jtag_vpi.v \
+	$(base_dir)/vsrc/ClockDivider2.v \
 	$(base_dir)/vsrc/AsyncResetReg.v \
 
 sim_vsrcs = \

--- a/vsrc/ClockDivider2.v
+++ b/vsrc/ClockDivider2.v
@@ -1,6 +1,9 @@
 // See LICENSE.SiFive for license details.
 
-/** This black-boxes a Clock Divider.
+/** This black-boxes a Clock Divider by 2.
+  * The output clock is phase-aligned to the input clock.
+  * If you use this in synthesis, make sure your sdc
+  * declares that you want it to do the same.
   *
   * Because Chisel does not support
   * blocking assignments, it is impossible

--- a/vsrc/ClockDivider2.v
+++ b/vsrc/ClockDivider2.v
@@ -1,0 +1,21 @@
+// See LICENSE.SiFive for license details.
+
+/** This black-boxes a Clock Divider.
+  *
+  * Because Chisel does not support
+  * blocking assignments, it is impossible
+  * to create a deterministic divided clock.
+  *
+  *  @param clk_out Divided Clock
+  *  @param clk_in  Clock Input
+  *
+  */
+
+module ClockDivider2 (output reg clk_out, input clk_in);
+
+   initial clk_out = 1'b0;
+   always @(posedge clk_in) begin
+      clk_out = ~clk_out; // Must use =, NOT <=
+   end
+
+endmodule // ClockDivider2


### PR DESCRIPTION
Make it possible to specify which side of the crossing is fast and which is slow.

Using this option can make it easier to close timing for the slow side of the crossing; it places the registers all on the slow side. However, if the wrong side is declared fast, the crossing will not be legal! The default remains a symmetric crossing which is safe in all cases and always puts the register on the sink side.