### PR TITLE
Interrupts: Less Pessimistic Synchronization

### DIFF
--- a/src/main/scala/coreplex/RocketTiles.scala
+++ b/src/main/scala/coreplex/RocketTiles.scala
@@ -43,16 +43,16 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
     val periphIntXbar = LazyModule(new IntXbar)
     val coreIntXbar   = LazyModule(new IntXbar)
 
-    // CLINT and Local Interrupts must be synchronized to the core clock
+    // Local Interrupts must be synchronized to the core clock
     // before being passed into this module.
     // This allows faster latency for interrupts which are already synchronized.
-    // The PLIC outputs interrupts that are synchronous to the periphery clock,
+    // The CLINT and PLIC outputs interrupts that are synchronous to the periphery clock,
     // so may or may not need to be synchronized depending on the Tile's
     // synchronization type.
     // Debug interrupt is definitely asynchronous in all cases.
 
     asyncIntXbar.intnode  := debug.intnode                  // debug
-    coreIntXbar.intnode   := clint.intnode                  // msip+mtip
+    periphIntXbar.intnode := clint.intnode                  // msip+mtip
     periphIntXbar.intnode := plic.intnode                   // meip
     if (c.core.useVM) periphIntXbar.intnode := plic.intnode // seip
     lip.foreach { coreIntXbar.intnode := _ }                // lip

--- a/src/main/scala/coreplex/RocketTiles.scala
+++ b/src/main/scala/coreplex/RocketTiles.scala
@@ -39,12 +39,23 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
       case SharedMemoryTLEdge => l1tol2.node.edgesIn(0)
     }
 
