### PR TITLE
point to riscv-tools README for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For more information (or if you run into any issues), please consult the
 You may need to install some additional packages to use this repository.
 Rather than list all dependencies here, please see the appropriate section of the READMEs for each of the subprojects:
 
-* [riscv-tools "Ubuntu Packages Needed"](https://github.com/riscv/riscv-tools/blob/master/README.md#quickstart)
+* [riscv-tools "Ubuntu Packages Needed"](https://github.com/riscv/riscv-tools/blob/priv-1.10/README.md#quickstart)
 * [chisel3 "Installation"](https://github.com/ucb-bar/chisel3#installation)
 
 ### Building The Project


### PR DESCRIPTION
As pointed out, if we just point to 'master' branch, then people wouldn't get the correct list of dependencies.

This addresses #702 