### PR TITLE
I$ improvements

### DIFF
--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -184,7 +184,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
           state := s_req
           count := count + 1
         }.otherwise {
-          resp_ae := invalid_paddr
+          resp_ae := pte.v && invalid_paddr
           state := s_ready
           resp_valid(r_req_dest) := true
         }

--- a/src/main/scala/rocket/Rocket.scala
+++ b/src/main/scala/rocket/Rocket.scala
@@ -4,6 +4,7 @@
 package rocket
 
 import Chisel._
+import chisel3.core.withReset
 import config._
 import tile._
 import uncore.constants._
@@ -172,7 +173,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p)
   val ibuf = Module(new IBuf)
   val id_expanded_inst = ibuf.io.inst.map(_.bits.inst)
   val id_inst = id_expanded_inst.map(_.bits)
-  ibuf.io.imem <> io.imem.resp
+  ibuf.io.imem <> (if (usingCompressed) withReset(reset || take_pc) { Queue(io.imem.resp, 1, flow = true) } else io.imem.resp)
   ibuf.io.kill := take_pc
 
   require(decodeWidth == 1 /* TODO */ && retireWidth == decodeWidth)


### PR DESCRIPTION
- Revive I$ parity option; pipeline it into the ID stage to keep it off SRAM critical path
- Get I$ s1_kill signal off the critical path
- Add a 1-entry flow queue between I$ and pipeline, cutting I$ -> decode -> stall signal -> I$ path