### PR TITLE
rocket: remove hard-coded paddrBits

### DIFF
--- a/src/main/scala/coreplex/RocketTiles.scala
+++ b/src/main/scala/coreplex/RocketTiles.scala
@@ -31,7 +31,6 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
       case TileKey => c
       case BuildRoCC => c.rocc
       case SharedMemoryTLEdge => l1tol2.node.edgesIn(0)
-      case PAddrBits => l1tol2.node.edgesIn(0).bundle.addressBits
     }
 
     // Hack debug interrupt into a node (future debug module should use diplomacy)

--- a/src/main/scala/rocket/Tile.scala
+++ b/src/main/scala/rocket/Tile.scala
@@ -119,6 +119,8 @@ class RocketTileModule(outer: RocketTile) extends BaseTileModule(outer, () => ne
     with CanHaveLegacyRoccsModule
     with CanHaveScratchpadModule {
 
+  require(outer.p(PAddrBits) >= outer.masterNode.edgesIn(0).bundle.addressBits)
+
   val core = Module(p(BuildCore)(outer.p))
   core.io.hartid := io.hartid
   outer.frontend.module.io.cpu <> core.io.imem

--- a/src/main/scala/tile/Core.scala
+++ b/src/main/scala/tile/Core.scala
@@ -52,7 +52,7 @@ trait HasCoreParameters extends HasTileParameters {
   def pgIdxBits = 12
   def pgLevelBits = 10 - log2Ceil(xLen / 32)
   def vaddrBits = pgIdxBits + pgLevels * pgLevelBits
-  val paddrBits = 32//p(PAddrBits)
+  val paddrBits = p(PAddrBits)
   def ppnBits = paddrBits - pgIdxBits
   def vpnBits = vaddrBits - pgIdxBits
   val pgLevels = p(PgLevels)


### PR DESCRIPTION
Fall back on global variable but check that it is compatible with memory as seen from rocket's tilelink master port.