### PR TITLE
diplomacy: use HeterogeneousBag instead of Vec

### DIFF
--- a/src/main/scala/uncore/ahb/Nodes.scala
+++ b/src/main/scala/uncore/ahb/Nodes.scala
@@ -12,8 +12,8 @@ object AHBImp extends NodeImp[AHBMasterPortParameters, AHBSlavePortParameters, A
   def edgeO(pd: AHBMasterPortParameters, pu: AHBSlavePortParameters): AHBEdgeParameters = AHBEdgeParameters(pd, pu)
   def edgeI(pd: AHBMasterPortParameters, pu: AHBSlavePortParameters): AHBEdgeParameters = AHBEdgeParameters(pd, pu)
 
-  def bundleO(eo: Seq[AHBEdgeParameters]): Vec[AHBBundle] = Vec(eo.size, AHBBundle(AHBBundleParameters.union(eo.map(_.bundle))))
-  def bundleI(ei: Seq[AHBEdgeParameters]): Vec[AHBBundle] = Vec(ei.size, AHBBundle(AHBBundleParameters.union(ei.map(_.bundle))))
+  def bundleO(eo: AHBEdgeParameters): AHBBundle = AHBBundle(eo.bundle)
+  def bundleI(ei: AHBEdgeParameters): AHBBundle = AHBBundle(ei.bundle)
 
   def colour = "#00ccff" // bluish
   override def labelI(ei: AHBEdgeParameters) = (ei.slave.beatBytes * 8).toString

--- a/src/main/scala/uncore/ahb/RegisterRouter.scala
+++ b/src/main/scala/uncore/ahb/RegisterRouter.scala
@@ -80,7 +80,7 @@ abstract class AHBRegisterRouterBase(address: AddressSet, interrupts: Int, concu
   val intnode = uncore.tilelink2.IntSourceNode(interrupts)
 }
 
-case class AHBRegBundleArg(interrupts: Vec[Vec[Bool]], in: Vec[AHBBundle])(implicit val p: Parameters)
+case class AHBRegBundleArg(interrupts: util.HeterogeneousBag[Vec[Bool]], in: util.HeterogeneousBag[AHBBundle])(implicit val p: Parameters)
 
 class AHBRegBundleBase(arg: AHBRegBundleArg) extends Bundle
 {

--- a/src/main/scala/uncore/apb/Nodes.scala
+++ b/src/main/scala/uncore/apb/Nodes.scala
@@ -12,8 +12,8 @@ object APBImp extends NodeImp[APBMasterPortParameters, APBSlavePortParameters, A
   def edgeO(pd: APBMasterPortParameters, pu: APBSlavePortParameters): APBEdgeParameters = APBEdgeParameters(pd, pu)
   def edgeI(pd: APBMasterPortParameters, pu: APBSlavePortParameters): APBEdgeParameters = APBEdgeParameters(pd, pu)
 
-  def bundleO(eo: Seq[APBEdgeParameters]): Vec[APBBundle] = Vec(eo.size, APBBundle(APBBundleParameters.union(eo.map(_.bundle))))
-  def bundleI(ei: Seq[APBEdgeParameters]): Vec[APBBundle] = Vec(ei.size, APBBundle(APBBundleParameters.union(ei.map(_.bundle))))
+  def bundleO(eo: APBEdgeParameters): APBBundle = APBBundle(eo.bundle)
+  def bundleI(ei: APBEdgeParameters): APBBundle = APBBundle(ei.bundle)
 
   def colour = "#00ccff" // bluish
   override def labelI(ei: APBEdgeParameters) = (ei.slave.beatBytes * 8).toString

--- a/src/main/scala/uncore/apb/RegisterRouter.scala
+++ b/src/main/scala/uncore/apb/RegisterRouter.scala
@@ -64,7 +64,7 @@ abstract class APBRegisterRouterBase(address: AddressSet, interrupts: Int, concu
   val intnode = uncore.tilelink2.IntSourceNode(interrupts)
 }
 
-case class APBRegBundleArg(interrupts: Vec[Vec[Bool]], in: Vec[APBBundle])(implicit val p: Parameters)
+case class APBRegBundleArg(interrupts: util.HeterogeneousBag[Vec[Bool]], in: util.HeterogeneousBag[APBBundle])(implicit val p: Parameters)
 
 class APBRegBundleBase(arg: APBRegBundleArg) extends Bundle
 {

--- a/src/main/scala/uncore/axi4/Nodes.scala
+++ b/src/main/scala/uncore/axi4/Nodes.scala
@@ -12,8 +12,8 @@ object AXI4Imp extends NodeImp[AXI4MasterPortParameters, AXI4SlavePortParameters
   def edgeO(pd: AXI4MasterPortParameters, pu: AXI4SlavePortParameters): AXI4EdgeParameters = AXI4EdgeParameters(pd, pu)
   def edgeI(pd: AXI4MasterPortParameters, pu: AXI4SlavePortParameters): AXI4EdgeParameters = AXI4EdgeParameters(pd, pu)
 
-  def bundleO(eo: Seq[AXI4EdgeParameters]): Vec[AXI4Bundle] = Vec(eo.size, AXI4Bundle(AXI4BundleParameters.union(eo.map(_.bundle))))
-  def bundleI(ei: Seq[AXI4EdgeParameters]): Vec[AXI4Bundle] = Vec(ei.size, AXI4Bundle(AXI4BundleParameters.union(ei.map(_.bundle))))
+  def bundleO(eo: AXI4EdgeParameters): AXI4Bundle = AXI4Bundle(eo.bundle)
+  def bundleI(ei: AXI4EdgeParameters): AXI4Bundle = AXI4Bundle(ei.bundle)
 
   def colour = "#00ccff" // bluish
   override def labelI(ei: AXI4EdgeParameters) = (ei.slave.beatBytes * 8).toString

--- a/src/main/scala/uncore/axi4/RegisterRouter.scala
+++ b/src/main/scala/uncore/axi4/RegisterRouter.scala
@@ -85,7 +85,7 @@ abstract class AXI4RegisterRouterBase(address: AddressSet, interrupts: Int, conc
   val intnode = uncore.tilelink2.IntSourceNode(interrupts)
 }
 
-case class AXI4RegBundleArg(interrupts: Vec[Vec[Bool]], in: Vec[AXI4Bundle])(implicit val p: Parameters)
+case class AXI4RegBundleArg(interrupts: util.HeterogeneousBag[Vec[Bool]], in: util.HeterogeneousBag[AXI4Bundle])(implicit val p: Parameters)
 
 class AXI4RegBundleBase(arg: AXI4RegBundleArg) extends Bundle
 {

--- a/src/main/scala/uncore/tilelink2/IntNodes.scala
+++ b/src/main/scala/uncore/tilelink2/IntNodes.scala
@@ -126,6 +126,8 @@ class IntXing()(implicit p: Parameters) extends LazyModule
       val out = intnode.bundleOut
     }
 
-    io.out := RegNext(RegNext(RegNext(io.in)))
+    (io.in zip io.out) foreach { case (in, out) =>
+      out := RegNext(RegNext(RegNext(in)))
+    }
   }
 }

--- a/src/main/scala/uncore/tilelink2/IntNodes.scala
+++ b/src/main/scala/uncore/tilelink2/IntNodes.scala
@@ -53,14 +53,8 @@ object IntImp extends NodeImp[IntSourcePortParameters, IntSinkPortParameters, In
 {
   def edgeO(pd: IntSourcePortParameters, pu: IntSinkPortParameters): IntEdge = IntEdge(pd, pu)
   def edgeI(pd: IntSourcePortParameters, pu: IntSinkPortParameters): IntEdge = IntEdge(pd, pu)
-  def bundleO(eo: Seq[IntEdge]): Vec[Vec[Bool]] = {
-    if (eo.isEmpty) Vec(0, Vec(0, Bool())) else
-    Vec(eo.size, Vec(eo.map(_.source.num).max, Bool()))
-  }
-  def bundleI(ei: Seq[IntEdge]): Vec[Vec[Bool]] = {
-    if (ei.isEmpty) Vec(0, Vec(0, Bool())) else
-    Vec(ei.size, Vec(ei.map(_.source.num).max, Bool()))
-  }
+  def bundleO(eo: IntEdge): Vec[Bool] = Vec(eo.source.num, Bool())
+  def bundleI(ei: IntEdge): Vec[Bool] = Vec(ei.source.num, Bool())
 
   def colour = "#0000ff" // blue
   override def labelI(ei: IntEdge) = ei.source.sources.map(_.range.size).sum.toString

--- a/src/main/scala/uncore/tilelink2/Nodes.scala
+++ b/src/main/scala/uncore/tilelink2/Nodes.scala
@@ -18,8 +18,8 @@ object TLImp extends NodeImp[TLClientPortParameters, TLManagerPortParameters, TL
   def edgeO(pd: TLClientPortParameters, pu: TLManagerPortParameters): TLEdgeOut = new TLEdgeOut(pd, pu)
   def edgeI(pd: TLClientPortParameters, pu: TLManagerPortParameters): TLEdgeIn  = new TLEdgeIn(pd, pu)
 
-  def bundleO(eo: Seq[TLEdgeOut]): Vec[TLBundle] = Vec(eo.size, TLBundle(TLBundleParameters.union(eo.map(_.bundle))))
-  def bundleI(ei: Seq[TLEdgeIn]):  Vec[TLBundle] = Vec(ei.size, TLBundle(TLBundleParameters.union(ei.map(_.bundle))))
+  def bundleO(eo: TLEdgeOut): TLBundle = TLBundle(eo.bundle)
+  def bundleI(ei: TLEdgeIn):  TLBundle = TLBundle(ei.bundle)
 
   def colour = "#000000" // black
   override def labelI(ei: TLEdgeIn)  = (ei.manager.beatBytes * 8).toString
@@ -156,8 +156,8 @@ object TLAsyncImp extends NodeImp[TLAsyncClientPortParameters, TLAsyncManagerPor
   def edgeO(pd: TLAsyncClientPortParameters, pu: TLAsyncManagerPortParameters): TLAsyncEdgeParameters = TLAsyncEdgeParameters(pd, pu)
   def edgeI(pd: TLAsyncClientPortParameters, pu: TLAsyncManagerPortParameters): TLAsyncEdgeParameters = TLAsyncEdgeParameters(pd, pu)
 
-  def bundleO(eo: Seq[TLAsyncEdgeParameters]): Vec[TLAsyncBundle] = Vec(eo.size, new TLAsyncBundle(TLAsyncBundleParameters.union(eo.map(_.bundle))))
-  def bundleI(ei: Seq[TLAsyncEdgeParameters]): Vec[TLAsyncBundle] = Vec(ei.size, new TLAsyncBundle(TLAsyncBundleParameters.union(ei.map(_.bundle))))
+  def bundleO(eo: TLAsyncEdgeParameters): TLAsyncBundle = new TLAsyncBundle(eo.bundle)
+  def bundleI(ei: TLAsyncEdgeParameters): TLAsyncBundle = new TLAsyncBundle(ei.bundle)
 
   def colour = "#ff0000" // red
   override def labelI(ei: TLAsyncEdgeParameters) = ei.manager.depth.toString
@@ -188,8 +188,8 @@ object TLRationalImp extends NodeImp[TLRationalClientPortParameters, TLRationalM
   def edgeO(pd: TLRationalClientPortParameters, pu: TLRationalManagerPortParameters): TLRationalEdgeParameters = TLRationalEdgeParameters(pd, pu)
   def edgeI(pd: TLRationalClientPortParameters, pu: TLRationalManagerPortParameters): TLRationalEdgeParameters = TLRationalEdgeParameters(pd, pu)
 
-  def bundleO(eo: Seq[TLRationalEdgeParameters]): Vec[TLRationalBundle] = Vec(eo.size, new TLRationalBundle(TLBundleParameters.union(eo.map(_.bundle))))
-  def bundleI(ei: Seq[TLRationalEdgeParameters]): Vec[TLRationalBundle] = Vec(ei.size, new TLRationalBundle(TLBundleParameters.union(ei.map(_.bundle))))
+  def bundleO(eo: TLRationalEdgeParameters): TLRationalBundle = new TLRationalBundle(eo.bundle)
+  def bundleI(ei: TLRationalEdgeParameters): TLRationalBundle = new TLRationalBundle(ei.bundle)
 
   def colour = "#00ff00" // green
 

--- a/src/main/scala/uncore/tilelink2/RegisterRouter.scala
+++ b/src/main/scala/uncore/tilelink2/RegisterRouter.scala
@@ -86,7 +86,7 @@ abstract class TLRegisterRouterBase(val address: AddressSet, interrupts: Int, co
   val intnode = IntSourceNode(interrupts)
 }
 
-case class TLRegBundleArg(interrupts: Vec[Vec[Bool]], in: Vec[TLBundle])(implicit val p: Parameters)
+case class TLRegBundleArg(interrupts: util.HeterogeneousBag[Vec[Bool]], in: util.HeterogeneousBag[TLBundle])(implicit val p: Parameters)
 
 class TLRegBundleBase(arg: TLRegBundleArg) extends Bundle
 {


### PR DESCRIPTION
This makes it possible for the bundles to have different widths.

Previously, we had to widen all the bundles passing through a node
to the widest of all the possibilities.  This would mean that if
you had two source[] fields, they end up the same.