### PR TITLE
Fix HastiTestSRAM can't R/W byte when HSIZE is 0

### DIFF
--- a/src/main/scala/junctions/hasti.scala
+++ b/src/main/scala/junctions/hasti.scala
@@ -470,7 +470,7 @@ class HastiTestSRAM(depth: Int)(implicit p: Parameters) extends HastiModule()(p)
   
   // Calculate the bitmask of which bytes are being accessed
   val mask_decode = Vec.tabulate(hastiAlignment+1) (UInt(_) <= io.hsize)
-  val mask_wide   = Vec.tabulate(hastiDataBytes) { i => mask_decode(log2Up(i+1)) }
+  val mask_wide   = Vec.tabulate(hastiDataBytes) { i => mask_decode(log2Ceil(i+1)) }
   val mask_shift  = if (hastiAlignment == 0) UInt(1) else
                     mask_wide.asUInt() << io.haddr(hastiAlignment-1,0)
   


### PR DESCRIPTION
**Problem: HastiTestSRAM can't Read/Write byte when HSIZE is 0 (indicates the size of a data transfer is byte).**

Take dataBits is 32 bits for example.

What the expected relationship between HSIZE and mask_decode is as below:

- HSIZE[2:0]        -> mask_decode[2:0]
- 000 (Byte)         -> 001
- 001 (Half word) -> 011
- 010 (Word)       -> 111

What the expected relationship between mask_decode and mask_wide is as below:

- mask_decode[2:0] -> mask_wide[3:0]
- 001 -> 0001
- 011 -> 0011
- 111 -> 1111

 In other words, 
- mask_wide[0] depends on mask_decode[0],
- mask_wide[1] depends on mask_decode[1],
- mask_wide[2] depends on mask_decode[2],
- mask_wide[3] depends on mask_decode[2].

Let's look at the code: `log2Up(i+1)` (In this example, i is from 0 to 3), the result never is 0. So mask_wide[0] never depends on mask_decode[0]. It should use` log2Ceil(i+1)` instead.

The difference between log2Up and log2Ceil is as below (more details see [Math.scala](https://github.com/ucb-bar/chisel3/blob/master/src/main/scala/chisel3/util/Math.scala) ):

- log2Up:  Compute the log2 rounded up with min value of 1 
- log2Ceil:  Compute the log2 rounded up 

