### PR TITLE
Grab bag of memory system improvements

### DIFF
--- a/src/main/scala/rocket/Arbiter.scala
+++ b/src/main/scala/rocket/Arbiter.scala
@@ -54,7 +54,7 @@ class HellaCacheArbiter(n: Int)(implicit p: Parameters) extends Module
       val resp = io.requestor(i).resp
       val tag_hit = io.mem.resp.bits.tag(log2Up(n)-1,0) === UInt(i)
       resp.valid := io.mem.resp.valid && tag_hit
-      io.requestor(i).xcpt := io.mem.xcpt
+      io.requestor(i).s2_xcpt := io.mem.s2_xcpt
       io.requestor(i).ordered := io.mem.ordered
       io.requestor(i).acquire := io.mem.acquire
       io.requestor(i).release := io.mem.release

--- a/src/main/scala/rocket/DCache.scala
+++ b/src/main/scala/rocket/DCache.scala
@@ -480,8 +480,9 @@ class DCacheModule(outer: DCache) extends HellaCacheModule(outer) {
   io.cpu.resp.bits.replay := false
   io.cpu.ordered := !(s1_valid || s2_valid || cached_grant_wait || uncachedInFlight.asUInt.orR)
 
-  val s1_xcpt = Mux(s1_nack || !tlb.io.req.valid, 0.U.asTypeOf(tlb.io.resp), tlb.io.resp)
-  io.cpu.s2_xcpt := RegEnable(s1_xcpt, s1_valid)
+  val s1_xcpt_valid = tlb.io.req.valid && !s1_nack
+  val s1_xcpt = tlb.io.resp
+  io.cpu.s2_xcpt := Mux(RegNext(s1_xcpt_valid), RegEnable(s1_xcpt, s1_valid_not_nacked), 0.U.asTypeOf(s1_xcpt))
 
   // uncached response
   io.cpu.replay_next := tl_out.d.fire() && grantIsUncachedData

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -58,6 +58,7 @@ trait HasL1HellaCacheParameters extends HasL1CacheParameters with HasCoreParamet
   def encDataBits = code.width(coreDataBits)
   def encRowBits = encDataBits*rowWords
   def lrscCycles = 32 // ISA requires 16-insn LRSC sequences to succeed
+  def lrscBackoff = 3 // disallow LRSC reacquisition briefly
   def nIOMSHRs = cacheParams.nMMIOs
   def maxUncachedInFlight = cacheParams.nMMIOs
   def dataScratchpadSize = cacheParams.dataScratchpadBytes

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -59,6 +59,7 @@ trait HasL1HellaCacheParameters extends HasL1CacheParameters with HasCoreParamet
   def encRowBits = encDataBits*rowWords
   def lrscCycles = 32 // ISA requires 16-insn LRSC sequences to succeed
   def lrscBackoff = 3 // disallow LRSC reacquisition briefly
+  def blockProbeAfterGrantCycles = 8 // give the processor some time to issue a request after a grant
   def nIOMSHRs = cacheParams.nMMIOs
   def maxUncachedInFlight = cacheParams.nMMIOs
   def dataScratchpadSize = cacheParams.dataScratchpadBytes

--- a/src/main/scala/rocket/HellaCache.scala
+++ b/src/main/scala/rocket/HellaCache.scala
@@ -130,7 +130,7 @@ class HellaCacheIO(implicit p: Parameters) extends CoreBundle()(p) {
 
   val resp = Valid(new HellaCacheResp).flip
   val replay_next = Bool(INPUT)
-  val xcpt = (new HellaCacheExceptions).asInput
+  val s2_xcpt = (new HellaCacheExceptions).asInput
   val invalidate_lr = Bool(OUTPUT)
   val ordered = Bool(INPUT)
 }

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -975,8 +975,9 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
   io.cpu.ordered := mshrs.io.fence_rdy && !s1_valid && !s2_valid
   io.cpu.replay_next := (s1_replay && s1_read) || mshrs.io.replay_next
 
-  val s1_xcpt = Mux(s1_nack || !dtlb.io.req.valid, 0.U.asTypeOf(dtlb.io.resp), dtlb.io.resp)
-  io.cpu.s2_xcpt := RegEnable(s1_xcpt, s1_clk_en)
+  val s1_xcpt_valid = dtlb.io.req.valid && !s1_nack
+  val s1_xcpt = dtlb.io.resp
+  io.cpu.s2_xcpt := Mux(RegNext(s1_xcpt_valid), RegEnable(s1_xcpt, s1_clk_en), 0.U.asTypeOf(s1_xcpt))
 
   // performance events
   io.cpu.acquire := edge.done(tl_out.a)

--- a/src/main/scala/rocket/NBDcache.scala
+++ b/src/main/scala/rocket/NBDcache.scala
@@ -794,18 +794,18 @@ class NonBlockingDCacheModule(outer: NonBlockingDCache) extends HellaCacheModule
 
   // load-reserved/store-conditional
   val lrsc_count = Reg(init=UInt(0))
-  val lrsc_valid = lrsc_count.orR
+  val lrsc_valid = lrsc_count > lrscBackoff
   val lrsc_addr = Reg(UInt())
   val (s2_lr, s2_sc) = (s2_req.cmd === M_XLR, s2_req.cmd === M_XSC)
   val s2_lrsc_addr_match = lrsc_valid && lrsc_addr === (s2_req.addr >> blockOffBits)
   val s2_sc_fail = s2_sc && !s2_lrsc_addr_match
-  when (lrsc_valid) { lrsc_count := lrsc_count - 1 }
+  when (lrsc_count > 0) { lrsc_count := lrsc_count - 1 }
   when (s2_valid_masked && s2_hit || s2_replay) {
     when (s2_lr) {
       lrsc_count := lrscCycles - 1
       lrsc_addr := s2_req.addr >> blockOffBits
     }
-    when (lrsc_valid) {
+    when (lrsc_count > 0) {
       lrsc_count := 0
     }
   }

--- a/src/main/scala/rocket/PTW.scala
+++ b/src/main/scala/rocket/PTW.scala
@@ -78,7 +78,6 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
   val count = Reg(UInt(width = log2Up(pgLevels)))
   val s1_kill = Reg(next = Bool(false))
   val resp_valid = Reg(next = Vec.fill(io.requestor.size)(Bool(false)))
-  val ae = Reg(next = io.mem.xcpt.ae.ld)
   val resp_ae = Reg(Bool())
 
   val r_req = Reg(new PTWReq)
@@ -189,7 +188,7 @@ class PTW(n: Int)(implicit edge: TLEdgeOut, p: Parameters) extends CoreModule()(
           resp_valid(r_req_dest) := true
         }
       }
-      when (ae) {
+      when (io.mem.s2_xcpt.ae.ld) {
         resp_ae := true
         state := s_ready
         resp_valid(r_req_dest) := true

--- a/src/main/scala/rocket/SimpleHellaCacheIF.scala
+++ b/src/main/scala/rocket/SimpleHellaCacheIF.scala
@@ -130,8 +130,6 @@ class SimpleHellaCacheIF(implicit p: Parameters) extends Module
   replayq.io.resp := io.cache.resp
   io.requestor.resp := io.cache.resp
 
-  assert(!Reg(next = io.cache.req.fire()) ||
-         !(io.cache.xcpt.ma.ld || io.cache.xcpt.ma.st ||
-           io.cache.xcpt.pf.ld || io.cache.xcpt.pf.st),
+  assert(!RegNext(RegNext(io.cache.req.fire())) || !io.cache.s2_xcpt.asUInt.orR,
          "SimpleHellaCacheIF exception")
 }

--- a/src/main/scala/rocket/TLBPermissions.scala
+++ b/src/main/scala/rocket/TLBPermissions.scala
@@ -18,7 +18,7 @@ case class TLBPermissions(
 object TLBPageLookup
 {
   private case class TLBFixedPermissions(
-    t: RegionType.T,
+    e: Boolean, // get-/put-effects
     r: Boolean, // readable
     w: Boolean, // writeable
     x: Boolean, // executable
@@ -48,7 +48,7 @@ object TLBPageLookup
       require (m.supportsAcquireT || !m.supportsAcquireB, s"MemoryMap region ${m.name} supports AcquireB (cached read) but not AcquireT (cached write)... and rocket assumes this")
 
       (m.address, TLBFixedPermissions(
-        t = m.regionType,
+        e = Seq(RegionType.PUT_EFFECTS, RegionType.GET_EFFECTS) contains m.regionType,
         r = m.supportsGet     || m.supportsAcquireB, // if cached, never uses Get
         w = m.supportsPutFull || m.supportsAcquireT, // if cached, never uses Put
         x = m.executable,

--- a/src/main/scala/rocket/TLBPermissions.scala
+++ b/src/main/scala/rocket/TLBPermissions.scala
@@ -18,6 +18,7 @@ case class TLBPermissions(
 object TLBPageLookup
 {
   private case class TLBFixedPermissions(
+    t: RegionType.T,
     r: Boolean, // readable
     w: Boolean, // writeable
     x: Boolean, // executable
@@ -47,6 +48,7 @@ object TLBPageLookup
       require (m.supportsAcquireT || !m.supportsAcquireB, s"MemoryMap region ${m.name} supports AcquireB (cached read) but not AcquireT (cached write)... and rocket assumes this")
 
       (m.address, TLBFixedPermissions(
+        t = m.regionType,
         r = m.supportsGet     || m.supportsAcquireB, // if cached, never uses Get
         w = m.supportsPutFull || m.supportsAcquireT, // if cached, never uses Put
         x = m.executable,

--- a/src/main/scala/rocketchip/Generator.scala
+++ b/src/main/scala/rocketchip/Generator.scala
@@ -67,9 +67,13 @@ object Generator extends util.GeneratorApp {
         }
       }
     }
-    if (coreParams.useAtomics)    TestGeneration.addSuites(env.map(if (xlen == 64) rv64ua else rv32ua))
+    if (coreParams.useAtomics) {
+      if (tileParams.dcache.flatMap(_.scratch).isEmpty)
+        TestGeneration.addSuites(env.map(if (xlen == 64) rv64ua else rv32ua))
+      else
+        TestGeneration.addSuites(env.map(if (xlen == 64) rv64uaSansLRSC else rv32uaSansLRSC))
+    }
     if (coreParams.useCompressed) TestGeneration.addSuites(env.map(if (xlen == 64) rv64uc else rv32uc))
-    if (coreParams.useAtomics && tileParams.dcache.flatMap(_.scratch).isEmpty) TestGeneration.addSuites(env.map(if (xlen == 64) rv64lrsc else rv32lrsc))
     val (rvi, rvu) =
       if (xlen == 64) ((if (vm) rv64i else rv64pi), rv64u)
       else            ((if (vm) rv32i else rv32pi), rv32u)

--- a/src/main/scala/rocketchip/Generator.scala
+++ b/src/main/scala/rocketchip/Generator.scala
@@ -50,7 +50,8 @@ object Generator extends util.GeneratorApp {
     import DefaultTestSuites._
     val xlen = params(XLen)
     // TODO: for now only generate tests for the first core in the first coreplex
-    val coreParams = params(RocketTilesKey).head.core
+    val tileParams = params(RocketTilesKey).head
+    val coreParams = tileParams.core
     val vm = coreParams.useVM
     val env = if (vm) List("p","v") else List("p")
     coreParams.fpu foreach { case cfg =>
@@ -68,6 +69,7 @@ object Generator extends util.GeneratorApp {
     }
     if (coreParams.useAtomics)    TestGeneration.addSuites(env.map(if (xlen == 64) rv64ua else rv32ua))
     if (coreParams.useCompressed) TestGeneration.addSuites(env.map(if (xlen == 64) rv64uc else rv32uc))
+    if (coreParams.useAtomics && tileParams.dcache.flatMap(_.scratch).isEmpty) TestGeneration.addSuites(env.map(if (xlen == 64) rv64lrsc else rv32lrsc))
     val (rvi, rvu) =
       if (xlen == 64) ((if (vm) rv64i else rv64pi), rv64u)
       else            ((if (vm) rv32i else rv32pi), rv32u)

--- a/src/main/scala/rocketchip/RocketTestSuite.scala
+++ b/src/main/scala/rocketchip/RocketTestSuite.scala
@@ -120,8 +120,11 @@ object DefaultTestSuites {
   val rv32umNames = LinkedHashSet("mul", "mulh", "mulhsu", "mulhu", "div", "divu", "rem", "remu")
   val rv32um = new AssemblyTestSuite("rv32um", rv32umNames)(_)
 
-  val rv32uaNames = LinkedHashSet("lrsc", "amoadd_w", "amoand_w", "amoor_w", "amoxor_w", "amoswap_w", "amomax_w", "amomaxu_w", "amomin_w", "amominu_w")
+  val rv32uaNames = LinkedHashSet("amoadd_w", "amoand_w", "amoor_w", "amoxor_w", "amoswap_w", "amomax_w", "amomaxu_w", "amomin_w", "amominu_w")
   val rv32ua = new AssemblyTestSuite("rv32ua", rv32uaNames)(_)
+
+  val rv32lrscNames = LinkedHashSet("lrsc")
+  val rv32lrsc = new AssemblyTestSuite("rv32ua", rv32lrscNames)(_)
 
   val rv32siNames = LinkedHashSet("csr", "ma_fetch", "scall", "sbreak", "wfi", "dirty")
   val rv32si = new AssemblyTestSuite("rv32si", rv32siNames)(_)
@@ -141,6 +144,8 @@ object DefaultTestSuites {
 
   val rv64uaNames = rv32uaNames.map(_.replaceAll("_w","_d"))
   val rv64ua = new AssemblyTestSuite("rv64ua", rv32uaNames ++ rv64uaNames)(_)
+
+  val rv64lrsc = new AssemblyTestSuite("rv64ua", rv32lrscNames)(_)
 
   val rv64ucNames = rv32ucNames
   val rv64uc = new AssemblyTestSuite("rv64uc", rv64ucNames)(_)

--- a/src/main/scala/rocketchip/RocketTestSuite.scala
+++ b/src/main/scala/rocketchip/RocketTestSuite.scala
@@ -4,13 +4,14 @@
 package rocketchip
 
 import Chisel._
-import scala.collection.mutable.{LinkedHashSet, LinkedHashMap}
+import scala.collection.mutable.{LinkedHashSet, ArrayBuffer}
 
 abstract class RocketTestSuite {
   val dir: String
   val makeTargetName: String
   val names: LinkedHashSet[String]
   val envName: String
+  def kind: String
   def postScript = s"""
 
 $$(addprefix $$(output_dir)/, $$(addsuffix .hex, $$($makeTargetName))): $$(output_dir)/%.hex: $dir/%.hex
@@ -35,12 +36,14 @@ run-$makeTargetName-fst: $$(addprefix $$(output_dir)/, $$(addsuffix .fst, $$($ma
 class AssemblyTestSuite(prefix: String, val names: LinkedHashSet[String])(val envName: String) extends RocketTestSuite {
   val dir = "$(RISCV)/riscv64-unknown-elf/share/riscv-tests/isa"
   val makeTargetName = prefix + "-" + envName + "-asm-tests"
+  def kind = "asm"
   override def toString = s"$makeTargetName = \\\n" + names.map(n => s"\t$prefix-$envName-$n").mkString(" \\\n") + postScript
 }
 
 class BenchmarkTestSuite(makePrefix: String, val dir: String, val names: LinkedHashSet[String]) extends RocketTestSuite {
   val envName = ""
   val makeTargetName = makePrefix + "-bmark-tests"
+  def kind = "bmark"
   override def toString = s"$makeTargetName = \\\n" + names.map(n => s"\t$n.riscv").mkString(" \\\n") + postScript
 }
 
@@ -48,22 +51,14 @@ class RegressionTestSuite(val names: LinkedHashSet[String]) extends RocketTestSu
   val envName = ""
   val dir = "$(RISCV)/riscv64-unknown-elf/share/riscv-tests/isa"
   val makeTargetName = "regression-tests"
+  def kind = "regression"
   override def toString = s"$makeTargetName = \\\n" + names.mkString(" \\\n")
 }
 
 object TestGeneration {
-  import scala.collection.mutable.HashMap
-  val asmSuites = new LinkedHashMap[String,AssemblyTestSuite]()
-  val bmarkSuites = new LinkedHashMap[String,BenchmarkTestSuite]()
-  val regressionSuites = new LinkedHashMap[String,RegressionTestSuite]()
+  private val suites = ArrayBuffer[RocketTestSuite]()
 
-  def addSuite(s: RocketTestSuite) {
-    s match {
-      case a: AssemblyTestSuite => asmSuites += (a.makeTargetName -> a)
-      case b: BenchmarkTestSuite => bmarkSuites += (b.makeTargetName -> b)
-      case r: RegressionTestSuite => regressionSuites += (r.makeTargetName -> r)
-    }
-  }
+  def addSuite(s: RocketTestSuite) { suites += s }
   
   def addSuites(s: Seq[RocketTestSuite]) { s.foreach(addSuite) }
 
@@ -98,11 +93,7 @@ run-$kind-tests-fast: $$(addprefix $$(output_dir)/, $$(addsuffix .run, $targets)
       } else { "\n" }
     }
 
-    List(
-      gen("asm", asmSuites.values.toSeq),
-      gen("bmark", bmarkSuites.values.toSeq),
-      gen("regression", regressionSuites.values.toSeq)
-    ).mkString("\n")
+    suites.groupBy(_.kind).map { case (kind, s) => gen(kind, s) }.mkString("\n")
   }
 
 }
@@ -120,11 +111,11 @@ object DefaultTestSuites {
   val rv32umNames = LinkedHashSet("mul", "mulh", "mulhsu", "mulhu", "div", "divu", "rem", "remu")
   val rv32um = new AssemblyTestSuite("rv32um", rv32umNames)(_)
 
-  val rv32uaNames = LinkedHashSet("amoadd_w", "amoand_w", "amoor_w", "amoxor_w", "amoswap_w", "amomax_w", "amomaxu_w", "amomin_w", "amominu_w")
-  val rv32ua = new AssemblyTestSuite("rv32ua", rv32uaNames)(_)
+  val rv32uaSansLRSCNames = LinkedHashSet("amoadd_w", "amoand_w", "amoor_w", "amoxor_w", "amoswap_w", "amomax_w", "amomaxu_w", "amomin_w", "amominu_w")
+  val rv32uaSansLRSC = new AssemblyTestSuite("rv32ua", rv32uaSansLRSCNames)(_)
 
-  val rv32lrscNames = LinkedHashSet("lrsc")
-  val rv32lrsc = new AssemblyTestSuite("rv32ua", rv32lrscNames)(_)
+  val rv32uaNames = rv32uaSansLRSCNames + "lrsc"
+  val rv32ua = new AssemblyTestSuite("rv32ua", rv32uaNames)(_)
 
   val rv32siNames = LinkedHashSet("csr", "ma_fetch", "scall", "sbreak", "wfi", "dirty")
   val rv32si = new AssemblyTestSuite("rv32si", rv32siNames)(_)
@@ -142,10 +133,11 @@ object DefaultTestSuites {
   val rv64umNames = LinkedHashSet("divuw", "divw", "mulw", "remuw", "remw")
   val rv64um = new AssemblyTestSuite("rv64um", rv32umNames ++ rv64umNames)(_)
 
-  val rv64uaNames = rv32uaNames.map(_.replaceAll("_w","_d"))
-  val rv64ua = new AssemblyTestSuite("rv64ua", rv32uaNames ++ rv64uaNames)(_)
+  val rv64uaSansLRSCNames = rv32uaSansLRSCNames.map(_.replaceAll("_w","_d"))
+  val rv64uaSansLRSC = new AssemblyTestSuite("rv64ua", rv32uaSansLRSCNames ++ rv64uaSansLRSCNames)(_)
 
-  val rv64lrsc = new AssemblyTestSuite("rv64ua", rv32lrscNames)(_)
+  val rv64uaNames = rv64uaSansLRSCNames + "lrsc"
+  val rv64ua = new AssemblyTestSuite("rv64ua", rv32uaNames ++ rv64uaNames)(_)
 
   val rv64ucNames = rv32ucNames
   val rv64uc = new AssemblyTestSuite("rv64uc", rv64ucNames)(_)
@@ -169,8 +161,6 @@ object DefaultTestSuites {
   val groundtestNames = LinkedHashSet("simple")
   val groundtest64 = new AssemblyTestSuite("rv64ui", groundtestNames)(_)
   val groundtest32 = new AssemblyTestSuite("rv32ui", groundtestNames)(_)
-
-  // TODO: "rv64ui-pm-lrsc", "rv64mi-pm-ipi",
 
   val rv64u = List(rv64ui, rv64um)
   val rv64i = List(rv64ui, rv64si, rv64mi)


### PR DESCRIPTION
- Mitigate critical path for D$ exception reporting
- Send D$ grant acks early
- Cope with early grant acks in broadcast hub
- Cope with early release acks in D$
- Generate access exceptions for LR/SC on uncacheable memory (including scratchpad)
- Guarantee eventual probe forward progress for pessimal LR/SC sequences