### PR TITLE
Revert "rocket: hard-wire UXL/SXL fields to 0"

### DIFF
--- a/src/main/scala/rocket/CSR.scala
+++ b/src/main/scala/rocket/CSR.scala
@@ -21,7 +21,9 @@ class MStatus extends Bundle {
   val dprv = UInt(width = PRV.SZ) // effective privilege for data accesses
   val prv = UInt(width = PRV.SZ) // not truly part of mstatus, but convenient
   val sd = Bool()
-  val zero2 = UInt(width = 31)
+  val zero2 = UInt(width = 27)
+  val sxl = UInt(width = 2)
+  val uxl = UInt(width = 2)
   val sd_rv32 = Bool()
   val zero1 = UInt(width = 8)
   val tsr = Bool()
@@ -380,6 +382,7 @@ class CSRFile(perfEventSets: EventSets = new EventSets(Seq()))(implicit p: Param
     val read_sip = read_mip & reg_mideleg
     val read_sstatus = Wire(init = 0.U.asTypeOf(new MStatus))
     read_sstatus.sd := io.status.sd
+    read_sstatus.uxl := io.status.uxl
     read_sstatus.sd_rv32 := io.status.sd_rv32
     read_sstatus.mxr := io.status.mxr
     read_sstatus.sum := io.status.sum
@@ -492,6 +495,8 @@ class CSRFile(perfEventSets: EventSets = new EventSets(Seq()))(implicit p: Param
   io.status.sd := io.status.fs.andR || io.status.xs.andR
   io.status.debug := reg_debug
   io.status.isa := reg_misa
+  io.status.uxl := (if (usingUser) log2Ceil(xLen) - 4 else 0)
+  io.status.sxl := (if (usingVM) log2Ceil(xLen) - 4 else 0)
   io.status.dprv := Reg(next = Mux(reg_mstatus.mprv && !reg_debug, reg_mstatus.mpp, reg_mstatus.prv))
   if (xLen == 32)
     io.status.sd_rv32 := io.status.sd


### PR DESCRIPTION
This reverts commit ea0714bfcba3546e14cd022faafe8a4c0c27e968.

We've waffled on this matter in the priv spec: https://github.com/riscv/riscv-isa-manual/commit/326bec83de23f4d2daf24cfed6b5251748cad632