-    val intBar = LazyModule(new IntXbar)
-    intBar.intnode := debug.intnode                  // debug
-    intBar.intnode := clint.intnode                  // msip+mtip
-    intBar.intnode := plic.intnode                   // meip
-    if (c.core.useVM) intBar.intnode := plic.intnode // seip
-    lip.foreach { intBar.intnode := _ }              // lip
+    val asyncIntXbar  = LazyModule(new IntXbar)
+    val periphIntXbar = LazyModule(new IntXbar)
+    val coreIntXbar   = LazyModule(new IntXbar)
+
+    // CLINT and Local Interrupts must be synchronized to the core clock
+    // before being passed into this module.
+    // This allows faster latency for interrupts which are already synchronized.
+    // The PLIC outputs interrupts that are synchronous to the periphery clock,
+    // so may or may not need to be synchronized depending on the Tile's
+    // synchronization type.
+    // Debug interrupt is definitely asynchronous in all cases.
+
+    asyncIntXbar.intnode  := debug.intnode                  // debug
+    coreIntXbar.intnode   := clint.intnode                  // msip+mtip
+    periphIntXbar.intnode := plic.intnode                   // meip
+    if (c.core.useVM) periphIntXbar.intnode := plic.intnode // seip
+    lip.foreach { coreIntXbar.intnode := _ }                // lip
 
     crossing match {
       case SynchronousCrossing(params) => {
@@ -55,7 +66,9 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
         fixer.node :=* buffer.node
         l1tol2.node :=* fixer.node
         wrapper.slaveNode :*= cbus.node
-        wrapper.intNode := intBar.intnode
+        wrapper.asyncIntNode  := asyncIntXbar.intnode
+        wrapper.periphIntNode := periphIntXbar.intnode
+        wrapper.coreIntNode   := coreIntXbar.intnode
         (io: HasRocketTilesBundle) => {
           // leave clock as default (simpler for hierarchical PnR)
           wrapper.module.io.hartid := UInt(i)
@@ -71,7 +84,9 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
         fixer.node :=* sink.node
         l1tol2.node :=* fixer.node
         wrapper.slaveNode :*= source.node
-        wrapper.intNode := intBar.intnode
+        wrapper.asyncIntNode  := asyncIntXbar.intnode
+        wrapper.periphIntNode := periphIntXbar.intnode
+        wrapper.coreIntNode   := coreIntXbar.intnode
         source.node :*= cbus.node
         (io: HasRocketTilesBundle) => {
           wrapper.module.clock := io.tcrs(i).clock
@@ -89,7 +104,9 @@ trait HasRocketTiles extends CoreplexRISCVPlatform {
         fixer.node :=* sink.node
         l1tol2.node :=* fixer.node
         wrapper.slaveNode :*= source.node
-        wrapper.intNode := intBar.intnode
+        wrapper.asyncIntNode := asyncIntXbar.intnode
+        wrapper.periphIntNode := periphIntXbar.intnode
+        wrapper.coreIntNode   := coreIntXbar.intnode
         source.node :*= cbus.node
         (io: HasRocketTilesBundle) => {
           wrapper.module.clock := io.tcrs(i).clock

--- a/src/main/scala/rocketchip/ExampleTop.scala
+++ b/src/main/scala/rocketchip/ExampleTop.scala
@@ -9,7 +9,7 @@ import rocketchip._
 
 /** Example Top with Periphery (w/o coreplex) */
 abstract class ExampleTop(implicit p: Parameters) extends BaseTop
-    with PeripheryExtInterrupts
+    with PeripheryAsyncExtInterrupts
     with PeripheryMasterAXI4Mem
     with PeripheryMasterAXI4MMIO
     with PeripherySlaveAXI4 {

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -59,11 +59,6 @@ abstract trait PeripheryExtInterrupts {
   val nExtInterrupts = p(NExtTopInterrupts)
   val extInterrupts = IntInternalInputNode(IntSourcePortSimple(num = nExtInterrupts, resources = device.int))
 
-  if (nExtInterrupts > 0) {
-    val extInterruptXing = LazyModule(new IntXing)
-    intBus.intnode := extInterruptXing.intnode
-    extInterruptXing.intnode := extInterrupts
-  }
 }
 
 trait PeripheryExtInterruptsBundle {

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -47,8 +47,7 @@ trait HasPeripheryParameters {
 }
 
 /////
-
-trait PeripheryExtInterrupts {
+abstract trait PeripheryExtInterrupts {
   this: HasTopLevelNetworks =>
 
   private val device = new Device with DeviceInterrupts {
@@ -82,7 +81,33 @@ trait PeripheryExtInterruptsModule {
   outer.extInterrupts.bundleIn.flatten.zipWithIndex.foreach { case(o, i) => o := io.interrupts(i) }
 }
 
+// This trait should be used if the External Interrupts have NOT
+// already been synchronized
+// to the Periphery (PLIC) Clock.
+
+trait PeripheryAsyncExtInterrupts extends PeripheryExtInterrupts {
+  this: HasTopLevelNetworks =>
+
+  if (nExtInterrupts > 0) {
+    val extInterruptXing = LazyModule(new IntXing)
+    intBus.intnode := extInterruptXing.intnode
+    extInterruptXing.intnode := extInterrupts
+  }
+
+}
+
+// This trait can be used if the External Interrupts have already been synchronized
+// to the Periphery (PLIC) Clock.
+
+trait PeripherySyncExtInterrupts extends PeripheryExtInterrupts {
+  this: HasTopLevelNetworks =>
+  
+  intBus.intnode := extInterrupts
+
+}
+
 /////
+
 
 trait PeripheryMasterAXI4Mem {
   this: HasTopLevelNetworks =>

--- a/src/main/scala/rocketchip/Periphery.scala
+++ b/src/main/scala/rocketchip/Periphery.scala
@@ -96,9 +96,10 @@ trait PeripheryAsyncExtInterrupts extends PeripheryExtInterrupts {
 
 trait PeripherySyncExtInterrupts extends PeripheryExtInterrupts {
   this: HasTopLevelNetworks =>
-  
-  intBus.intnode := extInterrupts
 
+  if (nExtInterrupts > 0) {
+    intBus.intnode := extInterrupts
+  }
 }
 
 /////

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -31,7 +31,7 @@ trait HasExternalInterrupts extends HasTileParameters {
   def csrIntMap: List[Int] = {
     val nlips = tileParams.core.nLocalInterrupts
     val seip = if (usingVM) Seq(9) else Nil
-    List(65535, 3, 7, 11) ++ seip ++ List.tabulate(nlips)(_ + 16)
+    List(65535, 11) ++ seip ++ List(3, 7) ++ List.tabulate(nlips)(_ + 16)
   }
 }
 

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -31,7 +31,7 @@ trait HasExternalInterrupts extends HasTileParameters {
   def csrIntMap: List[Int] = {
     val nlips = tileParams.core.nLocalInterrupts
     val seip = if (usingVM) Seq(9) else Nil
-    List(65535, 11) ++ seip ++ List(3, 7) ++ List.tabulate(nlips)(_ + 16)
+    List(65535, 3, 7, 11) ++ seip ++ List.tabulate(nlips)(_ + 16)
   }
 }
 
@@ -47,12 +47,13 @@ trait HasExternalInterruptsModule {
   // go from flat diplomatic Interrupts to bundled TileInterrupts
   def decodeCoreInterrupts(core: TileInterrupts) {
     val async_ips = Seq(core.debug)
-    val periph_ips = Seq(core.meip,
+    val periph_ips = Seq(
+      core.msip,
+      core.mtip,
+      core.meip,
       core.seip.getOrElse(Wire(Bool())))
 
-    val core_ips = Seq(
-      core.msip,
-      core.mtip) ++ core.lip
+    val core_ips = core.lip
 
     (async_ips ++ periph_ips ++ core_ips).zip(io.interrupts(0)).foreach { case(c, i) => c := i }
   }

--- a/src/main/scala/tile/Interrupts.scala
+++ b/src/main/scala/tile/Interrupts.scala
@@ -46,12 +46,14 @@ trait HasExternalInterruptsModule {
 
   // go from flat diplomatic Interrupts to bundled TileInterrupts
   def decodeCoreInterrupts(core: TileInterrupts) {
+    val async_ips = Seq(core.debug)
+    val periph_ips = Seq(core.meip,
+      core.seip.getOrElse(Wire(Bool())))
+
     val core_ips = Seq(
-      core.debug,
       core.msip,
-      core.mtip,
-      core.meip,
-      core.seip.getOrElse(Wire(Bool()))) ++ core.lip
-    core_ips.zip(io.interrupts(0)).foreach { case(c, i) => c := i }
+      core.mtip) ++ core.lip
+
+    (async_ips ++ periph_ips ++ core_ips).zip(io.interrupts(0)).foreach { case(c, i) => c := i }
   }
 }


### PR DESCRIPTION
This does a more fine-grained synchronization for the different interrupt types and different synchronization types:

Within the Coreplex:
-- only debug interrupt is always fully asynchronous
-- Local Interrupts are always assumed to have been synchronized to core clock 
-- CLINT interrupt is known to be synchronous to core clock
-- PLIC interrupt is known to be synchronous to periphery clock, treat it accordingly

Additionally, there are now two subtraits of the PeripheryExtInterrupts (which becomes abstract). One which does the synchronization and one which assumes it has already been done.

There may still be some issues in the way the interrupt numbers are being assigned, still verifying this does what we want.