### PR TITLE
Use 1 MHz as default timebase

### DIFF
--- a/src/main/scala/rocketchip/Configs.scala
+++ b/src/main/scala/rocketchip/Configs.scala
@@ -24,7 +24,8 @@ class BasePlatformConfig extends Config((site, here, up) => {
   // DTS descriptive parameters
   case DTSModel => "ucbbar,rocketchip-unknown"
   case DTSCompat => Nil
-  case DTSTimebase => BigInt(0)
+  case DTSTimebase => BigInt(1000000) // 1 MHz
+  case RTCPeriod => 1000 // Implies coreplex clock is DTSTimebase * RTCPeriod = 1 GHz
   // TileLink connection parameters
   case TLMonitorBuilder => (args: TLMonitorArgs) => Some(LazyModule(new TLMonitor(args)))
   case TLFuzzReadyValid => false
@@ -40,7 +41,6 @@ class BasePlatformConfig extends Config((site, here, up) => {
   case ExtMem => MasterConfig(base=0x80000000L, size=0x10000000L, beatBytes=8, idBits=4)
   case ExtBus => MasterConfig(base=0x60000000L, size=0x20000000L, beatBytes=8, idBits=4)
   case ExtIn  => SlaveConfig(beatBytes=8, idBits=8, sourceBits=2)
-  case RTCPeriod => 100 // gives 10 MHz RTC assuming 1 GHz uncore clock
 })
 
 /** Actual elaboratable target Configs */


### PR DESCRIPTION
Defaulting to 0 prevents Linux from booting