### PR TITLE
Remove tests obsoleted by new FP encoding proposal

### DIFF
--- a/src/main/scala/rocketchip/RocketTestSuite.scala
+++ b/src/main/scala/rocketchip/RocketTestSuite.scala
@@ -145,7 +145,7 @@ object DefaultTestSuites {
   val rv64ucNames = rv32ucNames
   val rv64uc = new AssemblyTestSuite("rv64uc", rv64ucNames)(_)
 
-  val rv64ufNames = LinkedHashSet("ldst", "move", "fsgnj", "fcmp", "fcvt", "fcvt_w", "fclass", "fadd", "fdiv", "fmin", "fmadd")
+  val rv64ufNames = LinkedHashSet("ldst", "move", "fcmp", "fcvt", "fcvt_w", "fclass", "fadd", "fdiv", "fmin", "fmadd")
   val rv64uf = new AssemblyTestSuite("rv64uf", rv64ufNames)(_)
   val rv64ufNoDiv = new AssemblyTestSuite("rv64uf", rv64ufNames - "fdiv")(_)
 


### PR DESCRIPTION
Jenkins builds are failing with a:
```
 ...
% cd vsim
% make clean
% make CHISEL_VERSION=3
% make -j 4 run CHISEL_VERSION=3
...
mkdir -p ./output
make: *** No rule to make target `/vm/home/jenkins/workspace/rocket-chip_with_chisel3/../riscv_tools/cd8bc4798c38ba11118492474e96baf717c7af36/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fsgnj', needed by `output/rv64uf-p-fsgnj'.  Stop.
```
