### PR TITLE
l1tol2: put a flow Q on the exits

### DIFF
--- a/src/main/scala/coreplex/CoreplexNetwork.scala
+++ b/src/main/scala/coreplex/CoreplexNetwork.scala
@@ -130,7 +130,7 @@ trait BankedL2CoherenceManagers extends CoreplexNetwork {
     val node = TLOutputNode()
     for (bank <- 0 until l2Config.nBanksPerChannel) {
       val offset = (bank * l2Config.nMemoryChannels) + channel
-      in := l1tol2.node
+      in := TLBuffer(BufferParams.flow)(l1tol2.node)
       node := TLFilter(AddressSet(offset * l1tol2_lineBytes, mask))(out)
     }
     node


### PR DESCRIPTION
This Xbar connects the largest components in the design; the cores
and the L2 banks. We already have a full buffer on the core side.
However, the valid path going to the L2 comes back as a ready path.
Putting a flow Q also on the outputs of the l1tol2 cuts this path
in half at no cost to IPC.

@hanatsifivedotcom