### PR TITLE
Allow RawModule as the top level for the Generator

### DIFF
--- a/src/main/scala/util/GeneratorUtils.scala
+++ b/src/main/scala/util/GeneratorUtils.scala
@@ -3,6 +3,7 @@
 package util
 
 import Chisel._
+import chisel3.experimental.{RawModule}
 import config._
 import diplomacy.LazyModule
 import java.io.{File, FileWriter}
@@ -45,7 +46,7 @@ trait HasGeneratorUtilities {
       Class.forName(names.fullTopModuleClass)
         .getConstructor(classOf[Parameters])
         .newInstance(params)
-        .asInstanceOf[Module]
+        .asInstanceOf[RawModule]
 
     Driver.elaborate(gen)
   }


### PR DESCRIPTION
If the thing you want to generate is a RawModule (especially if you want more control over the top level signal names), this allows you to do it by changing the class that the object is cast to.