### PR TITLE
Fix RVC/uncacheable instruction memory performance bug

### DIFF
--- a/src/main/scala/rocket/Frontend.scala
+++ b/src/main/scala/rocket/Frontend.scala
@@ -158,7 +158,7 @@ class FrontendModule(outer: Frontend) extends LazyModuleImp(outer)
   icache.io.s1_paddr := tlb.io.resp.paddr
   icache.io.s2_vaddr := s2_pc
   icache.io.s1_kill := io.cpu.req.valid || tlb.io.resp.miss || s2_replay
-  icache.io.s2_kill := s2_speculative && !s2_cacheable || s2_xcpt
+  icache.io.s2_kill := RegNext(RegNext(s0_valid)) && s2_speculative && !s2_cacheable || s2_xcpt
 
   fq.io.enq.valid := s2_valid && (icache.io.resp.valid || icache.io.s2_kill)
   fq.io.enq.bits.pc := s2_pc


### PR DESCRIPTION
9c1d12696552c70313c0c0ba22fef49287187d88 was an incomplete fix, so
sometimes we were requesting pipeline replays when they weren't
necessary.