### PR TITLE
Pass MODEL variable to emulator.cc

### DIFF
--- a/csrc/emulator.cc
+++ b/csrc/emulator.cc
@@ -155,7 +155,7 @@ done_processing:
   srand48(random_seed);
 
   Verilated::randReset(2);
-  VTestHarness *tile = new VTestHarness;
+  TEST_HARNESS *tile = new TEST_HARNESS;
 
 #if VM_TRACE
   Verilated::traceEverOn(true); // Verilator must compute traced signals

--- a/emulator/Makefrag-verilator
+++ b/emulator/Makefrag-verilator
@@ -1,5 +1,5 @@
 #--------------------------------------------------------------------
-# Verilator Generation 
+# Verilator Generation
 #--------------------------------------------------------------------
 firrtl = $(generated_dir)/$(long_name).fir
 firrtl_debug = $(generated_dir_debug)/$(long_name).fir
@@ -57,7 +57,7 @@ VERILATOR_FLAGS := --top-module $(MODEL) \
   --output-split 20000 \
 	-Wno-STMTDLY --x-assign unique \
   -I$(base_dir)/vsrc \
-  -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -include $(base_dir)/csrc/verilator.h"
+  -O3 -CFLAGS "$(CXXFLAGS) -DVERILATOR -DTEST_HARNESS=V$(MODEL) -include $(base_dir)/csrc/verilator.h"
 cppfiles = $(addprefix $(base_dir)/csrc/, $(addsuffix .cc, $(CXXSRCS)))
 headers = $(wildcard $(base_dir)/csrc/*.h)
 


### PR DESCRIPTION
This enables hot-swapping of the top-level test harness by specifying
`MODEL=MyTestHarness` when building the emulator.