### PR TITLE
jtag: make it easier to assign MFR ID externally

### DIFF
--- a/src/main/scala/jtag/JtagUtils.scala
+++ b/src/main/scala/jtag/JtagUtils.scala
@@ -5,6 +5,13 @@ package jtag
 import chisel3._
 import chisel3.util._
 
+class JTAGIdcodeBundle extends Bundle {
+  val version = UInt(4.W)
+  val partNumber = UInt(16.W)
+  val mfrId = UInt(11.W)
+  val always1 = UInt(1.W)
+}
+
 object JtagIdcode {
   /** Generates a JTAG IDCODE as a 32-bit integer, using the format in 12.1.1d.
     */

--- a/src/main/scala/rocketchip/RISCVPlatform.scala
+++ b/src/main/scala/rocketchip/RISCVPlatform.scala
@@ -24,6 +24,7 @@ trait PeripheryJTAGDTMBundle extends HasTopLevelNetworksBundle {
 
   val jtag = new JTAGIO(hasTRSTn = false).flip
   val jtag_reset = Bool(INPUT)
+  val jtag_mfr_id = UInt(INPUT, 11)
 
 }
 
@@ -36,6 +37,7 @@ trait PeripheryJTAGDTMModule extends HasTopLevelNetworksModule {
   
   dtm.clock             := io.jtag.TCK
   dtm.io.jtag_reset     := io.jtag_reset
+  dtm.io.jtag_mfr_id    := io.jtag_mfr_id
   dtm.reset             := dtm.io.fsmReset
 
   outer.coreplex.module.io.debug.dmi <> dtm.io.dmi
@@ -79,6 +81,7 @@ trait PeripheryDebugBundle extends HasTopLevelNetworksBundle {
 
   val jtag        = (p(IncludeJtagDTM)).option(new JTAGIO(hasTRSTn = false).flip)
   val jtag_reset  = (p(IncludeJtagDTM)).option(Bool(INPUT))
+  val jtag_mfr_id = (p(IncludeJtagDTM)).option(UInt(INPUT, 11))
 
   val ndreset = Bool(OUTPUT)
   val dmactive = Bool(OUTPUT)
@@ -96,6 +99,7 @@ trait PeripheryDebugModule extends HasTopLevelNetworksModule {
 
     dtm.clock          := io.jtag.get.TCK
     dtm.io.jtag_reset  := io.jtag_reset.get
+    dtm.io.jtag_mfr_id := io.jtag_mfr_id.get
     dtm.reset          := dtm.io.fsmReset
 
     outer.coreplex.module.io.debug.dmi <> dtm.io.dmi

--- a/src/main/scala/rocketchip/TestHarness.scala
+++ b/src/main/scala/rocketchip/TestHarness.scala
@@ -28,6 +28,7 @@ class TestHarness()(implicit p: Parameters) extends Module {
     val dtm = Module(new SimDTM).connect(clock, reset, dut.io.debug.get, io.success)
   } else {
     val jtag = Module(new JTAGVPI).connect(dut.io.jtag.get, dut.io.jtag_reset.get, reset, io.success)
+    dut.io.jtag_mfr_id.get := p(JtagDTMKey).idcodeManufId.U(11.W)
   }
 
   val mmio_sim = Module(LazyModule(new SimAXIMem(1, 4096)).module)


### PR DESCRIPTION
This pulls the Manufacturer ID out to the top level of Rocket Chip Example Top. 