### PR TITLE
Standardize Data.holdUnless and SeqMem.readAndHold

### DIFF
--- a/src/main/scala/junctions/hasti.scala
+++ b/src/main/scala/junctions/hasti.scala
@@ -6,7 +6,7 @@ package junctions
 import Chisel._
 import config._
 import unittest.UnitTest
-import util.ParameterizedBundle
+import util._
 
 object HastiConstants
 {
@@ -506,15 +506,12 @@ class HastiTestSRAM(depth: Int)(implicit p: Parameters) extends HastiModule()(p)
   // result must bypass data from the pending write into the read if they
   // happen to have matching address.
   
-  // Remove this once HoldUnless is in chisel3
-  def holdUnless[T <: Data](in : T, enable: Bool): T = Mux(!enable, RegEnable(in, enable), in)
-  
   // Pending write?
   val p_valid     = RegInit(Bool(false))
   val p_address   = Reg(a_address)
   val p_mask      = Reg(a_mask)
   val p_latch_d   = RegNext(ready && a_request && a_write, Bool(false))
-  val p_wdata     = holdUnless(d_wdata, p_latch_d)
+  val p_wdata     = d_wdata holdUnless p_latch_d
   
   // Use single-ported memory with byte-write enable
   val mem = SeqMem(1 << (depth-hastiAlignment), Vec(hastiDataBytes, Bits(width = 8)))
@@ -522,7 +519,7 @@ class HastiTestSRAM(depth: Int)(implicit p: Parameters) extends HastiModule()(p)
   // Decide is the SRAM port is used for reading or (potentially) writing
   val read = ready && a_request && !a_write
   // In case we are stalled, we need to hold the read data
-  val d_rdata = holdUnless(mem.read(a_address, read), RegNext(read))
+  val d_rdata = mem.readAndHold(a_address, read)
   // Whenever the port is not needed for reading, execute pending writes
   when (!read && p_valid) { mem.write(p_address, p_wdata, p_mask.toBools) }
   when (!read) { p_valid := Bool(false) }

--- a/src/main/scala/uncore/apb/SRAM.scala
+++ b/src/main/scala/uncore/apb/SRAM.scala
@@ -5,6 +5,7 @@ package uncore.apb
 import Chisel._
 import config._
 import diplomacy._
+import util._
 
 class APBRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4)(implicit p: Parameters) extends LazyModule
 {
@@ -34,7 +35,6 @@ class APBRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4
 
     // Use single-ported memory with byte-write enable
     val mem = SeqMem(1 << mask.filter(b=>b).size, Vec(beatBytes, Bits(width = 8)))
-    def holdUnless[T <: Data](in : T, enable: Bool): T = Mux(!enable, RegEnable(in, enable), in)
 
     val read = in.psel && !in.penable && !in.pwrite
     when (in.psel && !in.penable && in.pwrite) {
@@ -43,6 +43,6 @@ class APBRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4
 
     in.pready  := Bool(true)
     in.pslverr := Bool(false)
-    in.prdata  := holdUnless(mem.read(paddr, read).asUInt, RegNext(read))
+    in.prdata  := mem.readAndHold(paddr, read).asUInt
   }
 }

--- a/src/main/scala/uncore/axi4/SRAM.scala
+++ b/src/main/scala/uncore/axi4/SRAM.scala
@@ -5,6 +5,7 @@ package uncore.axi4
 import Chisel._
 import config._
 import diplomacy._
+import util._
 
 class AXI4RAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4)(implicit p: Parameters) extends LazyModule
 {
@@ -62,8 +63,7 @@ class AXI4RAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 
     }
 
     val ren = in.ar.fire()
-    def holdUnless[T <: Data](in : T, enable: Bool): T = Mux(!enable, RegEnable(in, enable), in)
-    val rdata = holdUnless(mem.read(r_addr, ren), RegNext(ren))
+    val rdata = mem.readAndHold(r_addr, ren)
 
     in.r.bits.id   := r_id
     in.r.bits.resp := AXI4Parameters.RESP_OKAY

