### PR TITLE
regmapper: remove the Pipe in the RegMapper Queue

### DIFF
--- a/src/main/scala/regmapper/RegMapper.scala
+++ b/src/main/scala/regmapper/RegMapper.scala
@@ -62,7 +62,7 @@ object RegMapper
     val depth = concurrency
     require (depth >= 0)
     require (!pipelined || depth > 0, "Register-based device with request/response handshaking needs concurrency > 0")
-    val back = if (depth > 0) Queue(front, depth, pipe = depth == 1) else front
+    val back = if (depth > 0) Queue(front, depth) else front
 
     // Convert to and from Bits
     def toBits(x: Int, tail: List[Boolean] = List.empty): List[Boolean] =

--- a/src/main/scala/uncore/devices/Plic.scala
+++ b/src/main/scala/uncore/devices/Plic.scala
@@ -75,7 +75,8 @@ class TLPLIC(maxPriorities: Int, address: BigInt = 0xC000000)(implicit p: Parame
     address   = Seq(AddressSet(address, PLICConsts.size-1)),
     device    = device,
     beatBytes = p(XLen)/8,
-    undefZero = false)
+    undefZero = false,
+    concurrency = 1) // Work around the enable -> claim hazard
 
   val intnode = IntNexusNode(
     numSourcePorts = 0 to 1024,


### PR DESCRIPTION
With this pipe here, devices which declare concurrency > 0
actually accept transactions on the same cycle they complete
the previous one. This is unexpected behavior.