### PR TITLE
travis: only run 4 jobs at once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,7 @@ env:
     - SUITE=RocketSuiteA
     - SUITE=RocketSuiteB
     - SUITE=RocketSuiteC
-    - SUITE=GroundtestSuiteA
-    - SUITE=GroundtestSuiteB
+    - SUITE=GroundtestSuite
     - SUITE=UnittestSuite
 
 # blacklist private branches

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -56,16 +56,12 @@ PROJECT=rocketchip
 CONFIGS=DefaultL2Config TinyConfig
 endif
 
-ifeq ($(SUITE),GroundtestSuiteA)
+ifeq ($(SUITE),GroundtestSuite)
 PROJECT=groundtest
-CONFIGS=MemtestConfig MemtestBufferlessConfig MemtestStatelessConfig
-# FancyMemtestConfig takes too long to compile
-endif
-
-ifeq ($(SUITE),GroundtestSuiteB)
-PROJECT=groundtest
-CONFIGS=BroadcastRegressionTestConfig BufferlessRegressionTestConfig CacheRegressionTestConfig \
+CONFIGS=MemtestConfig MemtestBufferlessConfig MemtestStatelessConfig \
+        BroadcastRegressionTestConfig BufferlessRegressionTestConfig CacheRegressionTestConfig \
 	ComparatorConfig ComparatorBufferlessConfig ComparatorStatelessConfig
+# FancyMemtestConfig takes too long to compile
 endif
 
 ifeq ($(SUITE),UnittestSuite)


### PR DESCRIPTION
We can only run 4 at a time; 5 causes the test time to double.
In the past we had a 50minute build deadline, but that's fixed.