--- a/src/main/scala/uncore/tilelink2/SRAM.scala
+++ b/src/main/scala/uncore/tilelink2/SRAM.scala
@@ -5,6 +5,7 @@ package uncore.tilelink2
 import Chisel._
 import config._
 import diplomacy._
+import util._
 
 class TLRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4)(implicit p: Parameters) extends LazyModule
 {
@@ -73,7 +74,7 @@ class TLRAM(address: AddressSet, executable: Boolean = true, beatBytes: Int = 4)
       mem.write(memAddress, wdata, in.a.bits.mask.toBools)
     }
     val ren = in.a.fire() && read
-    rdata := holdUnless(mem.read(memAddress, ren), RegNext(ren))
+    rdata := mem.readAndHold(memAddress, ren)
 
     // Tie off unused channels
     in.b.valid := Bool(false)

--- a/src/main/scala/uncore/tilelink2/SourceShrinker.scala
+++ b/src/main/scala/uncore/tilelink2/SourceShrinker.scala
@@ -6,6 +6,7 @@ import Chisel._
 import chisel3.internal.sourceinfo.SourceInfo
 import config._
 import diplomacy._
+import util._
 import scala.math.{min,max}
 
 class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyModule
@@ -54,7 +55,7 @@ class TLSourceShrinker(maxInFlight: Int)(implicit p: Parameters) extends LazyMod
         in.a.ready := out.a.ready && !block
         out.a.valid := in.a.valid && !block
         out.a.bits := in.a.bits
-        out.a.bits.source := holdUnless(nextFree, a_first)
+        out.a.bits.source := nextFree holdUnless a_first
 
         in.d <> out.d
         in.d.bits.source := sourceIdMap(out.d.bits.source)

--- a/src/main/scala/uncore/tilelink2/package.scala
+++ b/src/main/scala/uncore/tilelink2/package.scala
@@ -4,6 +4,7 @@ package uncore
 
 import Chisel._
 import diplomacy._
+import util._
 
 package object tilelink2
 {
@@ -16,7 +17,6 @@ package object tilelink2
   def OH1ToOH(x: UInt) = (x << 1 | UInt(1)) & ~Cat(UInt(0, width=1), x)
   def OH1ToUInt(x: UInt) = OHToUInt(OH1ToOH(x))
   def UIntToOH1(x: UInt, width: Int) = ~(SInt(-1, width=width).asUInt << x)(width-1, 0)
-  def holdUnless[T <: Data](in : T, enable: Bool): T = Mux(!enable, RegEnable(in, enable), in)
   def trailingZeros(x: Int) = if (x > 0) Some(log2Ceil(x & -x)) else None
   // Fill 1s from low bits to high bits
   def leftOR(x: UInt) = {

--- a/src/main/scala/util/Package.scala
+++ b/src/main/scala/util/Package.scala
@@ -23,6 +23,14 @@ package object util {
     def asUInt(): UInt = Cat(x.map(_.asUInt).reverse)
   }
 
+  implicit class DataToAugmentedData[T <: Data](val x: T) extends AnyVal {
+    def holdUnless(enable: Bool): T = Mux(enable, x, RegEnable(x, enable))
+  }
+
+  implicit class SeqMemToAugmentedSeqMem[T <: Data](val x: SeqMem[T]) extends AnyVal {
+    def readAndHold(addr: UInt, enable: Bool): T = x.read(addr, enable) holdUnless RegNext(enable)
+  }
+
   implicit def uintToBitPat(x: UInt): BitPat = BitPat(x)
   implicit def wcToUInt(c: WideCounter): UInt = c.value
 


### PR DESCRIPTION
- Remove redundant definitions
- Make API more idiomatic (x holdUnless y, instead of holdUnless(x, y))
- Add new SeqMem API, readAndHold, which corresponds to most common use of holdUnless