### PR TITLE
Debug Controls

### DIFF
--- a/regression/Makefile
+++ b/regression/Makefile
@@ -218,7 +218,7 @@ stamps/%/emulator-torture-$(TORTURE_CONFIG).stamp: stamps/%/emulator-debug.stamp
 #OPENOCD_HEAD ?= riscv
 OPENOCD_INSTALL ?= $(abspath $(TOP))/openocd-install
 #OPENOCD_VERSION = $(shell git ls-remote http://github.com/sifive/openocd.git $(OPENOCD_HEAD) | awk '{print $$1}')
-OPENOCD_VERSION = 7df6804934c13590fffb98012a3728225bd21c99
+OPENOCD_VERSION = c7a204b93abbbc286486967588449e7773fe09ac
 
 OPENOCD_DIR = $(OPENOCD_INSTALL)_$(OPENOCD_VERSION)/
 

--- a/src/main/scala/coreplex/RISCVPlatform.scala
+++ b/src/main/scala/coreplex/RISCVPlatform.scala
@@ -37,6 +37,8 @@ trait CoreplexRISCVPlatformBundle extends CoreplexNetworkBundle {
   val debug = new ClockedDMIIO().flip
   val rtcToggle = Bool(INPUT)
   val resetVector = UInt(INPUT, p(XLen))
+  val ndreset = Bool(OUTPUT)
+  val dmactive = Bool(OUTPUT)
 }
 
 trait CoreplexRISCVPlatformModule extends CoreplexNetworkModule {
@@ -47,10 +49,8 @@ trait CoreplexRISCVPlatformModule extends CoreplexNetworkModule {
   // TODO in inheriting traits: Set this to something meaningful, e.g. "component is in reset or powered down"
   val nDebugComponents = outer.debug.intnode.bundleOut.size
   outer.debug.module.io.ctrl.debugUnavail := Vec.fill(nDebugComponents){Bool(false)}
-  // TODO in inheriting traits: Use these values in your power and reset controls.
-  // TODO Or move these signals to Coreplex Top Level
-  // ... := outer.debug.module.io.ctrl.dmactive
-  // ... := outer.debug.module.io.ctrl.ndreset
+  io.dmactive := outer.debug.module.io.ctrl.dmactive
+  io.ndreset := outer.debug.module.io.ctrl.ndreset
 
   // Synchronize the rtc into the coreplex
   val rtcSync = ShiftRegister(io.rtcToggle, 3)

--- a/src/main/scala/rocketchip/RISCVPlatform.scala
+++ b/src/main/scala/rocketchip/RISCVPlatform.scala
@@ -80,6 +80,8 @@ trait PeripheryDebugBundle extends HasTopLevelNetworksBundle {
   val jtag        = (p(IncludeJtagDTM)).option(new JTAGIO(hasTRSTn = false).flip)
   val jtag_reset  = (p(IncludeJtagDTM)).option(Bool(INPUT))
 
+  val ndreset = Bool(OUTPUT)
+  val dmactive = Bool(OUTPUT)
 }
 
 trait PeripheryDebugModule extends HasTopLevelNetworksModule {
@@ -100,6 +102,10 @@ trait PeripheryDebugModule extends HasTopLevelNetworksModule {
     outer.coreplex.module.io.debug.dmiClock := io.jtag.get.TCK
     outer.coreplex.module.io.debug.dmiReset := ResetCatchAndSync(io.jtag.get.TCK, io.jtag_reset.get, "dmiResetCatch")
   }
+
+  io.ndreset  := outer.coreplex.module.io.ndreset
+  io.dmactive := outer.coreplex.module.io.dmactive
+
 }
 
 /// Real-time clock is based on RTCPeriod relative to Top clock

--- a/src/main/scala/rocketchip/TestHarness.scala
+++ b/src/main/scala/rocketchip/TestHarness.scala
@@ -14,7 +14,10 @@ class TestHarness()(implicit p: Parameters) extends Module {
   val io = new Bundle {
     val success = Bool(OUTPUT)
   }
+
   val dut = Module(LazyModule(new ExampleRocketTop).module)
+  dut.reset := reset | dut.io.ndreset
+
 
   dut.io.interrupts := UInt(0)
 

--- a/src/main/scala/uncore/devices/debug/Debug.scala
+++ b/src/main/scala/uncore/devices/debug/Debug.scala
@@ -215,7 +215,7 @@ class DebugInternalBundle ()(implicit val p: Parameters) extends ParameterizedBu
 class DebugCtrlBundle (nComponents: Int)(implicit val p: Parameters) extends ParameterizedBundle()(p) {
   val debugUnavail    = Vec(nComponents, Bool()).asInput
   val ndreset         = Bool(OUTPUT)
-  val debugActive     = Bool(OUTPUT)
+  val dmactive        = Bool(OUTPUT)
 }
 
 //*****************************************
@@ -404,7 +404,7 @@ class TLDebugModuleOuter(device: Device)(implicit p: Parameters) extends LazyMod
     io.innerCtrl.bits.resumereq := DMCONTROLWrData.resumereq
 
     io.ctrl.ndreset := DMCONTROLReg.ndmreset
-    io.ctrl.debugActive := DMCONTROLReg.dmactive
+    io.ctrl.dmactive := DMCONTROLReg.dmactive
 
   }
 }
@@ -1109,7 +1109,7 @@ class TLDebugModule(implicit p: Parameters) extends LazyModule {
     dmOuter.module.clock := io.dmi.dmiClock
 
     dmInner.module.io.innerCtrl    := dmOuter.module.io.innerCtrl
-    dmInner.module.io.dmactive     := dmOuter.module.io.ctrl.debugActive
+    dmInner.module.io.dmactive     := dmOuter.module.io.ctrl.dmactive
     dmInner.module.io.debugUnavail := io.ctrl.debugUnavail
 
     io.ctrl <> dmOuter.module.io.ctrl


### PR DESCRIPTION
Debug Module exports two signals, `ndreset` (Non Debug Reset) and `dmactive` (Debug Module Active). How they should be used is up to the integrator and not clear how to use them within the RocketChipExampleTop (because we want to basically override the entire reset). The TestHarness shows how `ndreset` could be used on an FPGA or SoC which is instantiating ExampleRocketChipTop.