### PR TITLE
TLROM: allow name and compatibility strings to be provided by subclasses

### DIFF
--- a/src/main/scala/uncore/devices/Rom.scala
+++ b/src/main/scala/uncore/devices/Rom.scala
@@ -12,9 +12,10 @@ import uncore.tilelink2._
 import uncore.util._
 import config._
 
-class TLROM(val base: BigInt, val size: Int, contentsDelayed: => Seq[Byte], executable: Boolean = true, beatBytes: Int = 4)(implicit p: Parameters) extends LazyModule
+class TLROM(val base: BigInt, val size: Int, contentsDelayed: => Seq[Byte], executable: Boolean = true,
+  beatBytes: Int = 4, name: String = "rom", devcompat: Seq[String] = Nil)(implicit p: Parameters) extends LazyModule
 {
-  val device = new SimpleDevice("rom", Nil)
+  val device = new SimpleDevice(name, devcompat)
 
   val node = TLManagerNode(beatBytes, TLManagerParameters(
     address     = List(AddressSet(base, size-1)),

--- a/src/main/scala/uncore/devices/Rom.scala
+++ b/src/main/scala/uncore/devices/Rom.scala
@@ -12,14 +12,13 @@ import uncore.tilelink2._
 import uncore.util._
 import config._
 
-class TLROM(val base: BigInt, val size: Int, contentsDelayed: => Seq[Byte], executable: Boolean = true,
-  beatBytes: Int = 4, name: String = "rom", devcompat: Seq[String] = Nil)(implicit p: Parameters) extends LazyModule
+class TLROM(val base: BigInt, val size: Int, contentsDelayed: => Seq[Byte], executable: Boolean = true, beatBytes: Int = 4,
+  resources: Seq[Resource] = new SimpleDevice("rom", Nil).reg)(implicit p: Parameters) extends LazyModule
 {
-  val device = new SimpleDevice(name, devcompat)
 
   val node = TLManagerNode(beatBytes, TLManagerParameters(
     address     = List(AddressSet(base, size-1)),
-    resources   = device.reg,
+    resources   = resources,
     regionType  = RegionType.UNCACHED,
     executable  = executable,
     supportsGet = TransferSizes(1, beatBytes),


### PR DESCRIPTION
This allows TLROM devices to specify a name and compatibility string for the Config String other than "rom" 